### PR TITLE
Fixed incorrect selection merging (issues #254 and #255)

### DIFF
--- a/BrainPortal/lib/persistent_selection.rb
+++ b/BrainPortal/lib/persistent_selection.rb
@@ -47,10 +47,11 @@ module PersistentSelection
       value = value.first if value.is_a?(Enumerable)
       next if value.blank?
 
+      key   = key.sub(/^_psel_/, '')
       value = JSON.parse(value)
       next unless value['bound'].is_a?(Array) && value['selection'].is_a?(Array)
 
-      params[key.sub(/^_psel_/, '')] = value['selection']
+      params[key] = value['selection']
         .to_set
         .subtract(value['bound'])
         .merge(params[key] || [])

--- a/BrainPortal/lib/persistent_selection.rb
+++ b/BrainPortal/lib/persistent_selection.rb
@@ -40,18 +40,18 @@ module PersistentSelection
   # selected values are expected to be unique, and that the selection elements
   # are expected to be directly in params (not nested under any other key).
   def merge_persistent_selection
-    params.each do |key, value|
+    params.keys.each do |key|
       next unless key =~ /^_psel_/
-      params.delete(key)
 
-      key   = key.sub(/^_psel_/, '')
+      value = params.delete(key)
       value = value.first if value.is_a?(Enumerable)
       next if value.blank?
 
       value = JSON.parse(value)
       next unless value['bound'].is_a?(Array) && value['selection'].is_a?(Array)
 
-      params[key] = value['selection'].to_set
+      params[key.sub(/^_psel_/, '')] = value['selection']
+        .to_set
         .subtract(value['bound'])
         .merge(params[key] || [])
         .to_a


### PR DESCRIPTION
Caused by trying to add new keys to `params` while iterating for `_psel_*` keys (which breaks iteration). This changeset fixes this simple issue by iterating over a duplicate of the hash's keys instead and reworking the loop sightly.