### PR TITLE
Access profiles

### DIFF
--- a/BrainPortal/app/controllers/access_profiles_controller.rb
+++ b/BrainPortal/app/controllers/access_profiles_controller.rb
@@ -1,0 +1,147 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Simple controller for creating/editing access profiles, which are
+# an admin-only resource.
+class AccessProfilesController < ApplicationController
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_filter :login_required
+  before_filter :admin_role_required
+
+  def index #:nodoc:
+
+    @scope = scope_from_session('access_profiles')
+    scope_default_order(@scope, 'name')
+
+    @base_scope       = AccessProfile.where({})
+    @access_profiles  = @scope.apply(@base_scope)
+
+    respond_to do |format|
+      format.html # index.html.erb
+    end
+  end
+
+  def show #:nodoc:
+    @access_profile = AccessProfile.find(params[:id])
+
+    respond_to do |format|
+      format.html # show.html.erb
+    end
+  end
+
+  def new #:nodoc:
+    @access_profile = AccessProfile.new
+  end
+
+  def create #:nodoc:
+    @access_profile = AccessProfile.new(params[:access_profile])
+
+    respond_to do |format|
+      if @access_profile.save
+        flash[:notice] = 'AccessProfile was successfully created.'
+        format.html  { redirect_to :action => :index }
+      else
+        format.html  { render :action  => :new }
+      end
+    end
+  end
+
+  def update #:nodoc:
+    @access_profile = AccessProfile.find(params[:id])
+
+    # Remember 'before' state for the two main associations
+    old_group_ids = @access_profile.group_ids.sort
+    old_user_ids  = @access_profile.user_ids.sort
+
+    # The success variable will be false for errors on ordinary attributes;
+    # for the group_ids and user_ids list, these are always updated... :-(
+    success = @access_profile.update_attributes_with_logging(params[:access_profile], current_user)
+
+    # Adjust groups and users, and log differences
+    new_group_ids = @access_profile.group_ids.sort
+    new_user_ids  = @access_profile.user_ids.sort
+    @access_profile.addlog_object_list_updated("Projects", Group, old_group_ids, new_group_ids, current_user)
+    @access_profile.addlog_object_list_updated("Users",    User,  old_user_ids,  new_user_ids,  current_user, :login)
+
+    # Group list has changed? Apply to each affected user
+    if old_group_ids != new_group_ids
+      ap_removed_gids = old_group_ids - new_group_ids # what disappeared in the current AP
+      affected_users = User.where(:id => params[:affected_user_ids])
+      affected_users.each do |user|
+        # Find the union of all group_ids for all the APs the user is still associated with
+        add_gids    = user.access_profiles.inject([]) { |tot,ap| tot += ap.group_ids; tot }
+        remove_gids = ap_removed_gids - add_gids # must not remove gids that are also present in other APs
+
+        # Update the list of group for the user
+        orig_user_gids = user.group_ids
+        user.group_ids = user.group_ids - remove_gids + add_gids
+        user.addlog_object_list_updated("Updated Access Profile '#{@access_profile.name}', Projects",
+                                        Group, orig_user_gids, user.group_ids, current_user)
+      end
+    end
+
+    # New users added to the the AP? Adjust their groups
+    added_uids   = new_user_ids - old_user_ids
+    User.find(added_uids).each do |user|
+      orig_user_gids = user.group_ids
+      user.group_ids = orig_user_gids + @access_profile.group_ids
+      user.addlog_object_list_updated("Added Access Profile '#{@access_profile.name}', Projects",
+                                      Group, orig_user_gids, user.group_ids, current_user)
+    end
+
+    # Some users lost access to the the AP? Adjust their groups
+    removed_uids = old_user_ids - new_user_ids
+    User.find(removed_uids).each do |user|
+      # Find the union of all group_ids for all the APs the user is still associated with
+      ap_group_ids = user.access_profiles.inject([]) { |tot,ap| tot += ap.group_ids; tot }
+      # Find what group_ids are only in the current AP, and remove them
+      remove_gids = @access_profile.group_ids - ap_group_ids
+      orig_user_gids = user.group_ids
+      user.group_ids = orig_user_gids - remove_gids
+      user.addlog_object_list_updated("Removed Access Profile '#{@access_profile.name}', Projects",
+                                      Group, orig_user_gids, user.group_ids, current_user)
+    end
+
+    respond_to do |format|
+      if success
+        flash[:notice] = 'AccessProfile was successfully updated.'
+        format.html { redirect_to :action => "show" }
+        format.xml  { head :ok }
+      else
+        # @access_profile.reload
+        format.html { render :action => "show" }
+      end
+    end
+  end
+
+  def destroy #:nodoc:
+    @access_profile = AccessProfile.find(params[:id])
+    @access_profile.destroy
+
+    respond_to do |format|
+      format.html { redirect_to :action => :index, :status => 303 }
+    end
+  end
+
+end

--- a/BrainPortal/app/helpers/access_profiles_helper.rb
+++ b/BrainPortal/app/helpers/access_profiles_helper.rb
@@ -1,0 +1,37 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Helper methods for Access Profile views.
+module AccessProfilesHelper
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Generates a pretty colored label for an access profile
+  def access_profile_label(access_profile, options={})
+    color  = access_profile.color.presence || "white";
+    label  = "<span class=\"access_profile_label\" style=\"background: #{color}\">"
+    label += options[:with_link] ? link_to_access_profile_if_accessible(access_profile) : access_profile.name
+    label += "</span>"
+    label.html_safe
+  end
+
+end

--- a/BrainPortal/app/helpers/resource_link_helper.rb
+++ b/BrainPortal/app/helpers/resource_link_helper.rb
@@ -17,14 +17,14 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Helpers for resource links.
 module ResourceLinkHelper
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
-  
+
   # Creates a link to the show page of a +userfile+, as long
   # as the +cur_user+ has access to it. By default, +cur_user+ is
   # current_user.
@@ -136,7 +136,7 @@ module ResourceLinkHelper
   end
 
   # This method works like link_to_group_if_accessible() except that
-  # the link is created only if the group is a WorkGroup. 
+  # the link is created only if the group is a WorkGroup.
   # The first argument MUST be an actual group.
   # The link created will be to the edit page of the group.
   def link_to_group_if_editable(group, cur_user = current_user, options = {})
@@ -187,6 +187,27 @@ module ResourceLinkHelper
   # :path (the default is the show path).
   def link_to_task_if_accessible(task, cur_user = current_user, options = {})
     link_to_model_if_accessible(CbrainTask,task,:name,cur_user,options)
+  end
+
+  # Creates a link to the show page of an +access_profile+, as long
+  # as the +cur_user+ has access to it. By default, +cur_user+ is
+  # current_user.
+  #
+  # +access_profile+ can be provided as an ID too.
+  #
+  # If the ID is nil, then the string
+  #   "(None)"
+  # will be returned.
+  #
+  # If the ID is invalid, the string
+  #   "(Deleted/Non-existing)"
+  # will be returned.
+  #
+  # +options+ can contain a :name for
+  # the link (the default is the profile's name) and a
+  # :path (the default is the show path).
+  def link_to_access_profile_if_accessible(access_profile, cur_user = current_user, options = {})
+    link_to_model_if_accessible(AccessProfile,access_profile,:name,cur_user,options)
   end
 
   # Implements the link_to_{SOMETHING}_if_available() methods

