### PR TITLE
Do a 'docker pull' before each 'docker run' to make sure that the image is up-to-date.

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1677,14 +1677,14 @@ class ClusterTask < CbrainTask
     cache_dir=RemoteResource.current_resource.dp_cache_dir;
     task_dir=self.bourreau.cms_shared_dir;
     docker_commands = "cat << \"DOCKERJOB\" > .dockerjob.sh
-#!/bin/bash -l\n
-#{commands_joined}\n
-DOCKERJOB\n
-chmod 755 ./.dockerjob.sh\n
+#!/bin/bash -l
+#{commands_joined}
+DOCKERJOB
+chmod 755 ./.dockerjob.sh
 # Pull the Docker image to avoid inconsistencies coming from different image versions on worker nodes
-#{docker_executable_name} pull #{self.tool_config.docker_image}\n
+#{docker_executable_name} pull #{self.tool_config.docker_image.bash_escape}
 # Run the task commands
-#{docker_executable_name} run --rm -v ${PWD}:${PWD} -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w ${PWD} #{self.tool_config.docker_image} ${PWD}/.dockerjob.sh \n
+#{docker_executable_name} run --rm -v ${PWD}:${PWD} -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w ${PWD} #{self.tool_config.docker_image.bash_escape} ${PWD}/.dockerjob.sh
 "
     return docker_commands
   end

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1681,6 +1681,9 @@ class ClusterTask < CbrainTask
 #{commands_joined}\n
 DOCKERJOB\n
 chmod 755 ./.dockerjob.sh\n
+# Pull the Docker image to avoid inconsistencies coming from different image versions on worker nodes
+#{docker_executable_name} pull #{self.tool_config.docker_image}\n
+# Run the task commands
 #{docker_executable_name} run --rm -v ${PWD}:${PWD} -v #{cache_dir}:#{cache_dir} -v #{task_dir}:#{task_dir} -w ${PWD} #{self.tool_config.docker_image} ${PWD}/.dockerjob.sh \n
 "
     return docker_commands


### PR DESCRIPTION
This is required to avoid inconsistencies among cluster nodes when an image, say foo:latest, is updated and the cluster nodes use it at different times. 