### PR TITLE
Replaced file icons in the userfiles index table

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -100,14 +100,6 @@ class UserfilesController < ApplicationController
       simple_pairs      = tree_sort_by_pairs(simple_pairs) # private method in this controller
       # At this point, each simple_pair is [ userfile_id, parent_id, [ child1_id, child2_id... ], orig_idx, level ]
       @userfiles_total  = simple_pairs.size
-      if params[:find_file_id]
-        find_file_id    = params[:find_file_id].to_i
-        find_file_index = simple_pairs.index { |u| u[0] == find_file_id }
-        if find_file_index
-          @current_page = (find_file_index / @per_page) + 1
-          offset = (@current_page - 1) * @per_page
-        end
-      end
 
       # Paginate the list of simple objects
       page_of_userfiles = simple_pairs[offset, @per_page] || []

--- a/BrainPortal/app/helpers/userfiles_helper.rb
+++ b/BrainPortal/app/helpers/userfiles_helper.rb
@@ -31,13 +31,6 @@ module UserfilesHelper
   def filename_listing(userfile, link_options={})
     html = []
     html << tree_view_icon(userfile.level) if @filter_params["tree_sort"] == "on" && userfile.level.to_i > 0
-    if userfile.is_a? FileCollection
-      file_icon = image_tag "/images/folder_icon_solid.png"
-    else
-      file_icon = image_tag "/images/file_icon.png"
-    end
-    html << ajax_link(file_icon, {:action => :index, :clear_filter => true, :find_file_id => userfile.id}, :datatype => "script", :title => "Show in Unfiltered File List")
-    html << " "
     html << link_to_userfile_if_accessible(userfile, nil, link_options)
     if userfile.hidden?
       html << " "
@@ -51,7 +44,7 @@ module UserfilesHelper
     userfile.sync_status.each do |syncstat|
       html << render(:partial => 'userfiles/syncstatus', :locals => { :syncstat => syncstat })
     end
-    
+
     html.join.html_safe
   end
 

--- a/BrainPortal/app/views/userfiles/_userfiles_display.html.erb
+++ b/BrainPortal/app/views/userfiles/_userfiles_display.html.erb
@@ -90,7 +90,21 @@
         :select_value => u.id
       } if u.available?
     end
+  %>
 
+  <%
+    t.column('', :type_icon,
+      :pretty_name => "Type Icon"
+    ) do |u|
+  %>
+    <% if u.is_a?(FileCollection) %>
+      <span class="ui-icon ui-icon-folder-collapsed"></span>
+    <% else %>
+      <span class="ui-icon ui-icon-document"></span>
+    <% end %>
+  <% end %>
+
+  <%
     t.column("Filename", :name,
       :sortable => true
     ) do |u|

--- a/BrainPortal/public/stylesheets/cbrain.css
+++ b/BrainPortal/public/stylesheets/cbrain.css
@@ -1441,6 +1441,15 @@ pre {
   display: table-row;
 }
 
+#userfiles_table td.type_icon,
+#userfiles_table th.type_icon {
+  max-width: 12px;
+}
+
+#userfiles_table td.type_icon > .ui-icon {
+  background-image: url(../images/ui-black-icons.png);
+}
+
 /* % ######################################################### */
 /* % Show page table formatting */
 /* % ######################################################### */


### PR DESCRIPTION
The new icons share the same palette as the new task table icons, and
are no longer click-able (the functionality, removing filters and going
to the file's page, was deemed unnecessary).