### PR TITLE
Removal of leftover UndoWhere include, minor users table fix

### DIFF
--- a/BrainPortal/app/views/users/_users_table.html.erb
+++ b/BrainPortal/app/views/users/_users_table.html.erb
@@ -80,15 +80,15 @@
 
     t.column("Login", :login,
       :sortable => true,
-      :filters  => filter_values_for(@base_scope, :account_locked,
-        scope:  @scope,
-        format: lambda do |value, label, count, scoped|
+      :filters  => scoped_filters_for(
+        @base_scope, @scope, :account_locked,
+        format: lambda do |value, label, base, view|
           label = (!value || value == 0 ? 'Unlocked' : 'Locked')
           {
             :value     => value,
-            :label     => "#{label} (of #{count})",
-            :indicator => scoped,
-            :empty     => scoped == 0
+            :label     => "#{label} (of #{base})",
+            :indicator => view,
+            :empty     => view == 0
           }
         end
       )

--- a/BrainPortal/config/initializers/core_extensions/active_record.rb
+++ b/BrainPortal/config/initializers/core_extensions/active_record.rb
@@ -108,19 +108,13 @@ module ActiveRecord #:nodoc:
 
     include CBRAINExtensions::ActiveRecordExtensions::RelationExtensions::RawData
 
-    #####################################################################
-    # ActiveRecord::Relation Added Behavior For To Undo Conditions
-    #####################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::RelationExtensions::UndoWhere
-
   end
 
   # CBRAIN ActiveRecord::Associations::CollectionProxy extensions
   # delegating extended Relation methods.
   module Associations #:nodoc:
     class CollectionProxy #:nodoc:
-      delegate :raw_first_column, :raw_rows, :undo_where, :to => :scoped
+      delegate :raw_first_column, :raw_rows, :to => :scoped
     end
   end
 


### PR DESCRIPTION
This changeset removes the previously removed UndoWhere module from
the AR extensions initializer and fixes an incorrect call in the users
table following a recent refactor of filter_values_for. (In other words,
two simple bugfixes)