### PR TITLE
Issue #253 - Invalid counts in Messages table

### DIFF
--- a/BrainPortal/app/helpers/scope_helper.rb
+++ b/BrainPortal/app/helpers/scope_helper.rb
@@ -255,6 +255,14 @@ module ScopeHelper
     values.map! { |value| value.constantize.pretty_type rescue value } if
       attribute == 'type'
 
+    # Special case for the messages table; a null (nil) sender means the
+    # message was sent by the system, and a filter for it should be displayed
+    # as such.
+    if attribute == 'sender'
+      values << nil if values.blank?
+      values.map! { |value| value.nil? ? 'System' : value }
+    end
+
     # Convert the values to a textual representation, depending on which
     # operator they will be used with; single values are as-is, but
     # sets are converted to 'A, B or C' and ranges to 'A and B'.

--- a/BrainPortal/app/views/messages/_message_index_display.html.erb
+++ b/BrainPortal/app/views/messages/_message_index_display.html.erb
@@ -156,8 +156,8 @@
 
       t.column("Recipient", :recipient,
         :sortable => true,
-        :filters  => filter_values_for(
-          @base_scope, :user_id,
+        :filters  => scoped_filters_for(
+          @base_scope, @scope, :user_id,
           label: 'users.login',
           association: [User, 'id', 'user_id']
         )


### PR DESCRIPTION
- Added a special case in pretty_scope_filter to display
  'Sender: System' if the value for a filter on 'sender' is nil.
- Added scoped counts (filter_values_for -> scoped_filters_for) to the
  recipient column filters

Note that this changeset does not add scoped counts for the sender
column filters, as it would require reworking a great part of
filter_values_for to handle NULL columns when using associations.