### PR TITLE
Dashboard and search for all users.

### DIFF
--- a/BrainPortal/app/controllers/portal_controller.rb
+++ b/BrainPortal/app/controllers/portal_controller.rb
@@ -37,11 +37,6 @@ class PortalController < ApplicationController
       return
     end
 
-    if current_user.has_role?(:normal_user)
-      redirect_to start_page_path
-      return
-    end
-
     @num_files              = current_user.userfiles.count
     @groups                 = current_user.has_role?(:admin_user) ? current_user.groups.order(:name) : current_user.available_groups.order(:name)
     @default_data_provider  = DataProvider.find_by_id(current_user.meta["pref_data_provider_id"])

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -193,7 +193,7 @@ class User < ActiveRecord::Base
        (password_type(crypted_password) == :pbkdf2 && plain_crypted_password == encrypt_in_pbkdf2(password))
       self.password = password # not a real attribute; only used by encrypt_password() below
       self.encrypt_password()  # explicit call to compute the crypted password (stored as a real rails attribute)
-      self.password   = nil    # zap pseudo-attribute for security
+      self.password = nil      # zap pseudo-attribute for security
       self.save
       true
     # This is now the default CBRAIN encryption mode
@@ -202,6 +202,8 @@ class User < ActiveRecord::Base
     else
       false
     end
+  ensure
+    0.upto(password.size-1) { |i| password[i]='x' } # mutate password in memory, hopefully
   end
 
   # Create a random password (to be sent for resets).

--- a/BrainPortal/app/views/layouts/_section_account.html.erb
+++ b/BrainPortal/app/views/layouts/_section_account.html.erb
@@ -36,9 +36,7 @@
 
   <span class="home_credits">
     <% if current_user %>
-      <% unless current_user.try(:has_role?, :normal_user) %>
-        <%= link_to "Dashboard", home_path %>
-      <% end %>
+      <%= link_to "Dashboard", home_path %>
       <%= link_to 'My Account', user_path(current_user) %>
       <%= link_to 'Projects', groups_path %>
       <%= link_to 'Messages', messages_path, :title  => pluralize(@unread_message_count, "unread message"), :id  => "message_menu_tab" %>

--- a/BrainPortal/app/views/layouts/_section_menu.html.erb
+++ b/BrainPortal/app/views/layouts/_section_menu.html.erb
@@ -47,8 +47,7 @@
 
   <%= image_tag "ajax-loader.gif", :style => "display:none", :id => "loading_image" %>
 
-  <% if current_user && current_user.has_role?(:admin_user) &&
-     ! (params[:controller] == 'portal' && params[:action] == 'search') %>
+  <% if current_user && ! (params[:controller] == 'portal' && params[:action] == 'search') %>
     <div id="cbsearch">
       <%= form_tag search_path, :method => :get do %>
         <%= text_field_tag :search, nil, :placeholder => 'Search for anything' %>

--- a/BrainPortal/app/views/portal/welcome.html.erb
+++ b/BrainPortal/app/views/portal/welcome.html.erb
@@ -197,6 +197,7 @@
           <tr>
             <td><%= link_to_task_if_accessible(task, nil, :name_method => :name_and_bourreau) %></td>
             <td><%= link_to_user_if_accessible(task.user) %></td>
+            <td><%= link_to_group_if_accessible(task.group) %></td>
             <td><%= colored_status(task.status) %></td>
             <td><%= to_localtime(task.updated_at,:datetime) %></td>
           </tr>
@@ -218,6 +219,7 @@
           <tr>
             <td><%= link_to_userfile_if_accessible(file, nil) %></td>
             <td><%= link_to_user_if_accessible(file.user) %></td>
+            <td><%= link_to_group_if_accessible(file.group) %></td>
             <td><%= colored_pretty_size(file.size) %></td>
             <td><%= to_localtime(file.updated_at,:datetime) %></td>
           </tr>

