### PR TITLE
Renamed tool attribute cbrain_task_class

### DIFF
--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -89,6 +89,15 @@ class SessionsController < ApplicationController
     end
   end
 
+  # Send a proper HTTP error code
+  def auth_failed
+    respond_to do |format|
+      format.html { render :action => 'new' }
+      format.json { render :nothing => true, :status  => 401 }
+      format.xml  { render :nothing => true, :status  => 401 }
+    end
+  end
+
   ###############################################
   #
   # Private methods

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -181,7 +181,7 @@ class TasksController < ApplicationController
       return
     end
 
-    @toolname         = Tool.find(params[:tool_id]).cbrain_task_class.demodulize
+    @toolname         = Tool.find(params[:tool_id]).cbrain_task_class_name.demodulize
 
     @task             = CbrainTask.const_get(@toolname).new
 
@@ -307,7 +307,7 @@ class TasksController < ApplicationController
     @tool_config = tool_config # for acces in view
 
     # A brand new task object!
-    @toolname         = Tool.find(params[:tool_id]).cbrain_task_class.demodulize
+    @toolname         = Tool.find(params[:tool_id]).cbrain_task_class_name.demodulize
     @task             = CbrainTask.const_get(@toolname).new(params[:cbrain_task])
     @task.user_id   ||= current_user.id
     @task.group_id  ||= current_project.try(:id) || current_user.own_group.id

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -296,7 +296,7 @@ class CbrainTask < ActiveRecord::Base
   # a task and a tool; it's based on the class name stored
   # in one of the tool's attribute.
   def self.tool
-    Tool.where( :cbrain_task_class => self.to_s ).first
+    Tool.where( :cbrain_task_class_name => self.to_s ).first
   end
 
   # Same as the class method of the same name.

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -301,7 +301,7 @@ class ToolConfig < ActiveRecord::Base
 
   # Return the Ruby class associated with the tool associated with this tool_config.
   def cbrain_task_class
-    self.tool.cbrain_task_class.constantize
+    self.tool.cbrain_task_class
   end
 
 end

--- a/BrainPortal/app/views/custom_filters/_task_custom_filter.html.erb
+++ b/BrainPortal/app/views/custom_filters/_task_custom_filter.html.erb
@@ -18,16 +18,16 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 -%>
 
 <% custom_filter ||= @custom_filter %>
 
 Task<br>
-<%= task_type_select("data[type]", {:task_types => current_user.available_tools.map(&:cbrain_task_class).sort, :selector => custom_filter.data["type"], :include_top => true }, :multiple => true, :size => 10) %>
+<%= task_type_select("data[type]", {:task_types => current_user.available_tools.map(&:cbrain_task_class_name).sort, :selector => custom_filter.data["type"], :include_top => true }, :multiple => true, :size => 10) %>
 
-<p>                                                                                                                                                     
+<p>
 Status<br>
 <%= task_status_select("data[status]", {:selector => custom_filter.data["status"]}, :multiple => true, :size => 10) %>
 

--- a/BrainPortal/app/views/tools/_form_fields.html.erb
+++ b/BrainPortal/app/views/tools/_form_fields.html.erb
@@ -31,8 +31,8 @@
 
 <p>
   <span title="PortalTask subclass which implements this tool.">
-     <%= f.label :cbrain_task_class, "CbrainTask Class:" %>
-     <%= f.text_field :cbrain_task_class %>
+     <%= f.label :cbrain_task_class_name, "CbrainTask Class name:" %>
+     <%= f.text_field :cbrain_task_class_name %>
   </span>
 </p>
 

--- a/BrainPortal/app/views/tools/_tools_table.html.erb
+++ b/BrainPortal/app/views/tools/_tools_table.html.erb
@@ -112,13 +112,13 @@
     end
 
     t.column("Help", :help) do |tool|
-      path   = tool.cbrain_task_class.constantize.public_path("edit_params_help.html") rescue nil
-      path ||= tool.cbrain_task_class.constantize.help_filepath rescue nil # Boutiques help-page
+      path   = tool.cbrain_task_class.public_path("edit_params_help.html") rescue nil
+      path ||= tool.cbrain_task_class.help_filepath rescue nil # Boutiques help-page
       overlay_ajax_link "Help", path.to_s if path
     end
 
     t.column("Info", :info) do |tool|
