### PR TITLE
Scope fixes following review and testing

### DIFF
--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -297,13 +297,16 @@ class DataProvidersController < ApplicationController
     })
 
     # Browsing as a different user? Make sure the target user is set.
-    @as_user   = current_user
+    @as_user = current_user
       .available_users
-      .where(:id => @scope.custom['as_user_id'] ||= (
-        params['as_user_id'] || current_user.id
+      .where(:id => (
+        params['as_user_id'] ||
+        @scope.custom['as_user_id'] ||
+        current_user.id
       ))
       .first
     @as_user ||= current_user
+    @scope.custom['as_user_id'] = @as_user.id
 
     begin
       # [ base, size, type, mtime ]

--- a/BrainPortal/app/helpers/scope_helper.rb
+++ b/BrainPortal/app/helpers/scope_helper.rb
@@ -384,7 +384,7 @@ module ScopeHelper
     # Format the generated filter arrays as DynamicTable's filter hashes
     filters.map do |value, label, count, *rest|
       scoped = rest.first
-      label  = "#{label} (#{scoped}/#{count})" if scoped
+      label  = "#{label} (of #{count})" if scoped
       {
         :value     => value,
         :label     => label,
@@ -418,7 +418,7 @@ module ScopeHelper
       lambda do |args|
         value, label, count, scoped = args
         label = block.(label) rescue label
-        label = "#{label} (#{scoped}/#{count})" if scoped
+        label = "#{label} (of #{count})" if scoped
         {
           :value     => value,
           :label     => label,
@@ -561,7 +561,7 @@ module ScopeHelper
     # [[value, label, count], [...]]
     filters = model
       .where("#{attribute} IS NOT NULL")
-      .order(attribute, label)
+      .order(label, attribute)
       .group(attribute, label)
       .raw_rows(attribute, "#{label} AS #{label_alias}", "COUNT(#{attribute})")
       .reject { |r| r.first.blank? }
@@ -608,7 +608,7 @@ module ScopeHelper
       collection
         .map     { |i| [attr_get.(i), lbl_get.(i)].freeze }
         .reject  { |v, l| v.blank? }
-        .sort_by { |v, l| v }
+        .sort_by { |v, l| l }
         .inject(Hash.new(0)) { |h, i| h[i] += 1; h }
     end
 

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -40,10 +40,23 @@ module ShowTableHelper
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  # Class that actually builds the table.
+  # Helper class to represent the show table properties required for rendering.
+  # This object is the one passed to +show_table+'s block, and it keeps
+  # track of each cell (field) to be rendered.
   class TableBuilder
-    attr_accessor :cells, :width
+    # Cells to be rendered to form the table, as an array of pairs
+    # (cell HTML markup, individual cell width).
+    attr_accessor :cells
 
+    # Table width, in cells. This property holds how many cells should be
+    # displayed per row, as show tables are mainly cell-based, rather than
+    # column/row-based.
+    attr_accessor :width
+
+    # Create a new TableBuilder for +object+ using +template+ for rendering.
+    # Available +options+ are the same as for the +show_table+ helper method.
+    # Internal method; use +show_table+ (which uses this class) to create and
+    # render show tables.
     def initialize(object, template, options = {}) #:nodoc:
       @object          = object
       @template        = template
@@ -54,29 +67,79 @@ module ShowTableHelper
       @edit_cell_count = 0
     end
 
-    # Returns true if the content is editable
+    # Whether or not this table has editable content. An editable table will
+    # have a toggle button to switch to edition mode.
     def editable?
       !@edit_disabled && @edit_cell_count > 0
     end
 
-    # Generates a cell
+    # Generate a single cell for the table, optionally along with a header cell
+    # containing +header+. Expects a block taking no arguments to generate
+    # the contents of the cell.
+    # Note that cells are placed from left to right in rows of *width* (width
+    # attribute) cells.
+    #
+    # The available +options+ are:
+    # [:no_header]
+    #  Do not generate a header cell with the main content one. +head+ is
+    #  ignored.
+    #
+    # [:show_width]
+    #  Width (in cells or columns) of this cell in the table. For example,
+    #  if a table has 2 cells per row, a show_width of 2 would make the
+    #  generated cell as wide as the entire table. Defaults to 1.
+    #
+    # [:th_options]
+    #  HTML attributes to tackle on the generated header cell. Note that
+    #  +build_cell+ does not have any default attributes for header cells.
+    #
+    # [:td_options]
+    #  Same as :th_options, but for the content cell. Note that +build_cell+
+    #  may override any colspan attribute given in +td_options+, if required.
+    #
+    # [<...>]
+    #  All other options are added as HTML attributes to both the generated
+    #  header and content cells.
     def cell(header = "", options = {}, &block)
       build_cell(ERB::Util.html_escape(header), @template.capture(&block), options)
     end
 
-    # Generates a row
+    # Generate a new table row containing a single cell as wide as the table.
+    # Expects a block taking no arguments to generate the contents of the cell.
+    # The available +options+ are the same as for +cell+ (and will apply to the
+    # single cell filling the row) except for +no_header+ and +show_width+,
+    # which are respectively set to true (as there is no header for full-row
+    # cells) and the width of the table. Note that this method will also pad the
+    # last row with blanks before adding the new row
+    # (see +pad_row_with_blank_cells+).
     def row(options = {}, &block)
       pad_row_with_blank_cells(options)
       build_cell("", @template.capture(&block), options.dup.merge( { :no_header => true, :show_width => @width } ) )
     end
 
-    # Generates the attribute of a cell
+    # Generate a cell for a field named +field+ inside the table's source
+    # object. This method has the same +options+ as the +cell+ method, with
+    # one addition:
+    # [:header]
+    #  Contents for the header cell to generate along with the field cell.
+    #  Defaults to +field+ (field name).
     def attribute_cell(field, options = {})
       header = options[:header] || field.to_s.humanize
       build_cell(ERB::Util.html_escape(header), ERB::Util.html_escape(@object.send(field)), options)
     end
 
-    # Generates an editable cell
+    # Generate an editable cell for a field named +field+ inside the table's
+    # source object. Expects a block taking no arguments to generate HTML
+    # markup for editing +field+ (use +inline_edit_field+'s +content+ option
+    # to specify the cell's contents in display mode).
+    # Unless edition is disabled, the generated cell will toggle between display
+    # and edition mode when the table's edition toggle button is used.
+    #
+    # This method supports both +cell+ and +inline_edit_field+'s
+    # options, with one addition:
+    # [:header]
+    #  Contents for the header cell to generate along with the field cell.
+    #  Defaults to +field+ (field name).
     def edit_cell(field, options = {}, &block)
       header    = options.delete(:header) || field.to_s.humanize
       object    = @object
@@ -85,7 +148,19 @@ module ShowTableHelper
       build_cell(ERB::Util.html_escape(header), @template.instance_eval{ inline_edit_field(object, field, options, &block) }, options)
     end
 
-    # Generates an editable checkbox
+    # Generates an editable checkbox cell for +field+, of which the current
+    # value is expected to be +cur_value+, a checked checkbox corresponding to
+    # +checked_value+ and an unchecked one to +unchecked_value+.
+    #
+    # A specialization of +edit_cell+, this method provides some useful
+    # defaults when generating checkbox cells:
+    # - The cell's contents in display mode default to a disabled checkbox
+    # - If no block is given, the edition mode markup defaults to an hidden
+    #   field for +unchecked_value+ and a checkbox for +checked_value+.
+    #
+    # As +boolean_edit_cell+ is a specialization of +edit_cell+, +field+,
+    # +&block+ and +options+ are handled the same way (save for the defaults
+    # outlined above).
     def boolean_edit_cell(field, cur_value, checked_value = "1", unchecked_value = "0", options = {}, &block)
       options[:content] ||= @template.disabled_checkbox(cur_value == checked_value)
       if block_given?
@@ -95,23 +170,32 @@ module ShowTableHelper
       end
     end
 
-    # Generates an empty cell
+    # Generate +n+ empty cells (blank content and header), each with the same
+    # +options+. Available +options+ are the same as the ones for +cell+.
+    #
+    # FIXME: +options+ is destructively modified in +build_cell+, meaning only
+    # the first cell will have +options+ applied.
     def empty_cell(n = 1, options = {})
       n.times { build_cell("","",options) }
     end
 
-    # Generates X empty cells
+    # Alias for +empty_cell+ (see +empty_cell+).
     def empty_cells(n, options = {})
       empty_cell(n, options)
     end
 
-    # Generates a blank row
+    # Generate a new blank/empty table row. A simple wrapper around +row+, this
+    # method takes the same arguments save for the block, which isn't required
+    # as there is no content to display. See +row+ for more information on how
+    # rows are generated.
     def blank_row(options = {})
       pad_row_with_blank_cells(options)
       row(options) { "&nbsp;".html_safe }
     end
 
-    # Generates a row with empty cells
+    # Fill the last table row with empty cells (+empty_cell+). Each generated
+    # empty cell is generated with the same +options+, which are the same as
+    # the ones for +cell+.
     def pad_row_with_blank_cells(options = {})
       in_current_row = (@cells.inject(0) { |tot,c| tot += c[1]; tot } ) % @width  # c[1] is the show_width of each cell
       empty_cell(@width - in_current_row, options) if in_current_row > 0
@@ -119,6 +203,10 @@ module ShowTableHelper
 
     private
 
+    # Generate a single show table cell containing +content+, usually along with
+    # another header cell containing +head+. Internal method backing most
+    # cell-generating methods in TableBuilder. Available +options+ are the
+    # same as those specified for the +cell+ method.
     def build_cell(head = "", content = "", options = {}) #:nodoc:
       no_header      = options.delete(:no_header)
       header_options = options.delete(:th_options) || {}
@@ -139,6 +227,24 @@ module ShowTableHelper
     end
   end # class TableBuilder
 
+  # Generate an input field for +attribute+ within +object+ which can be
+  # toggled by the user into either display or edition mode. This helper method
+  # is designed to be used within a show table, as the table's layout will
+  # provide the toggle button it requires. Expects a block taking no arguments
+  # to generate the HTML markup to render when in edition mode. In display mode,
+  # the field just shows +attribute+'s value.
+  #
+  # The available +options+ are:
+  # [:content]
+  #  Content to show in display mode instead of +attribute+'s value.
+  #
+  # [:disabled]
+  #  Disable edition; this field will always stay in display mode and will
+  #  ignore the show table's toggle button.
+  #
+  # Note that +object+ needs to look like an AR record, as it is expected to
+  # have an errors method. If it has one and it contains +attribute+, the
+  # display mode's text will reflect the erroneous state of the attribute.
   def inline_edit_field(object, attribute, options = {}, &block)
     default_text = h(options.delete(:content) || object.send(attribute))
     return default_text if options.delete(:disabled)
@@ -157,6 +263,35 @@ module ShowTableHelper
     return html
   end
 
+  # Create a show (and edition) table for +object+, which is expected to be
+  # an AR record (or a similar object) to use for most table values.
+  # Expects a block taking a single argument, a TableBuilder object, to specify
+  # which fields of +object+ to display (see TableBuilder's methods for more
+  # information).
+  #
+  # The available +options+ are:
+  # [header]
+  #  Title (header), to place on top of the table. Defaults to "Info".
+  #
+  # [url]
+  #  URL (as a string) to perform the edition request on should +object+ be
+  #  editable using this table. Defaults to an URL to the current controller
+  #  for the +create+ action if +object+ does not exist yet in the DB, or
+  #  +update+ with +object+'s ID otherwise.
+  #
+  # [method]
+  #  HTTP method to perform the edition request with, should +object+ be
+  #  editable using this table. Defaults to POST if the object has not been
+  #  saved yet, PUT otherwise.
+  #
+  # [width]
+  #  Table row width, in cells (in other words, the column count).
+  #  Defaults to 2 cells per row.
+  #
+  # [edit_condition]
+  #  Whether or not to make the table's fields editable by the user. If the
+  #  table is editable (+edit_condition+ is specified as true), an edit toggle
+  #  will be added next to the header/title to switch into edition mode.
   def show_table(object, options = {})
     header = options.delete(:header) || "Info"
     url    = options.delete :url

--- a/BrainPortal/app/views/bourreaux/_bourreaux_display.html.erb
+++ b/BrainPortal/app/views/bourreaux/_bourreaux_display.html.erb
@@ -28,7 +28,7 @@
     :class      => [ :resource_list ],
     :scope      => @scope,
     :render     => false,
-    :sort_map   => {
+    :order_map  => {
       :owner => { :a => 'users.login', :j => User  },
       :group => { :a => 'groups.name', :j => Group }
     },

--- a/BrainPortal/app/views/data_providers/_dp_browse_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_dp_browse_table.html.erb
@@ -34,9 +34,9 @@
   <div class="pagination">
     <div class="pagination_left_side">
       Register files as:
-      <%= master_select("file_select", ["..."] + SingleFile.valid_file_classes.map(&:pretty_type)) %>,
+      <%= master_select("file_select", ["..."] + SingleFile.valid_file_classes.map(&:pretty_type).sort) %>,
       and directories as:
-      <%= master_select("directory_select", ["..."] + FileCollection.valid_file_classes.map(&:pretty_type)) %>
+      <%= master_select("directory_select", ["..."] + FileCollection.valid_file_classes.map(&:pretty_type).sort) %>
     </div>
 
     <div class="pagination_right_side">

--- a/BrainPortal/app/views/messages/_message_index_display.html.erb
+++ b/BrainPortal/app/views/messages/_message_index_display.html.erb
@@ -107,7 +107,7 @@
             label = (! value || value == 0) ? 'Not critical' : 'Critical'
             {
               :value     => value,
-              :label     => "#{label} (#{scoped}/#{count})",
+              :label     => "#{label} (of #{count})",
               :indicator => scoped,
               :empty     => scoped == 0
             }
@@ -124,7 +124,7 @@
           format: lambda do |value, label, count, scoped|
             {
               :value     => value,
-              :label     => "#{label.humanize} (#{scoped}/#{count})",
+              :label     => "#{label.humanize} (of #{count})",
               :indicator => scoped,
               :empty     => scoped == 0
             }

--- a/BrainPortal/app/views/shared/_active_filters.html.erb
+++ b/BrainPortal/app/views/shared/_active_filters.html.erb
@@ -51,7 +51,7 @@
       <% end %>
       <% Array(scope.custom[:custom_filters]).uniq.each do |id| %>
         <span class="current_filters_item">
-          <%= crop_text_to(30, UserfileCustomFilter.find(id).name) %>
+          <%= crop_text_to(30, CustomFilter.find(id).name) %>
         </span>
         <%=
           scope_custom_link(delete_icon,

--- a/BrainPortal/app/views/users/_users_table.html.erb
+++ b/BrainPortal/app/views/users/_users_table.html.erb
@@ -86,7 +86,7 @@
           label = (!value || value == 0 ? 'Unlocked' : 'Locked')
           {
             :value     => value,
-            :label     => "#{label} (#{scoped}/#{count})",
+            :label     => "#{label} (of #{count})",
             :indicator => scoped,
             :empty     => scoped == 0
           }


### PR DESCRIPTION
This pull request fixes the following Scope issues:
- Broken 'as user' DP browsing
- Filter count format: (34/100) -> (of 100)
- Odd filter menu order (now somewhat ordered by label)
- Broken user & group ordering on bourreaux
- Odd 'register all files' select box order
- Broken custom filters for tasks
- Spurious scopes with only pagination parameters
- Invalid scope filters/ordering rules cannot be removed and
  make the target page inaccessible.

And fixes issue #190