### PR TITLE
Removed format_source_id from code base

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -602,7 +602,7 @@ class UserfilesController < ApplicationController
       @userfile.group_id   = new_group_id if current_user.available_groups.where(:id => new_group_id).first
       @userfile            = @userfile.class_update
 
-      if @userfile.save_with_logging(current_user, %w( group_writable num_files format_source_id parent_id hidden ) )
+      if @userfile.save_with_logging(current_user, %w( group_writable num_files parent_id hidden ) )
         if new_name != old_name
           @userfile.provider_rename(new_name)
           @userfile.addlog("Renamed by #{current_user.login}: #{old_name} -> #{new_name}")
@@ -1621,9 +1621,6 @@ class UserfilesController < ApplicationController
     unless filters["view_hidden"] == 'on'
       header_scope = header_scope.where( :hidden => false ) # show only the non-hidden files
     end
-
-    # The userfile index only show and count the main files, not their subformats.
-    header_scope = header_scope.where( :format_source_id => nil )
 
     header_scope
   end

--- a/BrainPortal/app/helpers/userfiles_helper.rb
+++ b/BrainPortal/app/helpers/userfiles_helper.rb
@@ -51,20 +51,7 @@ module UserfilesHelper
     userfile.sync_status.each do |syncstat|
       html << render(:partial => 'userfiles/syncstatus', :locals => { :syncstat => syncstat })
     end
-    if userfile.formats.count > 0
-      html << "<br>"
-      html << ("&nbsp;" * ((userfile.level || 0) * 5))
-      html << show_hide_toggle("Formats ", ".format_#{userfile.id}", :class  => "action_link")
-      html << userfile.formats.map do |u|
-                if u.available?
-                  cb = check_box_tag("file_ids[]", u.id.to_s, false)
-                else
-                  cb = "<input type='checkbox' DISABLED />"
-                end
-                cb = "<span class=\"format_#{userfile.id}\" style=\"display:none\">#{cb}</span>"
-                link_to_userfile_if_accessible(u,current_user,:name => u.format_name) + " #{cb}".html_safe
-              end.join(", ")
-    end
+    
     html.join.html_safe
   end
 

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -242,17 +242,6 @@ class Userfile < ActiveRecord::Base
   end
 
 
-
-  ##############################################
-  # Format Methods
-  ##############################################
-
-
-  # The format name (for display) of this userfile.
-  def format_name
-    nil
-  end
-
   ##############################################
   # Taging Subsystem
   ##############################################

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -103,7 +103,7 @@
       <%= user_select("userfile[user_id]", { :selector => @userfile }) %>
     <% end %>
 
-    <% t.edit_cell(:group_id, :header => "Project", :content => link_to_group_if_accessible(@userfile.group), :disabled => (!@userfile.has_owner_access?(current_user) || @userfile.format_source_id)) do %>
+    <% t.edit_cell(:group_id, :header => "Project", :content => link_to_group_if_accessible(@userfile.group), :disabled => (!@userfile.has_owner_access?(current_user))) do %>
       <%= group_select 'userfile[group_id]', { :groups => current_user.available_groups, :selector => @userfile.group_id.to_s } %>
     <% end  %>
 

--- a/BrainPortal/db/migrate/20150605192215_add_index_to_user_files.rb
+++ b/BrainPortal/db/migrate/20150605192215_add_index_to_user_files.rb
@@ -1,0 +1,6 @@
+class AddIndexToUserFiles < ActiveRecord::Migration
+  def change
+    add_index :userfiles, [:archived, :id]
+    add_index :userfiles, [:immutable, :id]
+  end
+end

--- a/BrainPortal/db/migrate/20150605193138_add_index_to_user_files2.rb
+++ b/BrainPortal/db/migrate/20150605193138_add_index_to_user_files2.rb
@@ -1,0 +1,6 @@
+class AddIndexToUserFiles2 < ActiveRecord::Migration
+  def change
+    add_index :userfiles, [:hidden, :id]
+    add_index :userfiles, [:format_source_id, :id]
+  end
+end