--- a/BrainPortal/app/views/tasks/_tasks_display.html.erb
+++ b/BrainPortal/app/views/tasks/_tasks_display.html.erb
@@ -280,9 +280,9 @@
             .where(:batch_id => id)
             .order('cbrain_tasks.updated_at desc')
             .first
-            .updated_at,
+            .try(:updated_at),
           :datetime
-        )
+        ) rescue ""
       end
     end
   %>

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -117,13 +117,13 @@
       <%= select_tag("userfile[group_writable]", options_for_select([['Read Only', false],['Read/Write', true]])) %>
     <% end %>
 
-    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon) do %>
+    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
       <%= hidden_field_tag "userfile[hidden]", "0" %>
       <%= check_box_tag("userfile[hidden]",    "1", @userfile.hidden?) %>
       <%= hidden_icon %>
     <% end %>
 
-    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon ) do %>
+    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
       <%= hidden_field_tag "userfile[immutable]", "0" %>
       <%= check_box_tag("userfile[immutable]",    "1", @userfile.immutable?) %>
       <%= immutable_icon %>
@@ -152,7 +152,7 @@
       <% end %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => simple_format(@userfile.description, :sanitize => true), :show_width => 2) do %>
+    <% t.edit_cell(:description, :content => simple_format(@userfile.description, :sanitize => true), :show_width => 2, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
       <%= text_area_tag "userfile[description]", @userfile.description, :rows => 10, :cols => 80 %>
     <% end %>
 
@@ -188,10 +188,17 @@
         (This file cannot be viewed as it is stored on Data Provider
         <%= link_to_data_provider_if_accessible(@userfile.data_provider) %>
         which is configured to <strong>not allow synchronization</strong> <em>at all</em>)
-		
-  	  <% elsif @sync_status == "Corrupted" %>
-  	
-		<span style="background-color: pink;">(The content of this file seems to be corrupted. This might be the result of a bad data transfer while it was being created or a filesystem failure. There isn't much you can do about this, although if the file was produced by a task, consider restarting the task's Post Processing stage.)</span>
+
+      <% elsif @sync_status == "Corrupted" %>
+
+        <span style="background-color: pink;">
+          (The content of this file seems to be corrupted.
+          This might be the result of a bad data transfer while
+          it was being created or a filesystem failure. There isn't
+          much you can do about this, although if the file was
+          produced by a task, consider restarting the task's
+          Post Processing stage.)
+        </span>
 
       <% elsif ! @userfile.data_provider.rr_allowed_syncing? %>
 
@@ -209,7 +216,7 @@
 
         (The contents of this file cannot be viewed: no viewer code available at this moment
         for files of type '<%= @userfile.pretty_type %>')
-	  
+
       <% else %>
 
         <% if ! @userfile.is_locally_synced? %>

--- a/BrainPortal/lib/exception_helpers.rb
+++ b/BrainPortal/lib/exception_helpers.rb
@@ -87,12 +87,12 @@ module ExceptionHelpers
       format.xml  { render :xml => {:error  => exception.message}, :status => 500 }
     end
   end
-  
+
   # Redirect to the index page if available and wasn't the source of
   # the exception, otherwise to welcome page.
   def default_redirect
     final_resting_place = start_page_params
-    if self.respond_to?(:index) && params[:action] != "index"
+    if self.respond_to?(:index) && params[:action].to_s != "index"
       { :action => :index }
     elsif final_resting_place.keys.all? { |k| params[k].to_s == final_resting_place[k].to_s }
       "/500.html" # in case there's an error in the welcome page itself


### PR DESCRIPTION
The dashboard is now available to all users. It is identical to the sysadmin's
except for the `System Info` panel on the extreme left, which is not shown.

The `Search for anything` feature is enabled for all users too.

Other small bug fixes or improvements:

Edit panels in userfile 'show' pages
In-memory password zapping (just in case, no garantee)
Tasks index robustness when tasks being deleted while rendering