### PR TITLE
Issue #118 - Speed up test suite

### DIFF
--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -194,7 +194,9 @@ class ApplicationController < ActionController::Base
     # Compute the info from the request (when not logged in)
     ip   ||= reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR']
     if host.blank? && ip =~ /^[\d\.]+$/
-      addrinfo = Socket.gethostbyaddr(ip.split(/\./).map(&:to_i).pack("CCCC")) rescue [ ip ]
+      addrinfo = Rails.cache.fetch("host_addr/#{ip}") do
+        Socket.gethostbyaddr(ip.split(/\./).map(&:to_i).pack("CCCC")) rescue [ ip ]
+      end
       host = addrinfo[0]
     end
 

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -242,7 +242,9 @@ class SessionsController < ApplicationController
     from_ip = reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR']
     if from_ip
       if from_ip  =~ /^[\d\.]+$/
-        addrinfo  = Socket.gethostbyaddr(from_ip.split(/\./).map(&:to_i).pack("CCCC")) rescue [ from_ip ]
+        addrinfo  = Rails.cache.fetch("host_addr/#{from_ip}") do
+          Socket.gethostbyaddr(from_ip.split(/\./).map(&:to_i).pack("CCCC")) rescue [ from_ip ]
+        end
         from_host = addrinfo[0]
       else
         from_host = from_ip # already got name?!?

--- a/BrainPortal/spec/factories/portal_factories.rb
+++ b/BrainPortal/spec/factories/portal_factories.rb
@@ -32,6 +32,16 @@ FactoryGirl.define do
     sequence(:email)      { |n| "user#{n}@example.com" }
     password              "Password!"
     password_confirmation "Password!"
+
+    after(:build) do |user|
+      user.define_singleton_method(:encrypt_password) { true }
+    end
+
+    trait :encrypted_password do
+      after(:build) do |user|
+        user.define_singleton_method(:encrypt_password) { user.class.instance_method(:encrypt_password).bind(user).call }
+      end
+    end
   end
 
   factory :normal_user, parent: :user, class: NormalUser do

--- a/BrainPortal/spec/models/user_spec.rb
+++ b/BrainPortal/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ require 'rails_helper'
 
 describe User do
 
-  let(:normal_user) { create(:normal_user) }
+  let(:normal_user) { create(:normal_user, :encrypted_password) }
 
 
   describe "#validate" do


### PR DESCRIPTION
After profiling, the two hot spots were gethostbyaddr and
encrypt_password. This changeset solves these by caching gethostbyaddr
and stubbing encrypt_password in all tests except those for the User
model.

On my machine (Ubuntu 12.04.5 LTS, core i5 750 CPU, ~4GB RAM), these
changes make the tests take 2 minutes instead of ~40.

Might cause some tests to fail.