-      path = tool.cbrain_task_class.constantize.public_path("tool_info.html") rescue nil
+      path = tool.cbrain_task_class.public_path("tool_info.html") rescue nil
       overlay_ajax_link "Info", path.to_s if path
     end
   %>

--- a/BrainPortal/config/console_rc/lib/fast_finder.rb
+++ b/BrainPortal/config/console_rc/lib/fast_finder.rb
@@ -163,7 +163,7 @@ class Tool
       self.class.to_s, self.id,
       user.login,      group.name,
       name,
-      cbrain_task_class
+      cbrain_task_class_name
   end
 end
 

--- a/BrainPortal/db/migrate/20160613200409_rename_tool_cbrain_task_class.rb
+++ b/BrainPortal/db/migrate/20160613200409_rename_tool_cbrain_task_class.rb
@@ -1,0 +1,5 @@
+class RenameToolCbrainTaskClass < ActiveRecord::Migration
+  def change
+    rename_column :tools, :cbrain_task_class,      :cbrain_task_class_name
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -363,7 +363,7 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
     t.string   "category"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "cbrain_task_class"
+    t.string   "cbrain_task_class_name"
     t.string   "select_menu_text"
     t.text     "description"
     t.string   "url"
@@ -373,7 +373,7 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
   end
 
   add_index "tools", ["category"], :name => "index_tools_on_category"
-  add_index "tools", ["cbrain_task_class"], :name => "index_tools_on_cbrain_task_class"
+  add_index "tools", ["cbrain_task_class_name"], :name => "index_tools_on_cbrain_task_class"
   add_index "tools", ["group_id"], :name => "index_tools_on_group_id"
   add_index "tools", ["user_id"], :name => "index_tools_on_user_id"
 
@@ -387,11 +387,11 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
     t.string   "type"
     t.integer  "group_id"
     t.integer  "data_provider_id"
-    t.boolean  "group_writable",                                  :default => false, :null => false
+    t.boolean  "group_writable",   :default => false, :null => false
     t.integer  "num_files"
-    t.boolean  "hidden",                                          :default => false
-    t.boolean  "immutable",                                       :default => false
-    t.boolean  "archived",                                        :default => false
+    t.boolean  "hidden",           :default => false
+    t.boolean  "immutable",        :default => false
+    t.boolean  "archived",         :default => false
     t.text     "description"
   end
 

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -387,11 +387,11 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
     t.string   "type"
     t.integer  "group_id"
     t.integer  "data_provider_id"
-    t.boolean  "group_writable",   :default => false, :null => false
+    t.boolean  "group_writable",                                  :default => false, :null => false
     t.integer  "num_files"
-    t.boolean  "hidden",           :default => false
-    t.boolean  "immutable",        :default => false
-    t.boolean  "archived",         :default => false
+    t.boolean  "hidden",                                          :default => false
+    t.boolean  "immutable",                                       :default => false
+    t.boolean  "archived",                                        :default => false
     t.text     "description"
   end
 

