### PR TITLE
Tests robustness

### DIFF
--- a/BrainPortal/spec/rails_helper.rb
+++ b/BrainPortal/spec/rails_helper.rb
@@ -20,6 +20,9 @@ require 'rspec/rails'
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
+# Preload two important exception classes
+CbrainError ; CbrainNotice
+
 RSpec.configure do |config|
   # If you do not include FactoryGirl::Syntax::Methods in your test suite,
   # then all factory_girl methods will need to be prefaced with FactoryGirl.


### PR DESCRIPTION
I found tests could fail depending on when our our custom exceptions `CbrainError` and `CbrainNotice` are first initialized. So I added a line to make sure they're loaded first.

Now all tests run properly even in random order.