--- a/BrainPortal/app/helpers/table_maker_helper.rb
+++ b/BrainPortal/app/helpers/table_maker_helper.rb
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 # Helpers for making tables
@@ -66,7 +66,7 @@ module TableMakerHelper
   #   :td_class    => class(es) for the HTML TD elements
   #   :tr_callback => a Proc which will receive |row| number,
   #                   and is expected to generate the full TR element
-  #   :tr_callback => a Proc which will receive |elem,row,col|
+  #   :td_callback => a Proc which will receive |elem,row,col|
   #                   and is expected to generate the full TD element
   #
   # For small arrays that don't need a full table generated,
@@ -122,12 +122,12 @@ module TableMakerHelper
       0.upto(cols-1) do |col|
 
         idx = options[:fill_by_columns] ? row+col*rows : col+row*cols
-   
+
         if col == 0
           result += "  " + tr_callback.call(row) + "\n"
         end
 
-        if idx < array.size 
+        if idx < array.size
           elem = array[idx]
           formatted_elem = block_given? ? capture { h(yield(elem,row,col)) } : h(elem)
           result += "    " + td_callback.call(formatted_elem,row,col) + "\n"
@@ -139,13 +139,13 @@ module TableMakerHelper
             result  += "<td #{spanatt}=\"#{num_cells - array.size}\"></td>".html_safe
           end
         end
-        
+
         if col + 1 == cols
           result += "  </tr>\n"
         end
       end
     end
-    
+
     result += "</table>\n"
 
     result.html_safe

--- a/BrainPortal/app/models/access_profile.rb
+++ b/BrainPortal/app/models/access_profile.rb
@@ -1,0 +1,40 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Model representing access profiles, a sort of
+# record where pre-defined profiles for users are created
+# by the admin. Later on, access restrictions will be
+# recorded here too.
+class AccessProfile < ActiveRecord::Base
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  validates_presence_of   :name
+  validates_uniqueness_of :name
+
+  has_and_belongs_to_many :groups
+  has_and_belongs_to_many :users
+
+  attr_accessible         :name, :color, :description, :group_ids, :user_ids
+
+end
+

--- a/BrainPortal/app/models/access_profile.rb
+++ b/BrainPortal/app/models/access_profile.rb
@@ -22,8 +22,16 @@
 
 # Model representing access profiles, a sort of
 # record where pre-defined profiles for users are created
-# by the admin. Later on, access restrictions will be
-# recorded here too.
+# by the admin.
+#
+# For the moment the model only contains:
+#
+# A list of group_ids (a profile can have many of these)
+# A list of user_ids  (a profile is 'applied' to these users)
+#
+# Later on, access restrictions will be
+# recorded here too. For instance, restrictions and
+# limits of launching tasks, number of files, etc etc.
 class AccessProfile < ActiveRecord::Base
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:

--- a/BrainPortal/app/models/group.rb
+++ b/BrainPortal/app/models/group.rb
@@ -51,6 +51,7 @@ class Group < ActiveRecord::Base
 
   has_many                :tools
   has_and_belongs_to_many :users
+  has_and_belongs_to_many :access_profiles
   has_many                :userfiles
   has_many                :data_providers
   has_many                :remote_resources

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -374,6 +374,61 @@ class User < ActiveRecord::Base
     true
   end
 
+
+
+  ##############################################
+  # Access Profiles Adjustments
+  ##############################################
+
+  # Returns the list of group IDs
+  # from all the AccessProfiles associated with
+  # the current user.
+  def union_group_ids_from_access_profiles
+    aps = self.access_profiles
+    aps.inject([]) do |group_ids,ap|
+      group_ids += ap.group_ids  # union of all
+      group_ids
+    end
+  end
+
+  # Scans the list of AccessProfiles associated
+  # with the current user, and makes sure the user
+  # is a member of all the groups in all these profiles.
+  # If a list of +remove_group_ids+ is supplied,
+  # the user will be removed from these groups as
+  # long as they are not also in any of the AccessProfiles.
+  #
+  #
+  # Ex: given two access profiles with these (overlapping) group IDs:
+  #
+  #   ap1.group_ids = [ 11, 12, 13, 99,            ]
+  #   ap2.group_ids = [             99, 21, 22, 23 ]
+  #
+  # then assigning these two AccessProfiles and invoking the method:
+  #
+  #   user.access_profile_ids = [ ap1.id, ap2.id ]
+  #   user.apply_access_profiles()
+  #
+  # will result in the user being added to all 7 groups, exactly as
+  # if an assignement was performed like this:
+  #
+  #   user.group_ids += [ 11, 12, 13, 99, 21, 22, 23 ]
+  #
+  # To handle the case of AccessProfiles having LOST some group_ids,
+  # we can supply a list of removed group_ids in +remove_group_ids+ :
+  #
+  #   ap1.group_ids = [ 12, 13 ]  # we removed 11 and 99
+  #   user.apply_access_profiles( [ 11, 99 ] )
+  #
+  # will result in the user's list of groups to lose group 11 but NOT
+  # group 99, because it's present in ap2.
+  def apply_access_profiles(remove_group_ids: [])
+    gids = union_group_ids_from_access_profiles
+    self.group_ids = self.group_ids - remove_group_ids + gids # - and + are NOT COMMUTATIVE!
+  end
+
+
+
   protected
 
   # "before save" callback; whenever the record is saved, if the 'password'

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -94,6 +94,7 @@ class User < ActiveRecord::Base
   has_many                :remote_resources,  :dependent => :restrict
   has_many                :cbrain_tasks,      :dependent => :restrict
 
+  has_and_belongs_to_many :access_profiles
   has_and_belongs_to_many :groups
   belongs_to              :site
 

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -1,0 +1,68 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<div class="menu_bar">
+  <%= link_to 'Create Access Profile', new_access_profile_path, :class => "button menu_button" %>
+  <%= overlay_ajax_link "Help", "/doc/access_profiles/access_profiles.html", :class  => "button" %>
+</div>
+
+<%=
+  render(:partial => 'shared/active_filters', :locals  => {
+    :scope => @scope,
+    :model => AccessProfile
+  })
+%>
+
+<div class="centered">(<%= pluralize @access_profiles.count, "access profile" %>)</div>
+
+<%=
+  dynamic_scoped_table(@access_profiles,
+    :id    => 'access_profiles_table',
+    :class => [ :resource_list ],
+    :scope => @scope
+  ) do |t|
+%>
+  <%
+    t.column("Name", :name,
+      :sortable => true,
+    ) { |s| access_profile_label(s, :with_link => true) }
+
+    t.column("Color", :color,
+      :sortable => true,
+    ) { |s| s.color.presence || "white" }
+
+
+    t.column("Description", :description,
+      :sortable => true,
+    ) { |s| overlay_description(s.description) }
+
+    t.column("Projects", :projects) do |s|
+      s.groups.map(&:name).sort.join(", ").presence || "(none)"
+    end
+
+    t.column("Users", :users) do |s|
+      s.users.map(&:login).sort.join(", ").presence || "(none)"
+    end
+  %>
+<% end %>

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -51,11 +51,11 @@
     ) { |s| overlay_description(s.description) }
 
     t.column("Projects", :projects) do |s|
-      s.groups.map(&:name).sort.join(", ").presence || "(none)"
+      (s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(none)"
     end
 
     t.column("Users", :users) do |s|
-      s.users.map(&:login).sort.join(", ").presence || "(none)"
+      (s.users.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence) || "(None)"
     end
   %>
 <% end %>

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -51,7 +51,7 @@
     ) { |s| overlay_description(s.description) }
 
     t.column("Projects", :projects) do |s|
