### PR TITLE
Docker improvements

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1646,7 +1646,7 @@ class ClusterTask < CbrainTask
 #{commands_joined}\n
 DOCKERJOB\n
 chmod 755 ./.dockerjob.sh\n
-docker run --rm -v $PWD:/cbrain-script -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w /cbrain-script #{self.tool_config.docker_image} /cbrain-script/.dockerjob.sh \n
+docker run --rm -v ${PWD}:${PWD} -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w ${PWD} #{self.tool_config.docker_image} ${PWD}/.dockerjob.sh \n
 "
     return docker_commands
   end

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -117,7 +117,7 @@ class RemoteResource < ActiveRecord::Base
                         :time_zone, :site_url_prefix, :dp_cache_dir, :dp_ignore_patterns, :cms_class,
                         :cms_default_queue, :cms_extra_qsub_args, :cms_shared_dir, :workers_instances,
                         :workers_chk_time, :workers_log_to, :workers_verbose, :help_url, :rr_timeout, :proxied_host,
-                        :spaced_dp_ignore_patterns, :license_agreements, :support_email, :system_from_email, :external_status_page_url
+                        :spaced_dp_ignore_patterns, :license_agreements, :support_email, :system_from_email, :external_status_page_url, :docker_executable_name
 
 
 

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -343,6 +343,12 @@
           %>
         <% end %>
       <% end %>
+      <%= show_table(@bourreau, :header => "Docker Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+        <% t.edit_cell :docker_executable_name, :header => "Docker executable" do %>
+          <%= text_field_tag "bourreau[docker_executable_name]", @bourreau.docker_executable_name, :size => 60 %><br/>
+           <div class="field_explanation">Name of the Docker executable available on the machines where tasks will run. Defaults to "docker" if left empty.</div>
+        <% end %>
+      <% end %>
     <% end %>
 
     <%= render :partial => 'runtime_info' %>

--- a/BrainPortal/db/migrate/20150730214453_add_docker_executable_name_to_remote_resources.rb
+++ b/BrainPortal/db/migrate/20150730214453_add_docker_executable_name_to_remote_resources.rb
@@ -1,0 +1,5 @@
+class AddDockerExecutableNameToRemoteResources < ActiveRecord::Migration
+  def change
+    add_column :remote_resources, :docker_executable_name, :string
+  end
+end


### PR DESCRIPTION
Improvements in the Docker support so that Docker can be used on Guillimin:
* support for relative paths in symlinks (as consequence of #33 input files were broken symlinks).
* support for alternate Docker executable names (Docker has to be invoked through 'udocker' on Guillimin).