### PR TITLE
Docker support

### DIFF
--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -142,7 +142,7 @@ class ToolConfigsController < ApplicationController
     form_tool_config.bourreau_id = @tool_config.bourreau_id
 
     # Update everything else
-    [ :version_name, :description, :script_prologue, :group_id, :ncpus ].each do |att|
+    [ :version_name, :description, :script_prologue, :group_id, :ncpus, :docker_image ].each do |att|
        @tool_config[att] = form_tool_config[att]
     end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1630,13 +1630,11 @@ class ClusterTask < CbrainTask
   end
 
   def use_docker?
-     
     return (self.tool_config.docker_image and self.tool_config.docker_image != "")
   end
   
   # Returns the command line(s) associated with the task, wrapped in a Docker call if a Docker image has to be used.
   def docker_commands
-
     commands = self.cluster_commands  
     commands_joined=commands.join("\n");
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1470,7 +1470,23 @@ class ClusterTask < CbrainTask
 
 # CbrainTask '#{self.name}' commands section
 
-#{commands.join("\n")}
+#{
+commands_joined=commands.join("\n");
+
+cache_dir=RemoteResource.current_resource.dp_cache_dir;
+task_dir=self.bourreau.cms_shared_dir;
+
+(self.tool_config.docker_image and self.tool_config.docker_image != "") ? "
+cat << DOCKERJOB > .dockerjob.sh
+#!/bin/bash\n
+#{commands_joined}\n
+DOCKERJOB\n
+chmod 755 ./.dockerjob.sh\n
+docker run -v $PWD:/cbrain-script -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w /cbrain-script #{self.tool_config.docker_image} /cbrain-script/.dockerjob.sh \n
+" 
+: "#{commands_joined}"
+}
+
 
     QSUB_SCRIPT
     qsubfile = self.qsub_script_basename

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1482,7 +1482,7 @@ cat << DOCKERJOB > .dockerjob.sh
 #{commands_joined}\n
 DOCKERJOB\n
 chmod 755 ./.dockerjob.sh\n
-docker run -v $PWD:/cbrain-script -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w /cbrain-script #{self.tool_config.docker_image} /cbrain-script/.dockerjob.sh \n
+docker run --rm -v $PWD:/cbrain-script -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w /cbrain-script #{self.tool_config.docker_image} /cbrain-script/.dockerjob.sh \n
 " 
 : "#{commands_joined}"
 }

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -56,7 +56,7 @@ class ToolConfig < ActiveRecord::Base
   cb_scope        :global_for_bourreaux , where( { :tool_id => nil } )
   cb_scope        :specific_versions    , where( "bourreau_id is not null and tool_id is not null" )
 
-  attr_accessible :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue, :group_id, :ncpus
+  attr_accessible :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue, :group_id, :ncpus, :docker_image
 
   # CBRAIN extension
   force_text_attribute_encoding 'UTF-8', :description, :version_name

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -95,5 +95,12 @@
   </div>
   </p>
 
+  <span title="Docker image">
+    <p><%= f.label :docker_image, "Docker image:" %><br/>
+      <%= f.text_field :docker_image %><br/>
+      <div class="field_explanation">The name and tag of the Docker image in which the tool is installed, for instance "centos:latest". This name refers to the Docker index accessed by the Bourreau, which is configured manually in the Bourreau for now.</div>
+    </p>
+  </span>
+
 </div>
 

--- a/BrainPortal/db/migrate/20150224202026_add_docker_image_to_tool_config.rb
+++ b/BrainPortal/db/migrate/20150224202026_add_docker_image_to_tool_config.rb
@@ -1,0 +1,5 @@
+class AddDockerImageToToolConfig < ActiveRecord::Migration
+  def change
+    add_column :tool_configs, :docker_image, :string
+  end
+end


### PR DESCRIPTION
To run a task in a Docker container, just add the name of the Docker image in the Tool configuration. The Docker image has to be stored on DockerHub (https://hub.docker.com). It assumes that a Docker service is running on the Bourreau. The behavior of tools with no Docker image configured remains unchanged.