--- a/BrainPortal/db/migrate/20150605193442_remove_index_to_user_files.rb
+++ b/BrainPortal/db/migrate/20150605193442_remove_index_to_user_files.rb
@@ -1,0 +1,8 @@
+class RemoveIndexToUserFiles < ActiveRecord::Migration
+  def change
+    remove_index :userfiles, [:archived]
+    remove_index :userfiles, [:hidden]
+    remove_index :userfiles, [:immutable]
+    remove_index :userfiles, [:format_source_id]
+  end
+end

--- a/BrainPortal/db/migrate/20150608151559_add_index_to_user_file.rb
+++ b/BrainPortal/db/migrate/20150608151559_add_index_to_user_file.rb
@@ -1,0 +1,8 @@
+class AddIndexToUserFile < ActiveRecord::Migration
+  def change
+    add_index :userfiles, [ :format_source_id, :type ]
+    add_index :userfiles, [ :format_source_id, :user_id ]
+    add_index :userfiles, [ :format_source_id, :data_provider_id ]
+    add_index :userfiles, [ :format_source_id, :group_id ]
+  end
+end

--- a/BrainPortal/db/migrate/20150608185724_remove_format_source_id_from_userfiles.rb
+++ b/BrainPortal/db/migrate/20150608185724_remove_format_source_id_from_userfiles.rb
@@ -1,0 +1,9 @@
+class RemoveFormatSourceIdFromUserfiles < ActiveRecord::Migration
+  def up
+    remove_column :userfiles, :format_source_id  
+  end
+
+  def down
+    add_column :userfiles, :format_source_id, :integer
+  end
+end

--- a/BrainPortal/db/migrate/20150608190254_remove_index_from_userfiles.rb
+++ b/BrainPortal/db/migrate/20150608190254_remove_index_from_userfiles.rb
@@ -1,0 +1,9 @@
+class RemoveIndexFromUserfiles < ActiveRecord::Migration
+  def change
+    remove_index(:userfiles, :name => 'index_userfiles_on_format_source_id_and_data_provider_id')
+    remove_index(:userfiles, :name => 'index_userfiles_on_format_source_id_and_group_id')
+    remove_index(:userfiles, :name => 'index_userfiles_on_format_source_id_and_type')
+    remove_index(:userfiles, :name => 'index_userfiles_on_format_source_id_and_user_id')
+  end
+
+end

--- a/BrainPortal/db/migrate/20150608195413_rmove_another_index_from_userfile.rb
+++ b/BrainPortal/db/migrate/20150608195413_rmove_another_index_from_userfile.rb
@@ -1,0 +1,5 @@
+class RmoveAnotherIndexFromUserfile < ActiveRecord::Migration
+  def change
+    remove_index(:userfiles, :name => 'index_userfiles_on_format_source_id_and_id')
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150608151559) do
+ActiveRecord::Schema.define(:version => 20150608190254) do
 
   create_table "active_record_logs", :force => true do |t|
     t.integer  "ar_id"
@@ -343,7 +343,6 @@ ActiveRecord::Schema.define(:version => 20150608151559) do
     t.integer  "data_provider_id"
     t.boolean  "group_writable",                                  :default => false, :null => false
     t.integer  "num_files"
-    t.integer  "format_source_id"
     t.boolean  "hidden",                                          :default => false
     t.boolean  "immutable",                                       :default => false
     t.boolean  "archived",                                        :default => false
@@ -352,13 +351,9 @@ ActiveRecord::Schema.define(:version => 20150608151559) do
 
   add_index "userfiles", ["archived", "id"], :name => "index_userfiles_on_archived_and_id"
   add_index "userfiles", ["data_provider_id"], :name => "index_userfiles_on_data_provider_id"
