### PR TITLE
Refactor smart data providers

### DIFF
--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -74,6 +74,11 @@ module SmartDataProviderInterface
   # This method returns the real data provider used
   # for implementing the behavior of all the methods
   # in the provider API. It is useful for debugging.
+  # Attempts to save() the real provider will be prevented   
+  # by special intercept code when setting up the current    
+  # provider; this is for security reasons, as saving    
+  # the real provider object should never be needed    
+  # in any way.
   def real_provider
     @real_provider
   end

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -41,32 +41,41 @@ module SmartDataProviderInterface
     dp_hostnames  = self.alternate_host.split(',').select { |host| host && ! host.blank? } rescue []
     dp_hostnames << self.remote_host rescue nil
     if dp_hostnames.empty? || dp_remote_dir.blank? # special case : usually when doing special select() on DPs with missing columns
-      @provider = nil
-      return @provider
+      @real_provider = nil
+      return @real_provider
     end
 
     # Create only one provider object, depending on whether we want a network provider
     # or a local provider
     if dp_hostnames.include?(Socket.gethostname) && File.directory?(dp_remote_dir)
-      @provider = localclass.new
-      @provider.make_all_accessible!
-      @provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! localclass.columns_hash[k] }
+      @real_provider = localclass.new
     else
-      @provider = networkclass.new
-      @provider.make_all_accessible!
-      @provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! networkclass.columns_hash[k] }
+      @real_provider = networkclass.new
     end
 
-    @provider.id = self.id
+    @real_provider.make_all_accessible!
+    @real_provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! @real_provider.class.columns_hash[k] }
+    @real_provider.id = self.id
 
-    @provider
+    # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects    
+    [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
+      @real_provider.readonly!    
+      @real_provider.class_eval do    
+        define_method(bad_method) do |*args|   
+          cb_error "Internal error: attempt to invoke method '#{bad_method}' on internal #{@real_provider.class == localclass ? "local" : "network"} provider object for SmartDataProvider '#{@real_provider.name}'"   
+        end    
+      end    
+    end
+
+
+    @real_provider
   end
 
   # This method returns the real data provider used
   # for implementing the behavior of all the methods
   # in the provider API. It is useful for debugging.
   def real_provider
-    @provider
+    @real_provider
   end
 
   ####################################
@@ -74,104 +83,104 @@ module SmartDataProviderInterface
   ####################################
 
   def is_alive? #:nodoc:
-    @provider && @provider.is_alive?
+    @real_provider && @real_provider.is_alive?
   end
 
   def is_alive! #:nodoc:
-    @provider && @provider.is_alive!
+    @real_provider && @real_provider.is_alive!
   end
 
   def is_browsable?(by_user = nil) #:nodoc:
-    @provider && @provider.is_browsable?(by_user)
+    @real_provider && @real_provider.is_browsable?(by_user)
   end
 
   def is_fast_syncing? #:nodoc:
-    @provider && @provider.is_fast_syncing?
+    @real_provider && @real_provider.is_fast_syncing?
   end
 
   def allow_file_owner_change? #:nodoc:
-    @provider && @provider.allow_file_owner_change?
+    @real_provider && @real_provider.allow_file_owner_change?
   end
 
   def sync_to_cache(userfile) #:nodoc:
-    @provider.sync_to_cache(userfile)
+    @real_provider.sync_to_cache(userfile)
   end
 
   def sync_to_provider(userfile) #:nodoc:
-    @provider.sync_to_provider(userfile)
+    @real_provider.sync_to_provider(userfile)
   end
 
   def cache_prepare(userfile) #:nodoc:
-    @provider.cache_prepare(userfile)
+    @real_provider.cache_prepare(userfile)
   end
 
   def cache_full_path(userfile) #:nodoc:
-    @provider.cache_full_path(userfile)
+    @real_provider.cache_full_path(userfile)
   end
 
   def provider_readhandle(userfile, *args, &block) #:nodoc:
-    @provider.provider_readhandle(userfile, *args, &block)
+    @real_provider.provider_readhandle(userfile, *args, &block)
   end
 
   def cache_readhandle(userfile, *args, &block) #:nodoc:
-    @provider.cache_readhandle(userfile, *args, &block)
+    @real_provider.cache_readhandle(userfile, *args, &block)
   end
 
   def cache_writehandle(userfile, *args, &block) #:nodoc:
-    @provider.cache_writehandle(userfile, *args, &block)
+    @real_provider.cache_writehandle(userfile, *args, &block)
   end
 
   def cache_copy_from_local_file(userfile,localfilename) #:nodoc:
-    @provider.cache_copy_from_local_file(userfile,localfilename)
+    @real_provider.cache_copy_from_local_file(userfile,localfilename)
   end
 
   def cache_copy_to_local_file(userfile,localfilename) #:nodoc:
-    @provider.cache_copy_to_local_file(userfile,localfilename)
+    @real_provider.cache_copy_to_local_file(userfile,localfilename)
   end
 
   def cache_erase(userfile) #:nodoc:
-    @provider.cache_erase(userfile)
+    @real_provider.cache_erase(userfile)
   end
 
   def cache_collection_index(userfile, directory = :all, allowed_types = :regular) #:nodoc:
-    @provider.cache_collection_index(userfile, directory, allowed_types)
+    @real_provider.cache_collection_index(userfile, directory, allowed_types)
   end
 
   def provider_erase(userfile) #:nodoc:
-    @provider.provider_erase(userfile)
+    @real_provider.provider_erase(userfile)
   end
 
   def provider_rename(userfile, newname) #:nodoc:
-    @provider.provider_rename(userfile, newname)
+    @real_provider.provider_rename(userfile, newname)
   end
 
   def provider_move_to_otherprovider(userfile, otherprovider, options = {}) #:nodoc:
-    @provider.provider_move_to_otherprovider(userfile, otherprovider, options)
+    @real_provider.provider_move_to_otherprovider(userfile, otherprovider, options)
   end
 
   def provider_copy_to_otherprovider(userfile, otherprovider, options = {}) #:nodoc:
-    @provider.provider_copy_to_otherprovider(userfile, otherprovider, options)
+    @real_provider.provider_copy_to_otherprovider(userfile, otherprovider, options)
   end
 
   def provider_list_all(user=nil) #:nodoc:
-    @provider.provider_list_all(user)
+    @real_provider.provider_list_all(user)
   end
 
   def provider_collection_index(userfile, directory = :all, allowed_types = :regular) #:nodoc:
-    @provider.provider_collection_index(userfile, directory, allowed_types)
+    @real_provider.provider_collection_index(userfile, directory, allowed_types)
   end
 
   def provider_report(force_reload=nil) #:nodoc:
-    @provider.provider_report(force_reload)
+    @real_provider.provider_report(force_reload)
   end
 
   def provider_repair(issue) #:nodoc:
-    @provider.provider_repair(issue)
+    @real_provider.provider_repair(issue)
   end
 
   # This method is specific to SSH data providers subclasses and not part of the official API
   def browse_remote_dir(user=nil) #:nodoc:
-    @provider.browse_remote_dir(user)
+    @real_provider.browse_remote_dir(user)
   end
 
   # This method is a utility method allowing access to
@@ -179,8 +188,8 @@ module SmartDataProviderInterface
   # class, even when the current smart provider is actually
   # configured to be local.
   def provider_full_path(userfile) #:nodoc:
-    if @provider.respond_to?(:provider_full_path)
-      @provider.provider_full_path(userfile)
+    if @real_provider.respond_to?(:provider_full_path)
+      @real_provider.provider_full_path(userfile)
     else
       "(unknown remote path)"
     end

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -56,10 +56,10 @@ module SmartDataProviderInterface
     @real_provider.make_all_accessible!
     @real_provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! @real_provider.class.columns_hash[k] }
     @real_provider.id = self.id # the real provider gets the id of the ActiveRecord object, even if it's never saved in the DB