--- a/BrainPortal/db/seeds_dev.rb
+++ b/BrainPortal/db/seeds_dev.rb
@@ -569,7 +569,7 @@ seeded_tools = []
 
 diag_tool = Tool.seed_record!(
   {
-    :cbrain_task_class => 'CbrainTask::Diagnostics'
+    :cbrain_task_class_name => 'CbrainTask::Diagnostics'
   },
   {
     :name => 'Diagnostics',
@@ -583,7 +583,7 @@ seeded_tools << diag_tool
 
 para_tool = Tool.seed_record!(
   {
-    :cbrain_task_class => 'CbrainTask::Parallelizer'
+    :cbrain_task_class_name => 'CbrainTask::Parallelizer'
   },
   {
     :name => 'Parallelizer',
@@ -597,7 +597,7 @@ seeded_tools << para_tool
 
 seri_tool = Tool.seed_record!(
   {
-    :cbrain_task_class => 'CbrainTask::CbSerializer'
+    :cbrain_task_class_name => 'CbrainTask::CbSerializer'
   },
   {
     :name => 'Serializer',
@@ -828,7 +828,7 @@ seeded_users.each do |user|
         howlong = rand(10) + 5
         tc = ToolConfig.find_by_tool_id_and_bourreau_id(tool.id, bourreau.id)
         next unless tc.can_be_accessed_by?(user)
-        taskclass = tool.cbrain_task_class.demodulize
+        taskclass = tool.cbrain_task_class_name.demodulize
         CbrainTask.const_get(taskclass).seed_record!(
           { :user_id                  => user.id,
             :group_id                 => group.id,

--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -208,14 +208,14 @@ module SchemaTaskGenerator
 
       # Create and save a new Tool for the task, unless there's already one.
       Tool.new(
-        :name              => name,
-        :user_id           => User.admin.id,
-        :group_id          => User.admin.own_group.id,
-        :category          => "scientific tool",
-        :cbrain_task_class => task.to_s,
-        :description       => description
+        :name                   => name,
+        :user_id                => User.admin.id,
+        :group_id               => User.admin.own_group.id,
+        :category               => "scientific tool",
+        :cbrain_task_class_name => task.to_s,
+        :description            => description
       ).save! unless
-        Tool.exists?(:cbrain_task_class => task.to_s)
+        Tool.exists?(:cbrain_task_class_name => task.to_s)
 
       # Create and save a new ToolConfig for the task on this server, unless
       # theres already one. Only applies to Bourreaux (as it would make no

--- a/BrainPortal/spec/boutiques/boutiques_tester_spec.rb
+++ b/BrainPortal/spec/boutiques/boutiques_tester_spec.rb
@@ -191,7 +191,7 @@ describe "BrainPortal Boutiques Tests" do
         expect( @task_const.to_s ).to eq( "CbrainTask::BoutiquesTest" )
       end
       it "should have a tool" do
-        expect( Tool.exists?(:cbrain_task_class => @task_const) ).to be true
+        expect( Tool.exists?(:cbrain_task_class_name => @task_const) ).to be true
       end
       it "should have no public path" do # Just test the help file
         expect( @task_const.public_path("edit_params_help.html") ).to eq( nil )

--- a/BrainPortal/spec/factories/portal_factories.rb
+++ b/BrainPortal/spec/factories/portal_factories.rb
@@ -257,11 +257,11 @@ FactoryGirl.define do
   ###################
 
   factory :tool do
-    sequence(:name)   { |n| "tool_#{n}" }
-    category          "scientific tool"
-    cbrain_task_class { |n| "CbrainTask::Snoozer#{n}"}
-    association       :user, factory: :normal_user
-    association       :group
+    sequence(:name)        { |n| "tool_#{n}" }
+    category               "scientific tool"
+    cbrain_task_class_name { |n| "CbrainTask::Snoozer#{n}"}
+    association            :user, factory: :normal_user
+    association            :group
   end
 
   factory :tool_config do

--- a/BrainPortal/spec/models/tool_config_spec.rb
+++ b/BrainPortal/spec/models/tool_config_spec.rb
@@ -155,7 +155,7 @@ describe ToolConfig do
 
   describe "#to_bash_prologue" do
 
-   let(:tool) {create(:tool, :cbrain_task_class => "CbrainTask::Civet")}
+   let(:tool) {create(:tool, :cbrain_task_class_name => "CbrainTask::Civet")}
 
    context "fill HEADER" do
       it "should print 'Configuration: tool_config.id'" do

--- a/BrainPortal/spec/models/tool_config_spec.rb
+++ b/BrainPortal/spec/models/tool_config_spec.rb
@@ -155,7 +155,7 @@ describe ToolConfig do
 
   describe "#to_bash_prologue" do
 
-   let(:tool) {create(:tool, :cbrain_task_class_name => "CbrainTask::Civet")}
+   let(:tool) {create(:tool, :cbrain_task_class_name => "CbrainTask::Diagnostics")}
 
    context "fill HEADER" do
       it "should print 'Configuration: tool_config.id'" do


### PR DESCRIPTION
DO NOT MERGE THIS PULL REQUEST; it's fine but its impact require careful scheduling.

The ActiveRecord attribute `cbrain_task_class` in Tools has been renamed
`cbrain_task_class_name`.

The name was misleading, the attribute contains a class name,
not the class itself. This has allowed me to add a new method
`cbrain_task_class` to tool to return the class itself.

Please review the changes carefully to make sure all the affected code seems to be equivalent to what it was.