### PR TITLE
Better internal messages for long boot reports.

### DIFF
--- a/Bourreau/lib/bourreau_system_checks.rb
+++ b/Bourreau/lib/bourreau_system_checks.rb
@@ -223,7 +223,7 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
           :description   => "Some work directories of tasks have disappeared.",
           :variable_text => "Number of tasks: #{bad_tasks.size}\n" +
                             "List of tasks:\n" + bad_tasks.sort
-                            .hashed_partitions_with_index { |p,i| i / 8 }.map { |r,pp| pp.join(" ") }.join("\n"),
+                            .each_slice(8).map { |tids| tids.join(" ") }.join("\n"),
           :critical      => true,
           :send_email    => false
         ) rescue true

--- a/Bourreau/lib/bourreau_system_checks.rb
+++ b/Bourreau/lib/bourreau_system_checks.rb
@@ -222,7 +222,8 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
           :header        => "Report of task workdir disappearances on '#{myself.name}'",
           :description   => "Some work directories of tasks have disappeared.",
           :variable_text => "Number of tasks: #{bad_tasks.size}\n" +
-                            "List of tasks:\n#{bad_tasks.join("\n")}\n",
+                            "List of tasks:\n" + bad_tasks.sort
+                            .hashed_partitions_with_index { |p,i| i / 8 }.map { |r,pp| pp.join(" ") }.join("\n"),
           :critical      => true,
           :send_email    => false
         ) rescue true

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -869,7 +869,8 @@ class DataProvider < ActiveRecord::Base
       newfile.name             = new_name
       newfile.user_id          = new_user_id
       newfile.group_id         = new_group_id
-      newfile.created_at       = Time.now unless target_exists
+      newfile.size             = userfile.size if     target_exists
+      newfile.created_at       = Time.now      unless target_exists
       newfile.updated_at       = Time.now
       newfile.immutable        = false
       newfile.save

--- a/BrainPortal/lib/cbrain_extensions/array_extensions/hashed_partitions.rb
+++ b/BrainPortal/lib/cbrain_extensions/array_extensions/hashed_partitions.rb
@@ -17,15 +17,15 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 module CBRAINExtensions #:nodoc:
   module ArrayExtensions #:nodoc:
-    
+
     # Convert array to hash based on given block.
     module HashedPartitions
-      
+
       # Converts the array into a complex hash.
       # Runs the given block, passing it each of the
       # elements of the array; the block must return
@@ -40,18 +40,29 @@ module CBRAINExtensions #:nodoc:
       # will return
       #
       #   { 0 => [0,3,6], 1 => [1,4], 2 => [2,5] }
+      #
+      # The method also works with a block receiving two arguments,
+      # the second one will be the index of the element in the array.
+      #
+      #   [ 'a', 'b', 'c', 'd'].hashed_partition { |n,i| i / 3 }
+      #
+      # will return
+      #
+      #   { 0 => ['a,'b','c'], 1 => ['d'] }
       def hashed_partition
         partitions = {}
-        self.each do |elem|
-           key = yield(elem)
+        self.each_with_index do |elem,i|
+           key = yield(elem,i)
            partitions[key] ||= []
            partitions[key] << elem
         end
         partitions
       end
 
-      alias hashed_partitions hashed_partition
-      
+      alias hashed_partitions            hashed_partition
+      alias hashed_partition_with_index  hashed_partition
+      alias hashed_partitions_with_index hashed_partition
+
     end
   end
 end

--- a/BrainPortal/lib/cbrain_system_checks.rb
+++ b/BrainPortal/lib/cbrain_system_checks.rb
@@ -276,7 +276,7 @@ class CbrainSystemChecks < CbrainChecker #:nodoc:
             :description   => "These relative paths in the local Data Provider cache were\n" +
                               "removed as there are no longer any userfiles matching them.\n",
             :variable_text => "#{wiped.size} cache subpaths:\n" + wiped.sort
-                              .hashed_partitions_with_index { |p,i| i / 10 }.map { |r,pp| pp.join(" ") }.join("\n"),
+                              .each_slice(10).map { |pp| pp.join(" ") }.join("\n"),
             :critical      => true,
             :send_email    => false
           ) rescue true

--- a/BrainPortal/lib/cbrain_system_checks.rb
+++ b/BrainPortal/lib/cbrain_system_checks.rb
@@ -275,7 +275,8 @@ class CbrainSystemChecks < CbrainChecker #:nodoc:
             :header        => "Report of cache crud removal on #{myself.is_a?(BrainPortal) ? "Portal" : "Execution Server"} '#{myself.name}'",
             :description   => "These relative paths in the local Data Provider cache were\n" +
                               "removed as there are no longer any userfiles matching them.\n",
-            :variable_text => "#{wiped.size} cache subpaths:\n" + wiped.sort.join("\n"),
+            :variable_text => "#{wiped.size} cache subpaths:\n" + wiped.sort
+                              .hashed_partitions_with_index { |p,i| i / 10 }.map { |r,pp| pp.join(" ") }.join("\n"),
             :critical      => true,
             :send_email    => false
           ) rescue true


### PR DESCRIPTION
Some system checks at boot time generated very very long internal messages, with hundreds or thousands of IDs each on one line. Now several are packed on each line.