+    @real_provider.readonly!
 
     # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects    
     [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
-      @real_provider.readonly!    
       @real_provider.class_eval do    
         define_method(bad_method) do |*args|   
           cb_error "Internal error: attempt to invoke method '#{bad_method}' on internal #{@real_provider.class == localclass ? "local" : "network"} provider object for SmartDataProvider '#{@real_provider.name}'"   

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -59,8 +59,8 @@ module SmartDataProviderInterface
     @real_provider.readonly!
 
     # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects    
-    [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
-      @real_provider.class_eval do    
+    @real_provider.class_eval do
+      [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
         define_method(bad_method) do |*args|   
           cb_error "Internal error: attempt to invoke method '#{bad_method}' on internal #{@real_provider.class == localclass ? "local" : "network"} provider object for SmartDataProvider '#{@real_provider.name}'"   
         end    

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -55,7 +55,7 @@ module SmartDataProviderInterface
 
     @real_provider.make_all_accessible!
     @real_provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! @real_provider.class.columns_hash[k] }
-    @real_provider.id = self.id
+    @real_provider.id = self.id # the real provider gets the id of the ActiveRecord object, even if it's never saved in the DB
 
     # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects    
     [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
@@ -74,10 +74,10 @@ module SmartDataProviderInterface
   # This method returns the real data provider used
   # for implementing the behavior of all the methods
   # in the provider API. It is useful for debugging.
-  # Attempts to save() the real provider will be prevented   
-  # by special intercept code when setting up the current    
-  # provider; this is for security reasons, as saving    
-  # the real provider object should never be needed    
+  # Attempts to save() the real provider will be prevented
+  # by special intercept code when setting up the current
+  # provider; this is for security reasons, as saving
+  # the real provider object should never be needed
   # in any way.
   def real_provider
     @real_provider


### PR DESCRIPTION
Solution to #400.
Removed all references from local_providers and remote_providers and use only one when selecting between the Data Providers.
Changed the data provider identifier to real_provider to prevent confusion.