-  add_index "userfiles", ["format_source_id", "data_provider_id"], :name => "index_userfiles_on_format_source_id_and_data_provider_id"
-  add_index "userfiles", ["format_source_id", "group_id"], :name => "index_userfiles_on_format_source_id_and_group_id"
-  add_index "userfiles", ["format_source_id", "id"], :name => "index_userfiles_on_format_source_id_and_id"
-  add_index "userfiles", ["format_source_id", "type"], :name => "index_userfiles_on_format_source_id_and_type"
-  add_index "userfiles", ["format_source_id", "user_id"], :name => "index_userfiles_on_format_source_id_and_user_id"
   add_index "userfiles", ["group_id"], :name => "index_userfiles_on_group_id"
   add_index "userfiles", ["hidden", "id"], :name => "index_userfiles_on_hidden_and_id"
+  add_index "userfiles", ["id"], :name => "index_userfiles_on_format_source_id_and_id"
   add_index "userfiles", ["immutable", "id"], :name => "index_userfiles_on_immutable_and_id"
   add_index "userfiles", ["name"], :name => "index_userfiles_on_name"
   add_index "userfiles", ["type"], :name => "index_userfiles_on_type"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150608190254) do
+ActiveRecord::Schema.define(:version => 20150608195413) do
 
   create_table "active_record_logs", :force => true do |t|
     t.integer  "ar_id"
@@ -353,7 +353,6 @@ ActiveRecord::Schema.define(:version => 20150608190254) do
   add_index "userfiles", ["data_provider_id"], :name => "index_userfiles_on_data_provider_id"
   add_index "userfiles", ["group_id"], :name => "index_userfiles_on_group_id"
   add_index "userfiles", ["hidden", "id"], :name => "index_userfiles_on_hidden_and_id"
-  add_index "userfiles", ["id"], :name => "index_userfiles_on_format_source_id_and_id"
   add_index "userfiles", ["immutable", "id"], :name => "index_userfiles_on_immutable_and_id"
   add_index "userfiles", ["name"], :name => "index_userfiles_on_name"
   add_index "userfiles", ["type"], :name => "index_userfiles_on_type"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150605193442) do
+ActiveRecord::Schema.define(:version => 20150608151559) do
 
   create_table "active_record_logs", :force => true do |t|
     t.integer  "ar_id"
@@ -352,7 +352,11 @@ ActiveRecord::Schema.define(:version => 20150605193442) do
 
   add_index "userfiles", ["archived", "id"], :name => "index_userfiles_on_archived_and_id"
   add_index "userfiles", ["data_provider_id"], :name => "index_userfiles_on_data_provider_id"
+  add_index "userfiles", ["format_source_id", "data_provider_id"], :name => "index_userfiles_on_format_source_id_and_data_provider_id"
+  add_index "userfiles", ["format_source_id", "group_id"], :name => "index_userfiles_on_format_source_id_and_group_id"
   add_index "userfiles", ["format_source_id", "id"], :name => "index_userfiles_on_format_source_id_and_id"
+  add_index "userfiles", ["format_source_id", "type"], :name => "index_userfiles_on_format_source_id_and_type"
+  add_index "userfiles", ["format_source_id", "user_id"], :name => "index_userfiles_on_format_source_id_and_user_id"
   add_index "userfiles", ["group_id"], :name => "index_userfiles_on_group_id"
   add_index "userfiles", ["hidden", "id"], :name => "index_userfiles_on_hidden_and_id"
   add_index "userfiles", ["immutable", "id"], :name => "index_userfiles_on_immutable_and_id"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20150526144742) do
+ActiveRecord::Schema.define(:version => 20150605193442) do
 
   create_table "active_record_logs", :force => true do |t|
     t.integer  "ar_id"
@@ -350,10 +350,12 @@ ActiveRecord::Schema.define(:version => 20150526144742) do
     t.text     "description"
   end
 
+  add_index "userfiles", ["archived", "id"], :name => "index_userfiles_on_archived_and_id"
   add_index "userfiles", ["data_provider_id"], :name => "index_userfiles_on_data_provider_id"
-  add_index "userfiles", ["format_source_id"], :name => "index_userfiles_on_format_source_id"
+  add_index "userfiles", ["format_source_id", "id"], :name => "index_userfiles_on_format_source_id_and_id"
   add_index "userfiles", ["group_id"], :name => "index_userfiles_on_group_id"
