### PR TITLE
HOTFIX: do not create tool configs in Boutiques task generator

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -113,14 +113,15 @@ module SchemaTaskGenerator
 
     # Integrates the encapsulated CbrainTask in this CBRAIN installation.
     # Unless +register+ is specified to be false, this method will add the
-    # required Tool and ToolConfig if necessary for the CbrainTask to be
+    # required Tool if necessary for the CbrainTask to be
     # useable right away (since almost all information required to make the
-    # Tool and ToolConfig objects is available in the spec).
+    # Tool and ToolConfig objects is available in the spec). The ToolConfig
+    # will also be created unless +create_tool_config+ is false.
     # Also, if +multi_version+ is specified, this method will wrap the
     # encapsulated CbrainTask in a version switcher class to allow different
     # CbrainTask classes for each tool version.
     # Returns the newly generated CbrainTask subclass.
-    def integrate(register: true, multi_version: false)
+    def integrate(register: true, create_tool_config:false, multi_version: false)
       # Make sure the task class about to be generated does not already exist,
       # to avoid mixing the classes up.
       name = SchemaTaskGenerator.classify(@name)
@@ -184,16 +185,17 @@ module SchemaTaskGenerator
 
       # With the task class and descriptor, we have enough information to
       # generate a Tool and ToolConfig to register the tool into CBRAIN.
-      register(task) if register
+      register(task,create_tool_config) if register
 
       task
     end
 
     # Register a newly generated CbrainTask subclass (+task+) in this CBRAIN
-    # installation, creating the appropriate Tool and ToolConfig objects from
-    # the information contained in the descriptor. The newly created Tool and
-    # ToolConfig will initially belong to the core admin.
-    def register(task)
+    # installation, creating the appropriate Tool object from
+    # the information contained in the descriptor. A ToolConfig is also created,
+    # unless +create_tool_config+ is false. The newly created Tool and ToolConfig
+    # will initially belong to the core admin.
+    def register(task, create_tool_config)
       name         = @descriptor['name']
       version      = @descriptor['tool-version'] || '(unknown)'
       description  = @descriptor['description']  || ''
@@ -223,7 +225,7 @@ module SchemaTaskGenerator
         :version_name => version,
         :description  => "#{name} #{version} on #{resource.name}",
         :docker_image => docker_image
-      ).save! unless
+      ).save! unless !create_tool_config ||
         ToolConfig.exists?(
           :tool_id      => task.tool.id,
           :bourreau_id  => resource.id,

--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -121,7 +121,7 @@ module SchemaTaskGenerator
     # encapsulated CbrainTask in a version switcher class to allow different
     # CbrainTask classes for each tool version.
     # Returns the newly generated CbrainTask subclass.
-    def integrate(register: true, create_tool_config:false, multi_version: false)
+    def integrate(register: true, create_tool_config: false, multi_version: false)
       # Make sure the task class about to be generated does not already exist,
       # to avoid mixing the classes up.
       name = SchemaTaskGenerator.classify(@name)


### PR DESCRIPTION
A ToolConfig is created for every Boutiques tool when the Bourreau starts. This is annoying because Boutiques tools that don't have a Docker image shouldn't be configured on Bourreaux where they are not installed, and Boutiques tools that have a Docker image shouldn't be configured on Bourreaux that don't have Docker installed. Moreover, even when ToolConfigs are deleted manually, they are re-created when the Bourreau re-start. 

This commit disables ToolConfig generation. See #389 for a longer-term solution. 