### PR TITLE
Fix for custom filters + scopes available filters bug

### DIFF
--- a/BrainPortal/app/helpers/scope_helper.rb
+++ b/BrainPortal/app/helpers/scope_helper.rb
@@ -572,9 +572,16 @@ module ScopeHelper
     # as +attribute+.
     label_alias = model.connection.quote_column_name('label')
 
+    # FIXME: undo_where is somewhat hacky and not exactly correct sometimes, but
+    # it is still required as some filters (custom filters) are still applied
+    # directly (without a Scope) and cannot be easily removed. Ideally, those
+    # filters should be ported to the Scope API and filter_values_for should
+    # accept a collection of scope objects to generate the separate counts with.
+    bare_model = model.undo_where(attribute)
+
     # Fetch the main filter values as an array of arrays:
     # [[value, label, count], [...]]
-    filters = model
+    filters = bare_model
       .where("#{attribute} IS NOT NULL")
       .order(label, attribute)
       .group(attribute, label)

--- a/BrainPortal/lib/cbrain_extensions/active_record_extensions/relation_extensions/undo_where.rb
+++ b/BrainPortal/lib/cbrain_extensions/active_record_extensions/relation_extensions/undo_where.rb
@@ -54,7 +54,8 @@ module CBRAINExtensions #:nodoc:
 
           to_reject = {} #  "tab1.col1" => true, "tab1.col2" => true etc...
           args.map do |colspec|  #  "col" or "table.col"
-            raise "Invalid column specification \"#{colspec}\"." unless colspec.to_s =~ /^((\w+)\.)?(\w+)$/
+            raise "Invalid column specification \"#{colspec}\"." unless
+              colspec.to_s =~ /^(\`?(\w+)\`?\.)?\`?(\w+)\`?$/
             tab = Regexp.last_match[2].presence || mytable
             col = Regexp.last_match[3]
             to_reject["#{tab}.#{col}"] = true


### PR DESCRIPTION
The available filters now recognize (somewhat) the presence of custom
filters and the filter menus are populated as expected. Note that this
fix relies on undo_where, and will probably bring back issue #125, which
would've been fixed by relying purely on Scope objects.

This changeset can be reverted once custom filters are ported to the
Scope API, which will let filter_values_for remove the corresponding
filter without having to rely on undo_where (provided it is enhanced to
allow using multiple Scope objects).