-  add_index "userfiles", ["hidden"], :name => "index_userfiles_on_hidden"
+  add_index "userfiles", ["hidden", "id"], :name => "index_userfiles_on_hidden_and_id"
+  add_index "userfiles", ["immutable", "id"], :name => "index_userfiles_on_immutable_and_id"
   add_index "userfiles", ["name"], :name => "index_userfiles_on_name"
   add_index "userfiles", ["type"], :name => "index_userfiles_on_type"
   add_index "userfiles", ["user_id"], :name => "index_userfiles_on_user_id"

--- a/BrainPortal/lib/portal_sanity_checks.rb
+++ b/BrainPortal/lib/portal_sanity_checks.rb
@@ -300,21 +300,6 @@ class PortalSanityChecks < CbrainChecker #:nodoc:
     end
   end
 
-  def self.ensure_format_groups_match_source_groups #:nodoc:
-
-    #-----------------------------------------------------------------------------
-    puts "C> Ensuring formats have the same group as source file..."
-    #-----------------------------------------------------------------------------
-
-    format_files = Userfile.all(:conditions  => "format_source_id IS NOT NULL")
-    format_files.each do |f|
-      if f.format_source && f.group_id != f.format_source.group_id
-        f.group_id = f.format_source.group_id
-        f.save!
-      end
-    end
-  end
-
   # Each tags should have a group
   def self.ensure_tags_have_a_group_id #:nodoc:
 

--- a/BrainPortal/spec/models/userfile_spec.rb
+++ b/BrainPortal/spec/models/userfile_spec.rb
@@ -256,75 +256,7 @@ describe Userfile do
       expect(userfile.update_file_type("new_type")).to be_falsey
     end
   end
-
-   describe "#add_format" do
-     let(:userfile1) {create(:userfile)}
-     let(:userfile2) {create(:userfile)}
-
-     it "should return an array containing all format_source" do
-       userfile.add_format(userfile).inspect
-       expect(userfile.add_format(userfile2).size).to eq(2)
-     end
-  end
-
-  describe "#format_name" do
-
-   it "should alweays return nil" do
-     expect(userfile.format_name).to eq(nil)
-   end
-  end
-
-  describe "#format_names" do
-
-    it "should call format_source" do
-      expect(userfile).to receive(:format_source)
-      userfile.format_names
-    end
-
-    it "should concatenate format_name and result of format.map" do
-      allow(userfile).to receive(:format_source).and_return(nil)
-      allow(userfile).to receive(:format_name).and_return(1)
-      allow(userfile).to receive_message_chain(:formats, :map).and_return([2,3])
-      expect(userfile.format_names).to match_array([1,2,3])
-    end
-  end
-
-  describe "#has_format?" do
-
-    it "should return true if get_format return true" do
-      allow(userfile).to receive(:get_format).and_return(true)
-      expect(userfile.has_format?("format")).to be_truthy
-    end
-
-    it "should return false if get_format return false" do
-      allow(userfile).to receive(:get_format).and_return(false)
-      expect(userfile.has_format?("format")).to be_falsey
-    end
-  end
-
-  describe "#get_format" do
-
-    it "should return self if self.format_name.to_s.downcase == f.to_s.downcase" do
-      f = double("format")
-      allow(f).to receive_message_chain(:to_s, :downcase).and_return(f)
-      allow(userfile).to receive_message_chain(:format_name, :to_s, :downcase).and_return(f)
-      expect(userfile.get_format(f)).to eq(userfile)
-    end
-
-    it "should return self if self.class.name == f" do
-      f = double("format")
-      allow(userfile).to receive_message_chain(:class, :name).and_return(f)
-      expect(userfile.get_format(f)).to eq(userfile)
-    end
-
-    it "should call formats.all.find on self in other case" do
-      f = double("format")
-      expect(userfile).to receive(:formats).and_return(Userfile)
-      userfile.get_format(f)
-    end
-
-  end
-
+  
   #Testing the get_tags_for_user method
   describe "#get_tags_for_user" do
 


### PR DESCRIPTION
This is to remove linkage between files with multiple formats as this feature is not used by users and slows down page loads.