-      (s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(none)"
+      (s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(None)"
     end
 
     t.column("Users", :users) do |s|

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -27,13 +27,6 @@
   <%= overlay_ajax_link "Help", "/doc/access_profiles/access_profiles.html", :class  => "button" %>
 </div>
 
-<%=
-  render(:partial => 'shared/active_filters', :locals  => {
-    :scope => @scope,
-    :model => AccessProfile
-  })
-%>
-
 <div class="centered">(<%= pluralize @access_profiles.count, "access profile" %>)</div>
 
 <%=

--- a/BrainPortal/app/views/access_profiles/index.html.erb
+++ b/BrainPortal/app/views/access_profiles/index.html.erb
@@ -1,0 +1,30 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Access Profiles' %>
+
+<div id="access_profile_table" class="index_block">
+  <%= render :partial => 'access_profiles_table' %>
+</div>
+

--- a/BrainPortal/app/views/access_profiles/index.js.erb
+++ b/BrainPortal/app/views/access_profiles/index.js.erb
@@ -1,0 +1,27 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<%= render :partial  => "shared/flash_update" %>
+jQuery("#acces_profile_table").html(<%= html_for_js(render(:partial => 'acces_profiles_table')) %>).trigger("new_content")
+

--- a/BrainPortal/app/views/access_profiles/new.html.erb
+++ b/BrainPortal/app/views/access_profiles/new.html.erb
@@ -52,6 +52,8 @@
 
   </div>
 
+  <div class="box_spacer"></div>
+
   <div class="generalbox">
     <h5>Project Membership</h5>
     <%= render :partial => 'shared/group_tables', :locals => { :model => @access_profile } %>

--- a/BrainPortal/app/views/access_profiles/new.html.erb
+++ b/BrainPortal/app/views/access_profiles/new.html.erb
@@ -1,0 +1,64 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Add New Access Profile' %>
+
+<h2>Add New Access Profile</h2>
+
+<%= error_messages_for(@access_profile) %>
+
+<%= form_for @access_profile, :url => { :action => "create" }, :datatype => "script" do |f| -%>
+
+  <div class="generalbox">
+
+    <%= f.label :name %><br>
+    <%= f.text_field :name %>
+    <p>
+
+    <%= f.label :color %><br>
+    <%= f.text_field :color %><br>
+    <span class="field_explanation">Use a CSS-compliant <strong>pale</strong> color:<br>
+    e.g. <em>#ff0</em> or <em>yellow</em> etc.</span>
+    <p>
+
+    <span title="Brief description of the profile.">
+      <%= f.label :description, "Description" %><br/>
+      <%= f.text_area :description, :rows => 6, :cols => 60 %><br/>
+      <span class="field_explanation">These are your private notes about this profile.</span>
+    </span>
+
+  </div>
+
+  <div class="generalbox">
+    <h5>Project Membership</h5>
+    <%= render :partial => 'shared/group_tables', :locals => { :model => @access_profile } %>
+  </div>
+
+  <div class="display_row centered">
+    <p>
+    <%= f.submit "Create" %>
+  </div>
+
+<% end %>
+

--- a/BrainPortal/app/views/access_profiles/new.html.erb
+++ b/BrainPortal/app/views/access_profiles/new.html.erb
@@ -24,6 +24,8 @@
 
 <% title 'Add New Access Profile' %>
 
+<%= overlay_ajax_link "Help", "/doc/access_profiles/access_profiles.html", :class  => "button" %>
+
 <h2>Add New Access Profile</h2>
 
 <%= error_messages_for(@access_profile) %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -1,0 +1,117 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title "Access Profile" %>
+
+<div class="menu_bar">
+  <%= overlay_ajax_link "Help", "/doc/access_profiles/access_profile_info.html", :class  => "button" %>
+  <%= link_to 'Delete', access_profile_path(@access_profile),  {
+        :confirm => "Are you sure you want to delete '#{@access_profile.name}' ?",
+        :method  => :delete,
+        :class => "button"
+        }
+  %>
+</div>
+
+<br>
+
+<%= error_messages_for @acces_profile, :header_message => "Access profile could not be updated." %>
+
+<div class="display_inline_block" style="min-width: 50%">
+
+  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user)) do |t| %>
+
+    <% t.edit_cell(:name, :content => access_profile_label(@access_profile)) do %>
+      <%= text_field_tag "access_profile[name]", @access_profile.name %>
+    <% end %>
+
+    <% t.edit_cell(:color) do %>
+      <%= text_field_tag "access_profile[color]", @access_profile.color %><br>
+      <span class="field_explanation">Use a CSS-compliant <strong>pale</strong> color:<br>
+      e.g. <em>#ff0</em> or <em>yellow</em> etc.</span>
+    <% end %>
+
+    <% t.edit_cell(:description, :content => overlay_description(@access_profile.description), :show_width => 2 ) do %>
+      <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
+      <span class="field_explanation">These are your private notes about this profile.</span>
+    <% end %>
+
+  <% end %>
+
+  <% myusers = @access_profile.users.all %>
+
+  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
+    <% group_names = @access_profile.groups.raw_first_column(:name).sort.join(", ").presence || "(None)" %>
+    <% t.edit_cell(:group_ids, :show_width => 2, :no_header => "Projects", :content => group_names) do %>
+
+      <%= render :partial => 'shared/group_tables', :locals => { :model => @access_profile } %>
+
+      <% if myusers.present? %>
+        <p>
+        <hr>
+        <p>
+          When adding or removing projects, apply the change to the users:
+          <%= select_all_checkbox "all_affected_users", :id => "togall", :checked => "1" %>
+          <%= render :partial => 'shared/users_checkbox_table',
+                     :locals => {
+                                :users         => myusers,
+                                :checked       => myusers,
+                                :variable_name => "affected_user_ids[]",
+                                :html_class    => "all_affected_users",
+                              }
+          %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
+    <% user_names = myusers.map(&:login).sort.join(", ").presence || "(None)" %>
+    <% t.edit_cell(:user_ids, :show_width => 2, :no_header => "Users", :content => user_names) do %>
+
+      Normal Users<br>
+      <%= render :partial => 'shared/users_checkbox_table',
+                 :locals => {
+                              :users         => User.where(:account_locked => false).order(:login).all,
+                              :checked       => myusers,
+                              :variable_name => "access_profile[user_ids][]",
+                            }
+      %>
+
+      <br>
+      Locked Users<br>
+      <%= render :partial => 'shared/users_checkbox_table',
+                 :locals => {
+                              :users         => User.where(:account_locked => true).order(:login).all,
+                              :checked       => myusers,
+                              :variable_name => "access_profile[user_ids][]",
+                            }
+      %>
+
+    <% end %>
+  <% end %>
+
+  <P>
+  <%= render :partial => "layouts/log_report", :locals  => { :log  => @access_profile.getlog, :title => 'Access Profile Log' } %>
+
+</div>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -62,7 +62,7 @@
   <% myusers = @access_profile.users.all %>
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
-    <% group_names = (@access_profile.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(none)" %>
+    <% group_names = (@access_profile.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(None)" %>
     <% t.edit_cell(:group_ids, :show_width => 2, :no_header => "Projects", :content => group_names) do %>
 
       <%= render :partial => 'shared/group_tables', :locals => { :model => @access_profile } %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -25,13 +25,13 @@
 <% title "Access Profile" %>
 
 <div class="menu_bar">
-  <%= overlay_ajax_link "Help", "/doc/access_profiles/access_profile_info.html", :class  => "button" %>
   <%= link_to 'Delete', access_profile_path(@access_profile),  {
         :confirm => "Are you sure you want to delete '#{@access_profile.name}' ?",
         :method  => :delete,
         :class => "button"
         }
   %>
+  <%= overlay_ajax_link "Help", "/doc/access_profiles/access_profiles.html", :class  => "button" %>
 </div>
 
 <br>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -62,7 +62,7 @@
   <% myusers = @access_profile.users.all %>
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
-    <% group_names = @access_profile.groups.raw_first_column(:name).sort.join(", ").presence || "(None)" %>
+    <% group_names = (@access_profile.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(none)" %>
     <% t.edit_cell(:group_ids, :show_width => 2, :no_header => "Projects", :content => group_names) do %>
 
       <%= render :partial => 'shared/group_tables', :locals => { :model => @access_profile } %>
@@ -86,7 +86,7 @@
   <% end %>
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
-    <% user_names = myusers.map(&:login).sort.join(", ").presence || "(None)" %>
+    <% user_names = (myusers.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence) || "(None)" %>
     <% t.edit_cell(:user_ids, :show_width => 2, :no_header => "Users", :content => user_names) do %>
 
       Normal Users<br>

--- a/BrainPortal/app/views/groups/_new.html.erb
+++ b/BrainPortal/app/views/groups/_new.html.erb
@@ -40,7 +40,7 @@
       <% if current_user.has_role?(:admin_user) %>
         <p>
           <%= f.label :site_id, "Site:" %>
-		  <%= site_select "group[site_id]",{}, :prompt => "(Select a site)" %>
+          <%= site_select "group[site_id]",{}, :prompt => "(Select a site)" %>
         </p>
         <p>
         Make this a system group invisible to normal users:

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -91,6 +91,17 @@
 
   <% end %>
 
+  <% # Access Profile List %>
+  <% if current_user.has_role?(:admin_user) && @group.access_profiles.count > 0 %>
+    <%= show_table(@group, :header => 'Access profiles') do |t| %>
+      <% t.cell("Access Profiles", :no_header => true) do %>
+        <%= array_to_table(@group.access_profiles.order(:name).all, :table_class => "simple", :cols => 4) do |access_profile| %>
+          <%= access_profile_label(access_profile, :with_link => true) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
   <%
     group_members  = @group.users
     open_invites   = Invitation.where(sender_id: current_user.id, group_id: @group.id, active: true)

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -55,7 +55,7 @@
     <% t.cell("Creator") { @group.creator.try(:login)} %>
 
     <% t.edit_cell(:site_id, :content => link_to_site_if_accessible(@group.site), :disabled => !current_user.has_role?(:admin_user)) do %>
-	  <%= site_select "group[site_id]", @group.site_id, :prompt => "(Select a site)" %>
+      <%= site_select "group[site_id]", @group.site_id, :prompt => "(Select a site)" %>
     <% end %>
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
@@ -101,8 +101,8 @@
     <% default_text = array_to_table(group_members.sort{ |a,b| a.login.casecmp(b.login)}, :table_class => 'simple bordered float_left', :cols => 20, :min_data => 20, :fill_by_columns => true ) { |u,r,c| link_to_user_with_tooltip(u) } %>
 
     <% t.edit_cell(:user_id, :show_width => 2,
-                             :header  => 'Members',
-                             :content => default_text) do %>
+                             :no_header  => 'Members',
+                             :content    => default_text) do %>
       <% if current_user.has_role? :normal_user %>
         <% group_members.each do |u| %>
           <%= link_to_user_with_tooltip u %><%= link_to(": Remove", group_path(@group, "group[user_ids]" => (@group.user_ids - [u.id]), update_users: true ), :method => :put, :class => "action_link") unless u == current_user %>
@@ -119,8 +119,8 @@
       <% default_text = array_to_table(open_invites.map(&:user).sort{ |a,b| a.login.casecmp(b.login)}, :table_class => 'simple bordered float_left', :cols => 20, :min_data => 20, :fill_by_columns => true ) { |u,r,c| u.login } %>
 
       <% t.edit_cell(:invites, :show_width => 2,
-                               :header  => 'Pending Invitations',
-                               :content => default_text) do %>
+                               :header     => 'Pending Invitations',
+                               :content    => default_text) do %>
         <% open_invites.each do |i| %>
           <%= link_to_user_with_tooltip i.user %>: <%= link_to("Cancel", invitation_path(i), :method => :delete, :class => "action_link") %>
           <br>

--- a/BrainPortal/app/views/layouts/_section_menu.html.erb
+++ b/BrainPortal/app/views/layouts/_section_menu.html.erb
@@ -81,6 +81,9 @@
            </li>
          <% end %>
          <% if current_user.has_role?(:admin_user) %>
+           <li <%= set_selected(params[:controller], :access_profiles) %>>
+             <%= link_to 'Profiles', access_profiles_path %>
+           </li>
            <li <%= set_selected(params[:controller], :sites) %>>
              <%= link_to 'Sites', sites_path %>
            </li>

--- a/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
+++ b/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
@@ -1,0 +1,57 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<%
+   # This partial renders a table of users logins with checkboxes
+   # Partial locals:
+   #
+   #   users         => [ user, user, ... ]
+   #   checked       => [ user, user, ... ]
+   #   variable_name => "somemodel[group_ids][]"  # for instance; must end with '[]'
+   #   boxids        => "some_dom_id"             # will be appened with _{id}
+   #   html_class    => "someclass"               # for checkboxes
+   checked    ||= []
+   boxids     ||= "id_#{rand(1000000)}"
+   html_class ||= ""
+ %>
+
+<%
+  # Convenience helper to render a single checkbox and a user name
+  user_check_box = lambda do |user|
+    check_box_tag( variable_name,                                # html var name
+                   user.id.to_s,                                 # value
+                   checked.include?(user),                       # checked or not
+                   :id => "#{boxids}_#{user.id}",                # unique DOM id
+                   :class => html_class,
+                 ).html_safe +
+    (" <label for=\"#{boxids}_#{user.id}\">" + h(user.login) + "</label>").html_safe
+  end
+%>
+
+<%= hidden_field_tag variable_name, [], :id => "#{boxids}_unchecked" %>
+
+<%= array_to_table(users, :cols => 4, :td_class => 'left_align no_wrap') do |user,r,c| %>
+  <%= user_check_box.(user) %>
+<% end %>
+

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -188,10 +188,15 @@
         (This file cannot be viewed as it is stored on Data Provider
         <%= link_to_data_provider_if_accessible(@userfile.data_provider) %>
         which is configured to <strong>not allow synchronization</strong> <em>at all</em>)
-		
-  	  <% elsif @sync_status == "Corrupted" %>
-  	
-		<span style="background-color: pink;">(The content of this file seems to be corrupted. This might be the result of a bad data transfer while it was being created or a filesystem failure. There isn't much you can do about this, although if the file was produced by a task, consider restarting the task's Post Processing stage.)</span>
+
+      <% elsif @sync_status == "Corrupted" %>
+
+        <span style="background-color: pink;">
+          (The content of this file seems to be corrupted. This might be the result
+          of a bad data transfer while it was being created or a filesystem failure.
+          There isn't much you can do about this, although if the file was produced
+          by a task, consider restarting the task's Post Processing stage.)
+        </span>
 
       <% elsif ! @userfile.data_provider.rr_allowed_syncing? %>
 
@@ -209,7 +214,7 @@
 
         (The contents of this file cannot be viewed: no viewer code available at this moment
         for files of type '<%= @userfile.pretty_type %>')
-	  
+
       <% else %>
 
         <% if ! @userfile.is_locally_synced? %>

--- a/BrainPortal/app/views/users/new.html.erb
+++ b/BrainPortal/app/views/users/new.html.erb
@@ -35,35 +35,32 @@
     <h5>Basic Information</h5>
 
     <p><%= f.label :full_name, "Full Name" %><br/>
-    <%= f.text_field :full_name %></p>
+    <%= f.text_field :full_name %>
 
     <p><%= f.label :login, "Login" %><br/>
     <%= f.text_field :login %><br>
-    <div class="field_explanation">For <strong>Tom Jones</strong>, use <strong>tjones</strong>, not 'tom' or 'jones'.</div>
-    </p>
+    <span class="field_explanation">For <strong>Tom Jones</strong>, use <strong>tjones</strong>, not 'tom' or 'jones'.</span>
 
     <p><%= f.label :email, "Email" %><br/>
-    <%= f.text_field :email %></p>
+    <%= f.text_field :email %>
 
     <p>
       <%= f.label :city, "City" %><br/>
       <%= f.text_field :city %>
-    </p>
 
     <p>
       <%= f.label :country, "Country" %><br/>
       <%= f.text_field :country %>
-    </p>
 
     <p><%= f.label :time_zone, "Time Zone" %><br/>
     <%= f.time_zone_select :time_zone,
         ActiveSupport::TimeZone.all.select { |t| t.name =~ /canada/i },
         { :default => ActiveSupport::TimeZone['Eastern Time (US & Canada)'],
           :include_blank => true }
-    %></p>
+    %>
 
     <p><%= f.label :type, "Type" %><br/>
-    <%= f.select :type, roles_for_user(current_user) %> </p>
+    <%= f.select :type, roles_for_user(current_user) %>
 
     <% if current_user.has_role? :admin_user %>
       <p><%= f.label :site_id, "Site" %><br/>
@@ -71,10 +68,10 @@
     <% end %>
 
     <p><%= f.label :password, "Password" %><br/>
-    <%= f.password_field :password %></p>
+    <%= f.password_field :password %>
 
     <p><%= f.label :password_confirmation, "Confirm Password" %><br/>
-    <%= f.password_field :password_confirmation %></p>
+    <%= f.password_field :password_confirmation %>
 
     <p><label for="no_password_reset_needed">No need to reset initial password:</label>
     <%= check_box_tag :no_password_reset_needed, "1", params[:no_password_reset_needed] == "1" %>
@@ -88,7 +85,18 @@
     <%= render :partial => 'shared/group_tables', :locals => {:model => @user} %>
   </div>
 
-  <p><%= submit_tag 'Create User' %></p>
+  <div class="box_spacer"></div>
+
+  <div class="generalbox">
+    <h5>Access Profiles</h5>
+    <% AccessProfile.order(:name).all.each do |access_profile| %>
+      <%= check_box_tag "access_profiles[]", access_profile.id, false, :id => "ap_#{access_profile.id}" %>
+      <label for="<%= "ap_#{access_profile.id}" %>"><%= access_profile_label(access_profile) %></label>
+      <p>
+    <% end %>
+  </div>
+
+  <p><%= submit_tag 'Create User' %>
 
 <% end %>
 

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -56,7 +56,7 @@
 
     <%
       t.edit_cell(:site_id, :content => link_to_site_if_accessible(@user.site), :disabled => !current_user.has_role?(:admin_user)) do
-		  site_select "user[site_id]", @user.site_id, :prompt => "(Select a site)"
+        site_select("user[site_id]", @user.site_id, :prompt => "(Select a site)")
       end
     %>
 
@@ -115,13 +115,15 @@
     <% end %>
 
   <% end %>
-  <% unless @user.signed_license_agreements.empty? %>
+
+  <% if @user.signed_license_agreements.present? %>
     <%= show_table(@user, :header => "License Agreements", :width => 3) do |t| %>
       <% @user.signed_license_agreements.each  do |la| %>
         <% t.cell("", :no_header => true) { link_to la, "/show_license/#{la}" } %>
       <% end  %>
     <% end %>
   <% end %>
+
   <%= show_table(@user, :header => 'Resources') do |t| %>
 
     <% t.cell("Files") do
@@ -151,6 +153,18 @@
 
   <% end %>
 
+  <% # Access Profile List %>
+  <% if current_user.has_role?(:admin_user) && @user.access_profiles.count > 0 %>
+    <%= show_table(@user, :header => 'Access profiles') do |t| %>
+      <% t.cell("Access Profiles", :no_header => true) do %>
+        <%= array_to_table(@user.access_profiles.order(:name).all, :table_class => "simple", :cols => 4) do |access_profile| %>
+          <%= access_profile_label(access_profile, :with_link => true) %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% # Admin users have access to ALL groups, so no need to show them all here %>
   <% unless @user.has_role? :admin_user %>
 
     <div>

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -42,10 +42,10 @@ CbrainRailsPortal::Application.routes.draw do
   resources :custom_filters
   resources :tool_configs
   resources :tags
-
-  # Standard CRUD resources, with extra methods
-
+  resources :access_profiles
   resources :feedbacks
+
+  # Standard CRUD resources, with extra actions
 
   resources :messages do
     collection do

--- a/BrainPortal/db/migrate/20160522180234_add_access_profiles.rb
+++ b/BrainPortal/db/migrate/20160522180234_add_access_profiles.rb
@@ -1,0 +1,54 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Add a new model, AccessProfile, where we can
+# store 'profiles' for new users. For the moments,
+# profiles are just a bunch of groups.
+#
+# Preliminary, will expand later with quotas
+# and maybe new types of access restrictions.
+class AddAccessProfiles < ActiveRecord::Migration #:nodoc:
+  def up
+    create_table :access_profiles do |t|
+      t.string :name,        :null => false
+      t.string :description
+      t.string :color
+
+      t.timestamps
+    end
+
+    create_table :access_profiles_groups, :id => false do |t|
+      t.integer :access_profile_id
+      t.integer :group_id
+    end
+    create_table :access_profiles_users, :id => false do |t|
+      t.integer :access_profile_id
+      t.integer :user_id
+    end
+  end
+
+  def self.down
+    drop_table :access_profiles
+    drop_table :access_profiles_groups
+    drop_table :access_profiles_users
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,25 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160218173528) do
+ActiveRecord::Schema.define(:version => 20160522180234) do
+
+  create_table "access_profiles", :force => true do |t|
+    t.string   "name",        :null => false
+    t.string   "description"
+    t.string   "color"
+    t.datetime "created_at",  :null => false
+    t.datetime "updated_at",  :null => false
+  end
+
+  create_table "access_profiles_groups", :id => false, :force => true do |t|
+    t.integer "access_profile_id"
+    t.integer "group_id"
+  end
+
+  create_table "access_profiles_users", :id => false, :force => true do |t|
+    t.integer "access_profile_id"
+    t.integer "user_id"
+  end
 
   create_table "active_record_logs", :force => true do |t|
     t.integer  "ar_id"

--- a/BrainPortal/lib/act_rec_log.rb
+++ b/BrainPortal/lib/act_rec_log.rb
@@ -392,7 +392,7 @@ module ActRecLog
   # he changes in the lists. +message+ should be a description of the
   # meaning of these lists. Example:
   #
-  #   mysite.addlog_object_list_updated("Managers", User, :login, [1,2,3], [2,3,4,5], adminuser)
+  #   mysite.addlog_object_list_updated("Managers", User, [1,2,3], [2,3,4,5], adminuser, :login)
   #
   # will add a log entry like this
   #

--- a/BrainPortal/lib/scir_lsf.rb
+++ b/BrainPortal/lib/scir_lsf.rb
@@ -28,7 +28,7 @@ class ScirLsf < Scir
 
   class Session < Scir::Session #:nodoc:
 
-    def update_job_info_cache #:nodoc:      
+    def update_job_info_cache #:nodoc:
       # on the implementation of bstat.  This method is supposed to
       # list all the statuses of the running tasks, and to keep it in
       # the @job_info_cache array.
@@ -40,14 +40,14 @@ class ScirLsf < Scir
         bjob_stat = line.gsub(/\s+/m, ' ').strip.split(" ")
         jid = bjob_stat[0]
         stat = bjob_stat[2]
-        stat = statestring_to_stateconst(stat)	
+        stat = statestring_to_stateconst(stat)
         @job_info_cache[jid] = { :drmaa_state => stat } unless stat == Scir::STATE_DONE #Do not add tasks to job_info_cache if they are done so CBRAIN moves them to post-processing
       end
       true
 
     end
 
-    def statestring_to_stateconst(state) #:nodoc:      
+    def statestring_to_stateconst(state) #:nodoc:
       # CBRAIN statuses to status strings parsed from the output of
       # bstat -f in method update_job_info_cache
       return Scir::STATE_RUNNING        if state.match(/RUN/i)
@@ -119,14 +119,14 @@ class ScirLsf < Scir
 
       File.chmod(0755, script)
 
-      command  = "bsub "      
+      command  = "bsub "
       command += "-J #{shell_escape(self.name)} "   if self.name
       command += "-cwd #{shell_escape(self.wd)} "     if self.wd
       command += "-o #{shell_escape(stdout)} " if stdout
-      command += "-e #{shell_escape(stderr)} " if stderr 
+      command += "-e #{shell_escape(stderr)} " if stderr
       command += "-q #{shell_escape(self.queue)} "  unless self.queue.blank?
       command += "#{Scir.cbrain_config[:extra_qsub_args]} " unless Scir.cbrain_config[:extra_qsub_args].blank?
-      command += "#{self.tc_extra_qsub_args} "              unless self.tc_extra_qsub_args.blank?      
+      command += "#{self.tc_extra_qsub_args} "              unless self.tc_extra_qsub_args.blank?
       command += "#{shell_escape(script)}"
       command += " 2>&1"
 

--- a/BrainPortal/public/doc/access_profiles/access_profiles.html
+++ b/BrainPortal/public/doc/access_profiles/access_profiles.html
@@ -1,0 +1,58 @@
+
+<!--
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-->
+
+<h1>Introduction To Access Profiles</h1>
+
+Access Profiles are way to simplify user access management to sets of projects.
+<p>
+An Access Profile is basically a set of arbitrary projects. When users are created<br>
+or modified, they can be assigned to one (or several) Access Profiles, and thus<br>
+they become a member of all their projects immediately.
+<p>
+Access Profiles and all their properties are never visible to normal users.
+
+<h2>Creating an Access Profile</h2>
+
+When creating a new Access Profile, the admin can set a color to help<br>
+differentiate it from other Access Profiles. Projects can also immediately<br>
+be assigned to it.
+
+<h2>Deleting an Access Profile</h2>
+Removing an Access Profile from a user will remove all the projects at once<br>
+(except those that may be part of other Access Profiles).
+
+<h2>Adjusting an Access Profile: adjusting the projects</h2>
+Adjusting the set of project in an Access Profile will (by default) immediately<br>
+affect all users associated with that Access Profile; however the<br>
+admin can select which users will be affected by the change using the checkboxes<br>
+at the bottom of the project list.
+
+<h2>Adjusting an Access Profile: adjusting the users</h2>
+Adjusting the list of users associated with an Access Profile will affect<br>
+all those users: they will either become members of all the projects in<br>
+the profile (if the user is added) or might lose access to the project<br>
+(if removed, and the project is in no other access profile that the<br>
+user has access to).
+<p>
+

--- a/BrainPortal/public/doc/access_profiles/access_profiles.html
+++ b/BrainPortal/public/doc/access_profiles/access_profiles.html
@@ -24,35 +24,83 @@
 
 <h1>Introduction To Access Profiles</h1>
 
-Access Profiles are way to simplify user access management to sets of projects.
-<p>
-An Access Profile is basically a set of arbitrary projects. When users are created<br>
-or modified, they can be assigned to one (or several) Access Profiles, and thus<br>
-they become a member of all their projects immediately.
-<p>
-Access Profiles and all their properties are never visible to normal users.
+<p class="medium_paragraphs">
 
-<h2>Creating an Access Profile</h2>
+Access profiles are way to simplify how users are assigned to projects.
 
-When creating a new Access Profile, the admin can set a color to help<br>
-differentiate it from other Access Profiles. Projects can also immediately<br>
+<p class="medium_paragraphs">
+
+An access profile is basically a set of arbitrary projects. When a user is created
+or modified, it can be assigned to one (or several) access profiles, and thus
+it becomes a member of all the projects in these access profiles.
+
+<p class="medium_paragraphs">
+
+For the sake of clarity, let's use three terms to link the three concepts
+of <em>users</em>, <em>projects</em> and <em>access profiles</em>.
+
+<ul>
+  <li><em>Users</em> are <strong>members</strong> of <em>projects</em></li>
+  <li><em>Projects</em> are <strong>assigned</strong> to <em>access profiles</em></li>
+  <li><em>Users</em> are <strong>linked</strong> to <em>access profiles</em></li>
+</ul>
+
+<p class="medium_paragraphs">
+
+It is possible for a project to be assigned to several access profiles,
+and for a user to be linked to these profiles with the redundant project.
+In that case, the user stays a member of the project as long as that project
+is assigned to at least one of these profiles. In other words, the set
+of projects that the user is a member of is the <strong>union</strong>
+of all the projects of all his linked access profiles.
+
+<p class="medium_paragraphs">
+
+Access profiles and all their properties are never visible to normal users.
+As far as they are concerned, they are members of projects, and that is all.
+
+<h4>Creating an Access Profile</h4>
+
+<p class="medium_paragraphs">
+
+When creating a new access profile, the admin can set a color to help
+differentiate it from other access profiles. Projects can also immediately
 be assigned to it.
 
-<h2>Deleting an Access Profile</h2>
-Removing an Access Profile from a user will remove all the projects at once<br>
-(except those that may be part of other Access Profiles).
+<h4>Deleting an Access Profile</h4>
 
-<h2>Adjusting an Access Profile: adjusting the projects</h2>
-Adjusting the set of project in an Access Profile will (by default) immediately<br>
-affect all users associated with that Access Profile; however the<br>
-admin can select which users will be affected by the change using the checkboxes<br>
-at the bottom of the project list.
+<p class="medium_paragraphs">
 
-<h2>Adjusting an Access Profile: adjusting the users</h2>
-Adjusting the list of users associated with an Access Profile will affect<br>
-all those users: they will either become members of all the projects in<br>
-the profile (if the user is added) or might lose access to the project<br>
-(if removed, and the project is in no other access profile that the<br>
-user has access to).
-<p>
+Removing an access profile will not delete the projects assigned to it.
+However, all users who were linked to the profile will no longer
+be members of the projects assigned to that profile
+(except those projects that may be assigned to other access profiles).
+
+<h4>Adjusting an Access Profile: adjusting the projects</h4>
+
+<p class="medium_paragraphs">
+
+Adjusting the set of project assigned to an access profile will (by default) immediately
+affect all users linked to that access profile. If new projects are
+assigned to the profiles, the users will become members of them. If projects
+are de-assigned to the profile, the users MAY lose membership of them.
+
+<p class="medium_paragraphs">
+
+When using the form, the admin can select which users will be affected by
+the changes using the checkboxes at the bottom of the project list. If
+a checkbox is not checked for a user, that user's project memberships
+will not be changed at all no matter what modifications are made
+to the access profile.
+
+<h4>Adjusting an Access Profile: adjusting the users</h4>
+
+<p class="medium_paragraphs">
+
+Adjusting the list of users linked to an access profile will affect
+all those users: they will either become members of all the projects in
+the profile (if the user is added) or might lose access to all these
+projects.
+
+<p class="medium_paragraphs">
 

--- a/BrainPortal/public/stylesheets/cbrain.css
+++ b/BrainPortal/public/stylesheets/cbrain.css
@@ -2087,6 +2087,7 @@ img {
   box-shadow: 0px 0px 4px black inset;
   padding: 0.5em;
   margin: 0.5em;
+  display: table-cell;
 }
 
 /* % ######################################################### */

--- a/BrainPortal/public/stylesheets/cbrain.css
+++ b/BrainPortal/public/stylesheets/cbrain.css
@@ -246,7 +246,6 @@ div.vertical_text {
   height: auto;
   margin: auto;
   text-align: left;
-/* background-color: pink; */
   transform:                translate(0%, 100%) rotate(-90deg) translate(0%, 0%);
   transform-origin:         0% 0%;
   -webkit-transform:        translate(0%, 100%) rotate(-90deg) translate(0%, 0%);
@@ -272,7 +271,6 @@ div.down_vertical_text {
   height: auto;
   margin: auto;
   text-align: left;
-/* background-color: pink; */
   transform:                translate(0%, -100%) rotate(90deg) translate(0%, 0%);
   transform-origin:         0% 100%;
   -webkit-transform:        translate(0%, -100%) rotate(90deg) translate(0%, 0%);
@@ -293,7 +291,6 @@ div.down_vertical_text2 {
   margin: auto;
   text-align: right;
   direction: rtl;
-/* background-color: pink; */
   transform:                translate(-100%, 0%) rotate(-90deg) translate(0%, 0%);
   transform-origin:         100% 0%;
   -webkit-transform:        translate(-100%, 0%) rotate(-90deg) translate(0%, 0%);
@@ -2078,6 +2075,18 @@ img {
 
 #message_table td.operations {
   text-align: right;
+}
+
+/* % ######################################################### */
+/* % Access Profiles styling */
+/* % ######################################################### */
+
+.access_profile_label {
+  border: none;
+  border-radius: 0.5em;
+  box-shadow: 0px 0px 4px black inset;
+  padding: 0.5em;
+  margin: 0.5em;
 }
 
 /* % ######################################################### */

--- a/BrainPortal/spec/controllers/access_profiles_controller_spec.rb
+++ b/BrainPortal/spec/controllers/access_profiles_controller_spec.rb
@@ -1,0 +1,294 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+require 'rails_helper'
+
+RSpec.describe AccessProfilesController, :type => :controller do
+  #let(:access_profile) { mock_model(AccessProfiles).as_null_object }
+
+  #==========================================
+  # Admin User
+  #==========================================
+
+  context "with an admin user" do
+
+    let(:current_user) { create(:admin_user) }
+
+    # User 'A', Group 'A' and AP 'A' all link together
+    let(:user_a)  { create(:normal_user,    :login => "U_A") }
+    let(:group_a) { create(:work_group,     :name  => "G_A",  :user_ids => [ user_a.id ] ) }
+    let(:ap_a)    { create(:access_profile, :name  => "AP_A", :user_ids => [ user_a.id ], :group_ids => [ group_a.id ] ) }
+
+    # User 'B' is in no group; Group 'B' has no users, AP 'B' has no groups
+    let(:user_b)  { create(:normal_user,    :login => "U_B") }
+    let(:group_b) { create(:work_group,     :name  => "G_B") }
+    let(:ap_b)    { create(:access_profile, :name  => "AP_B") }
+
+    # Group O has user 'B'
+    let(:group_o) { create(:work_group,     :name  => "G_Oth", :user_ids  => [ user_b.id ] ) }
+
+    # AP 'AB' has group 'A' and 'B' and no users
+    let(:ap_ab)   { create(:access_profile, :name      => "AP_AB",
+                                            :group_ids => [ group_a.id, group_b.id ],
+                                            :user_ids  => [ ],
+                          ) }
+
+    before(:each) do
+      session[:user_id] = current_user.id
+    #  user_a  ; user_b
+    #  group_a ; group_b ; group_o
+    #  ap_a    ; ap_b    ; ap_ab
+    end
+
+    #----------------
+    # INDEX
+    #----------------
+    describe "index" do
+      #before(:each) do
+      #  allow(controller).to receive(:current_user).and_return(current_user)
+      #end
+
+      it "should return all access_profiles" do
+        ap_a ; ap_b ; ap_ab
+        get :index
+        expect(assigns[:access_profiles].to_a).to match_array(AccessProfile.all)
+        expect(assigns[:access_profiles].size).to eq(3)
+      end
+    end
+
+    #----------------
+    # SHOW
+    #----------------
+    describe "show" do
+      it "should return a profile by ID" do
+        get :show, :id => ap_b.id
+        expect(assigns[:access_profile]).to match(ap_b)
+      end
+      it "should fail on a unknown profile ID" do
+        expect { get :show, :id => -987 }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    #----------------
+    # NEW
+    #----------------
+    describe "new" do
+      it "should initialize a new access profile" do
+        get :new
+        expect(assigns[:access_profile]).to be_a_new(AccessProfile)
+      end
+    end
+
+    #----------------
+    # CREATE
+    #----------------
+    describe "create" do
+      it "should create a new access profile" do
+        attributes =  { :name => "Abc",
+                        :description => "Desc1",
+                        :user_ids    => [ user_a.id, user_b.id ],
+                        :group_ids   => [ group_a.id, group_b.id ],
+                      }
+        post :create, :access_profile => attributes
+        expect(assigns[:access_profile]).to     match(AccessProfile.last)
+        expect(AccessProfile.last.user_ids).to  match_array(attributes[:user_ids])
+        expect(AccessProfile.last.group_ids).to match_array(attributes[:group_ids])
+      end
+    end
+
+    #----------------
+    # UPDATE
+    #----------------
+    describe "update" do
+      it "should find a profile by ID" do
+        post :update, :id => ap_b.id
+        expect(assigns[:access_profile]).to match(ap_b)
+      end
+      it "should fail on a unknown profile ID" do
+        expect { post :update, :id => -987 }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+      it "should change standard attributes" do
+        new_att = { :name => 'new_name', :description => 'new_desc', :color => '#cababe' }
+        post :update, :id => ap_b.id, :access_profile => new_att
+        updated_ap = AccessProfile.find(ap_b.id)
+        expect(updated_ap.name).to        match(new_att[:name])
+        expect(updated_ap.description).to match(new_att[:description])
+        expect(updated_ap.color).to       match(new_att[:color])
+      end
+      context "when a group is added" do
+        it "should adjust all affected users" do
+          allow(User).to receive_message_chain(:where, :all).and_return([ user_a ])
+          expect(user_a).to receive(:apply_access_profiles).and_return true
+          post :update, :id                => ap_a.id,
+                        :affected_user_ids => [ user_a.id ],
+                        :access_profile    =>
+                          ap_a.attributes.slice("name","description","color")
+                          .merge(:user_ids => [ user_a.id ], :group_ids => [ group_a.id, group_o.id ])
+        end
+      end
+      context "when a group is removed" do
+        it "should adjust all affected users" do
+          allow(User).to receive_message_chain(:where, :all).and_return([ user_a ])
+          expect(user_a).to receive(:apply_access_profiles).and_return true
+          post :update, :id                => ap_a.id,
+                        :affected_user_ids => [ user_a.id ],
+                        :access_profile    =>
+                          ap_a.attributes.slice("name","description","color")
+                          .merge(:user_ids => [ user_a.id ], :group_ids => [ ])
+        end
+      end
+      context "when a user is added" do
+        it "should adjust the user's group list" do  # add user B to AP B
+          allow(User).to receive(:find).with([ user_b.id ]).and_return([ user_b ])
+          allow(User).to receive(:find).with([ ]).and_return([ ])
+          expect(user_b).to receive(:apply_access_profiles).and_return true
+          post :update, :id                => ap_b.id,
+                        :access_profile    =>
+                          ap_b.attributes.slice("name","description","color")
+                          .merge(:user_ids => [ user_b.id ], :group_ids => [ ])
+        end
+      end
+      context "when a user is removed" do
+        it "should adjust the user's group list" do  # remove user A from AP A
+          allow(User).to receive(:find).with([ ]).and_return([ ])
+          allow(User).to receive(:find).with([ user_a.id ]).and_return([ user_a ])
+          expect(user_a).to receive(:apply_access_profiles).and_return true
+          post :update, :id                => ap_a.id,
+                        :access_profile    =>
+                          ap_a.attributes.slice("name","description","color")
+                          .merge(:user_ids => [ ], :group_ids => [ group_a.id ])
+        end
+      end
+    end
+
+    #----------------
+    # DESTROY
+    #----------------
+    describe "destroy" do
+      it "should destroy a the access profile" do
+        post :destroy, :id => ap_a.id
+        expect(AccessProfile.where(:id => ap_a.id).all).to match_array([])
+      end
+      it "should adjust all affected users" do
+        allow(User).to receive(:find).with([ user_a.id ]).and_return([ user_a ])
+        expect(user_a).to receive(:apply_access_profiles).with(remove_group_ids: [ group_a.id ]).and_return true
+        post :destroy, :id => ap_a.id
+      end
+    end
+
+  end
+
+  #==========================================
+  # Normal user: always 401
+  #==========================================
+
+  context "when the user is not an admin" do
+
+    let(:current_user) { create(:normal_user) }
+
+    before(:each) do
+      session[:user_id] = current_user.id
+    end
+
+    describe "index" do
+      it "should present the not authorized page" do
+        get :index
+        expect(response.code).to eq('401')
+      end
+    end
+    describe "show" do
+      it "should present the not authorized page" do
+        get :show, :id => 1
+        expect(response.code).to eq('401')
+      end
+    end
+    describe "new" do
+      it "should present the not authorized page" do
+        get :new
+        expect(response.code).to eq('401')
+      end
+    end
+    describe "create" do
+      it "should present the not authorized page" do
+        post :create
+        expect(response.code).to eq('401')
+      end
+    end
+    describe "update" do
+      it "should present the not authorized page" do
+        put :update, :id => 1
+        expect(response.code).to eq('401')
+      end
+    end
+    describe "destroy" do
+      it "should present the not authorized page" do
+        delete :destroy, :id => 1
+        expect(response.code).to eq('401')
+      end
+    end
+  end
+
+  #==========================================
+  # Not logged in: always back to login page
+  #==========================================
+
+  context "when the user is not logged in" do
+    describe "index" do
+      it "should redirect the login page" do
+        get :index
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+    describe "show" do
+      it "should redirect the login page" do
+        get :show, :id => 1
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+    describe "new" do
+      it "should redirect the login page" do
+        get :new
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+    describe "create" do
+      it "should redirect the login page" do
+        post :create
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+    describe "update" do
+      it "should redirect the login page" do
+        put :update, :id => 1
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+    describe "destroy" do
+      it "should redirect the login page" do
+        delete :destroy, :id => 1
+        expect(response).to redirect_to(:controller => :sessions, :action => :new)
+      end
+    end
+  end
+
+end
+

--- a/BrainPortal/spec/controllers/access_profiles_controller_spec.rb
+++ b/BrainPortal/spec/controllers/access_profiles_controller_spec.rb
@@ -23,7 +23,6 @@
 require 'rails_helper'
 
 RSpec.describe AccessProfilesController, :type => :controller do
-  #let(:access_profile) { mock_model(AccessProfiles).as_null_object }
 
   #==========================================
   # Admin User
@@ -54,19 +53,12 @@ RSpec.describe AccessProfilesController, :type => :controller do
 
     before(:each) do
       session[:user_id] = current_user.id
-    #  user_a  ; user_b
-    #  group_a ; group_b ; group_o
-    #  ap_a    ; ap_b    ; ap_ab
     end
 
     #----------------
     # INDEX
     #----------------
     describe "index" do
-      #before(:each) do
-      #  allow(controller).to receive(:current_user).and_return(current_user)
-      #end
-
       it "should return all access_profiles" do
         ap_a ; ap_b ; ap_ab
         get :index
@@ -184,7 +176,7 @@ RSpec.describe AccessProfilesController, :type => :controller do
     # DESTROY
     #----------------
     describe "destroy" do
-      it "should destroy a the access profile" do
+      it "should destroy the access profile" do
         post :destroy, :id => ap_a.id
         expect(AccessProfile.where(:id => ap_a.id).all).to match_array([])
       end

--- a/BrainPortal/spec/factories/portal_factories.rb
+++ b/BrainPortal/spec/factories/portal_factories.rb
@@ -272,7 +272,7 @@ FactoryGirl.define do
     association     :group
   end
 
- factory :site do
+  factory :site do
     sequence(:name) { |n| "site_#{n}" }
   end
 
@@ -287,6 +287,11 @@ FactoryGirl.define do
   end
 
   factory :cbrain_session do
+  end
+
+  factory :access_profile do
+    sequence(:name)        { |n| "ap_#{n}" }
+    sequence(:description) { |n| "description for ap_#{n}" }
   end
 
 end

--- a/BrainPortal/spec/models/cbrain_session_spec.rb
+++ b/BrainPortal/spec/models/cbrain_session_spec.rb
@@ -74,16 +74,15 @@ describe CbrainSession do
 
 
   describe "self.recent_activity" do
+
     1.upto(15) do |i|
       sess = ActiveRecord::SessionStore::Session.create!( :updated_at => (i*10).seconds.ago, :session_id => "xyz#{i}", :data => {})
       sess.user_id = i
       sess.active  = true
-      sess.save
-      let!(:name) { CbrainSession.new(sess, sess_model) }
+      sess.save!
     end
 
     it "should return an array containning recent activity (max n)" do
-      allow(CbrainSession).to receive(:clean_sessions).and_return(true)
       allow(User).to receive(:find_by_id).and_return(current_user)
       n = 9
       expect(CbrainSession.recent_activity(n).size).to eq(n)


### PR DESCRIPTION
This is a new model that is only useful for the administrator.
Each AccessProfile is basically

* a list of groups (a.k.a projects)
* a list of users

The purpose is to simplify user management. The admin
creates a AccessProfile, assigns it a bunch of groups,
and then when creating users or modifying them, they
can be assigned to the profile. When the profile's
list of group is changed, all users associated with the
profile will have their list of groups changed too.

Users can be assigned multiple AccessProfiles, which means
they get the UNION set of all groups from those profiles.

AccessProfiles have pretty labels the show up as colorful
boxes for the admin.