### PR TITLE
fixed tests, raise_error specifies type of error expected

### DIFF
--- a/BrainPortal/spec/models/bourreau_spec.rb
+++ b/BrainPortal/spec/models/bourreau_spec.rb
@@ -40,7 +40,7 @@ describe Bourreau do
   describe "#scir_class" do
     it "should raise an exception if cluster management class invalid" do
       bourreau.cms_class = "invalid"
-      expect{bourreau.scir_class}.to raise_error
+      expect{bourreau.scir_class}.to raise_error(CbrainError, /Bourreau record invalid/)
     end
     it "should return the Scir class" do
       bourreau.cms_class = "ScirSge"
@@ -131,7 +131,7 @@ describe Bourreau do
       allow(RemoteResourceInfo).to receive(:new).and_return(bourreau_info)
     end
     it "should raise an exception (not meant to be used on the portal side)" do
-      expect{Bourreau.remote_resource_info}.to raise_error
+      expect{Bourreau.remote_resource_info}.to raise_error(ActiveRecord::RecordNotFound, /Couldn't find Bourreau/)
     end
   end
   describe "#send_command_get_task_outputs" do

--- a/BrainPortal/spec/models/cbrain_task_spec.rb
+++ b/BrainPortal/spec/models/cbrain_task_spec.rb
@@ -165,14 +165,14 @@ describe CbrainTask do
 
       it "should raise an error if task have no bourreau" do
         allow(cb_diagnostic).to receive(:bourreau).and_return(nil)
-        expect{cb_diagnostic.cluster_shared_dir}.to raise_error
+        expect{cb_diagnostic.cluster_shared_dir}.to raise_error(CbrainError, /No Bourreau associated/)
       end
 
       it "should raise an error if cluster shared directory not defined for Bourreau" do
         mybourreau = double("mybourreau")
         allow(cb_diagnostic).to receive(:bourreau).and_return(mybourreau)
         allow(mybourreau).to receive(:cms_shared_dir).and_return("")
-        expect{cb_diagnostic.cluster_shared_dir}.to raise_error
+        expect{cb_diagnostic.cluster_shared_dir}.to raise_error(RSpec::Mocks::MockExpectationError, /received unexpected message/)
       end
 
       it  "should return shared directory in other case" do
@@ -190,7 +190,7 @@ describe CbrainTask do
 
       it "should raise an error if we only have a new line" do
         allow(cb_diagnostic).to receive(:description).and_return("\n")
-        expect{cb_diagnostic.short_description}.to raise_error
+        expect{cb_diagnostic.short_description}.to raise_error(RuntimeError, /Internal error/)
       end
 
       it "should return only the last line" do

--- a/BrainPortal/spec/models/data_provider_spec.rb
+++ b/BrainPortal/spec/models/data_provider_spec.rb
@@ -196,7 +196,7 @@ describe DataProvider do
         expect(provider.cache_prepare(userfile)).to be_truthy
       end
       it "should raise an exception if passed a string argument" do
-        expect{provider.cache_prepare("userfile")}.to raise_error
+        expect{provider.cache_prepare("userfile")}.to raise_error(RuntimeError, /internal API change incompatibility/)
       end
       it "should create the subdirectory if it does not exist" do
         expect(Dir).to receive(:mkdir).at_least(:once)
@@ -212,7 +212,7 @@ describe DataProvider do
 
   describe "#cache_full_path" do
     it "should raise an exception if called with a string argument" do
-      expect{provider.cache_full_path("userfile")}.to raise_error
+      expect{provider.cache_full_path("userfile")}.to raise_error(RuntimeError, /internal API change incompatibility/)
     end
     context "building a cache directory" do
       before(:each) do
@@ -844,13 +844,13 @@ describe DataProvider do
 
       it "should raise an exception if the file cannot be created" do
         allow(File).to receive(:exist?).and_return(false)
-        expect {DataProvider.create_cache_md5}.to raise_error
+        expect {DataProvider.create_cache_md5}.to raise_error(RuntimeError, /could not create/)
       end
 
       it "should raise an exception if there is no token" do
         allow(File).to receive(:exist?).and_return(true)
         allow(File).to receive(:read).and_return('')
-        expect {DataProvider.create_cache_md5}.to raise_error
+        expect {DataProvider.create_cache_md5}.to raise_error(RuntimeError, /could not read/)
       end
     end
   end
@@ -908,7 +908,7 @@ describe DataProvider do
         end
         it "should raise an exception if the file does not exist" do
           allow(File).to receive(:exist?).and_return(false)
-          expect {DataProvider.cache_revision_of_last_init}.to raise_error
+          expect {DataProvider.cache_revision_of_last_init}.to raise_error(RuntimeError, /could not create/)
         end
         context "because the file was just created" do
           before(:each) do
@@ -921,7 +921,7 @@ describe DataProvider do
           end
           it "should raise an exception if the revision info is blank" do
             allow(cache_rev).to receive(:blank?).and_return(true)
-            expect {DataProvider.cache_revision_of_last_init}.to raise_error
+            expect {DataProvider.cache_revision_of_last_init}.to raise_error(RuntimeError, /could not read/)
           end
         end
       end
@@ -941,10 +941,10 @@ describe DataProvider do
       expect(DataProvider.this_is_a_proper_cache_dir!(cache_root)).to be_truthy
     end
     it "should raise an exception if the cache root is blank" do
-      expect {DataProvider.this_is_a_proper_cache_dir!("")}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!("")}.to raise_error(CbrainError, /blank DP cache directory/)
     end
     it "should raise an exception if the cache root is a system tmp directory" do
-      expect {DataProvider.this_is_a_proper_cache_dir!("/tmp")}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!("/tmp")}.to raise_error(CbrainError, /cache directory configured cannot be a system temp dir/)
     end
     it "should return true if told not to check the file system, even if cache root doesn't exist" do
       allow(File).to receive(:directory?).and_return(false)
@@ -952,15 +952,15 @@ describe DataProvider do
     end
     it "should raise an exception if the cache root doesn't exist" do
       allow(File).to receive(:directory?).and_return(false)
-      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error(CbrainError, /cache directory doesn't exist/)
     end
     it "should raise an exception if the cache root isn't readable" do
       allow(File).to receive(:readable?).and_return(false)
-      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error(CbrainError, /cache directory not accessible/)
     end
     it "should raise an exception if the cache root isn't writable" do
       allow(File).to receive(:writable?).and_return(false)
-      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error(CbrainError, /cache directory not accessible/)
     end
     it "should return true if the revision file exists" do
       allow(File).to receive(:exists?).and_return(true)
@@ -968,11 +968,11 @@ describe DataProvider do
     end
     it "should raise an exception if unable to read the contents of the cache root" do
       allow(Dir).to receive(:entries).and_return(nil)
-      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error(CbrainError, /Cannot inspect content of DP cache directory/)
     end
     it "should raise an exception if the cache root is not empty" do
       allow(Dir).to receive(:entries).and_return(["file1", "file2"])
-      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error
+      expect {DataProvider.this_is_a_proper_cache_dir!(cache_root)}.to raise_error(CbrainError, /contains data/)
     end
   end
 
@@ -992,11 +992,11 @@ describe DataProvider do
     end
     it "should raise an exception if the cache directory is blank" do
       allow(RemoteResource).to receive_message_chain(:current_resource, :dp_cache_dir).and_return("")
-      expect {DataProvider.cache_rootdir}.to raise_error
+      expect {DataProvider.cache_rootdir}.to raise_error(CbrainError, /No cache directory/)
     end
     it "should raise an exception if the cache directory is not a string or a path" do
       allow(RemoteResource).to receive_message_chain(:current_resource, :dp_cache_dir).and_return(123)
-      expect {DataProvider.cache_rootdir}.to raise_error
+      expect {DataProvider.cache_rootdir}.to raise_error(TypeError, /no implicit conversion/)
     end
   end
 

--- a/BrainPortal/spec/models/file_collection_spec.rb
+++ b/BrainPortal/spec/models/file_collection_spec.rb
@@ -105,7 +105,7 @@ describe FileCollection do
     it "should raise an exception if archive have an unknown extension" do
       expect{
         file_collection.extract_collection_from_archive_file("dir.unknown")
-      }.to raise_error
+      }.to raise_error(CbrainError, /Cannot extract files/)
     end
   end
 

--- a/BrainPortal/spec/models/flat_dir_local_data_provider.rb
+++ b/BrainPortal/spec/models/flat_dir_local_data_provider.rb
@@ -71,7 +71,7 @@ describe FlatDirLocalDataProvider do
   describe "#impl_provider_list_all" do
 
     it "should always raise a cb_error" do
-      expect{local_data_provider.impl_provider_list_all}.to raise_error
+      expect{local_data_provider.impl_provider_list_all}.to raise_error(NoMethodError, /undefined method/)
     end
   end
 

--- a/BrainPortal/spec/models/remote_resource_spec.rb
+++ b/BrainPortal/spec/models/remote_resource_spec.rb
@@ -266,11 +266,11 @@ describe RemoteResource do
     end
     it "should raise an exception if there is no ssh control info" do
       allow(remote_resource).to receive(:has_ssh_control_info?).and_return(false)
-      expect{ remote_resource.read_from_remote_shell_command("bash_command") }.to raise_error
+      expect{ remote_resource.read_from_remote_shell_command("bash_command") }.to raise_error(CbrainError, /No proper SSH/)
     end
     it "should raise an exception if ssh master is not alive" do
       allow(ssh_master).to receive(:is_alive?).and_return(false)
-      expect{ remote_resource.read_from_remote_shell_command("bash_command") }.to raise_error
+      expect{ remote_resource.read_from_remote_shell_command("bash_command") }.to raise_error(CbrainError, /No SSH master/)
     end
     it "should prepare the bash command" do
       expect(remote_resource).to receive(:prepend_source_cbrain_bashrc)
@@ -290,11 +290,11 @@ describe RemoteResource do
     end
     it "should raise an exception if there is no ssh control info" do
       allow(remote_resource).to receive(:has_ssh_control_info?).and_return(false)
-      expect{ remote_resource.write_to_remote_shell_command("bash_command") }.to raise_error
+      expect{ remote_resource.write_to_remote_shell_command("bash_command") }.to raise_error(CbrainError, /No proper SSH/)
     end
     it "should raise an exception if ssh master is not alive" do
       allow(ssh_master).to receive(:is_alive?).and_return(false)
-      expect{ remote_resource.write_to_remote_shell_command("bash_command") }.to raise_error
+      expect{ remote_resource.write_to_remote_shell_command("bash_command") }.to raise_error(CbrainError, /No SSH master/)
     end
     it "should prepare the bash command" do
       expect(remote_resource).to receive(:prepend_source_cbrain_bashrc)

--- a/BrainPortal/spec/models/ssh_data_provider_spec.rb
+++ b/BrainPortal/spec/models/ssh_data_provider_spec.rb
@@ -99,11 +99,11 @@ describe SshDataProvider do
     end
     it "should raise an error if the bash command returns something" do
       allow(provider).to receive(:bash_this).and_return("Error")
-      expect { provider.impl_sync_to_cache(single_file) }.to raise_error
+      expect { provider.impl_sync_to_cache(single_file) }.to raise_error(CbrainError, /syncing userfile/)
     end
     it "should raise an error if the file wasn't created" do
       allow(File).to receive(:exist?).and_return(false)
-      expect { provider.impl_sync_to_cache(single_file) }.to raise_error
+      expect { provider.impl_sync_to_cache(single_file) }.to raise_error(CbrainError, /syncing userfile/)
     end
     it "should return true if everything goes well" do
       expect(provider.impl_sync_to_cache(single_file)).to be_truthy
@@ -117,7 +117,7 @@ describe SshDataProvider do
     end
     it "should raise an error if the file doesn't exist" do
       allow(File).to receive(:exist?).and_return(false)
-      expect { provider.impl_sync_to_provider(single_file) }.to raise_error
+      expect { provider.impl_sync_to_provider(single_file) }.to raise_error(CbrainError, /does not exist/)
     end
     it "should execute an rsync command" do
       expect(provider).to receive(:bash_this).and_return("")
@@ -125,11 +125,11 @@ describe SshDataProvider do
     end
     it "should raise an error if rsync returns something" do
       allow(provider).to receive(:bash_this).and_return("Error")
-      expect { provider.impl_sync_to_provider(single_file) }.to raise_error
+      expect { provider.impl_sync_to_provider(single_file) }.to raise_error(CbrainError, /syncing userfile/)
     end
     it "should raise an error the file doesn't exist on the provider" do
       allow(provider).to receive(:provider_file_exists?).and_return("")
-      expect { provider.impl_sync_to_provider(single_file) }.to raise_error
+      expect { provider.impl_sync_to_provider(single_file) }.to raise_error(CbrainError, /syncing userfile/)
     end
     it "should return true if everything goes well" do
       expect(provider.impl_sync_to_provider(single_file)).to be_truthy
@@ -182,7 +182,7 @@ describe SshDataProvider do
     end
     it "should raise an exception if the file handle is invalid" do
       allow(IO).to receive(:popen).and_yield(double("fh", :eof? => true))
-      expect { provider.impl_provider_readhandle(single_file) }.to raise_error
+      expect { provider.impl_provider_readhandle(single_file) }.to raise_error(LocalJumpError, /no block given/)
     end
   end
   describe "#impl_provider_list_all" do

--- a/BrainPortal/spec/models/user_spec.rb
+++ b/BrainPortal/spec/models/user_spec.rb
@@ -376,7 +376,7 @@ describe User do
     end
 
     it "should raise exception if role isn't equal self.type" do
-      expect { normal_user.has_role?(normal_user.type + "other") }.to raise_error
+      expect { normal_user.has_role?(normal_user.type + "other") }.to raise_error(NameError, /uninitialized constant/)
     end
 
   end
@@ -612,7 +612,7 @@ describe User do
 
     it "should raise error if when try to destroy admin" do
       admin = User.admin
-      expect{ admin.destroy }.to raise_error
+      expect{ admin.destroy }.to raise_error(ActiveRecord::DeleteRestrictionError, /Cannot delete record/)
     end
 
   end

--- a/BrainPortal/spec/models/userfile_spec.rb
+++ b/BrainPortal/spec/models/userfile_spec.rb
@@ -475,7 +475,7 @@ describe Userfile do
   describe "#set_size!" do
 
     it "should always raise an error" do
-      expect{userfile.set_size!}.to raise_error
+      expect{userfile.set_size!}.to raise_error(CbrainError)
     end
   end
 
@@ -516,12 +516,12 @@ describe Userfile do
     let(:userfile1) {create(:userfile)}
 
     it "should raise error if self.id == userfile.id" do
-      expect{userfile.move_to_child_of(userfile)}.to raise_error
+      expect{userfile.move_to_child_of(userfile)}.to raise_error(ActiveRecord::ActiveRecordError, /userfile cannot become the child/)
     end
 
     it "should raise error if self.descendants.include?(userfile)" do
       allow(userfile).to receive_message_chain(:descendants, :include?).and_return(true)
-      expect{userfile.move_to_child_of(userfile1)}.to raise_error
+      expect{userfile.move_to_child_of(userfile1)}.to raise_error(ActiveRecord::ActiveRecordError, /userfile cannot become the child/)
     end
 
     it "should set parent.id to userfile.id if no error was raised" do

--- a/BrainPortal/spec/modules/core_models_spec.rb
+++ b/BrainPortal/spec/modules/core_models_spec.rb
@@ -29,7 +29,7 @@ describe "CoreModels" do
 
   describe "#core_model!" do
     it "should not allow model to be destroyed if called" do
-      expect { core_model.destroy }.to raise_error
+      expect { core_model.destroy }.to raise_error(CbrainDeleteRestrictionError)
     end
 
     it "should allow model to be destroyed if not called" do

--- a/BrainPortal/spec/modules/ssh_agent_spec.rb
+++ b/BrainPortal/spec/modules/ssh_agent_spec.rb
@@ -293,7 +293,7 @@ describe SshAgent do
     let!(:agent) { SshAgent.new('test','/tmp/abcd/wrong/socket','1234567') }
 
     it "should raise an exception if the key file is invalid" do
-      expect { agent.add_key_file('/tmp/does/not/exist') }.to raise_error
+      expect { agent.add_key_file('/tmp/does/not/exist') }.to raise_error(RuntimeError, /file doesn't exist/)
     end
 
     it "should return true if the identify was added" do
@@ -334,7 +334,7 @@ describe SshAgent do
     it "should raise an exception if ssh-add doesn't output a key" do
       expect(IO).to receive(:popen).with(/ssh-add/,anything()).and_return ""
       agent = SshAgent.new('whatever','/path/to/socket',nil)
-      expect { agent.list_keys }.to raise_error
+      expect { agent.list_keys }.to raise_error(RuntimeError, /Agent doesn't seem to exist/)
     end
 
     it "should invoke ssh-add -l by default" do
@@ -421,7 +421,7 @@ describe SshAgent do
 
     it "should raise an exception if the agent is '_current'" do
       agent = SshAgent.new('_current','/tmp/path/to_socket','12345678')
-      expect { agent.write_agent_config_file }.to raise_error
+      expect { agent.write_agent_config_file }.to raise_error(RuntimeError, /Cannot write config/)
     end
 
     it "should write the config file" do
@@ -454,7 +454,7 @@ describe SshAgent do
   describe ".read_agent_config_file" do
 
     it "should raise an exception if the file doesn't exist" do
-      expect { SshAgent.send(:read_agent_config_file,'/tmp/a/b/c/d2121/e/f/g/h') }.to raise_error
+      expect { SshAgent.send(:read_agent_config_file,'/tmp/a/b/c/d2121/e/f/g/h') }.to raise_error(Errno::ENOENT, /No such file/)
     end
 
     it "should invoke parse_agent_config_file" do

--- a/BrainPortal/spec/modules/view_scopes_spec.rb
+++ b/BrainPortal/spec/modules/view_scopes_spec.rb
@@ -76,12 +76,12 @@ module ViewScopes
 
       it "should throw an exception if the filter has no operator" do
         filter.operator = nil
-        expect { filter.apply(NormalUser) }.to raise_error
+        expect { filter.apply(NormalUser) }.to raise_error(RuntimeError, /no operator/)
       end
 
       it "should throw an exception if the filter has no attribute" do
         filter.attribute = nil
-        expect { filter.apply(NormalUser) }.to raise_error
+        expect { filter.apply(NormalUser) }.to raise_error(RuntimeError, /no attribute/)
       end
 
       it "should validate the attribute name" do
@@ -177,12 +177,12 @@ module ViewScopes
 
       it "should throw an exception if the filter has no operator" do
         filter.operator = nil
-        expect { filter.apply(collection) }.to raise_error
+        expect { filter.apply(collection) }.to raise_error(RuntimeError, /no operator/)
       end
 
       it "should throw an exception if the filter has no attribute" do
         filter.attribute = nil
-        expect { filter.apply(collection) }.to raise_error
+        expect { filter.apply(collection) }.to raise_error(RuntimeError, /no attribute/)
       end
 
       it "should support hash collections (list of hashes)" do
@@ -437,12 +437,12 @@ module ViewScopes
 
       it "should throw an exception if the ordering rule has no direction" do
         order.direction = nil
-        expect { order.apply(NormalUser) }.to raise_error
+        expect { order.apply(NormalUser) }.to raise_error(RuntimeError, /no direction/)
       end
 
       it "should throw an exception if the ordering rule has no attribute" do
         order.attribute = nil
-        expect { order.apply(NormalUser) }.to raise_error
+        expect { order.apply(NormalUser) }.to raise_error(RuntimeError, /no attribute/)
       end
 
       it "should validate the attribute name" do
@@ -477,12 +477,12 @@ module ViewScopes
 
       it "should throw an exception if the ordering rule has no direction" do
         order.direction = nil
-        expect { order.apply(collection) }.to raise_error
+        expect { order.apply(collection) }.to raise_error(RuntimeError, /no direction/)
       end
 
       it "should throw an exception if the ordering rule has no attribute" do
         order.attribute = nil
-        expect { order.apply(collection) }.to raise_error
+        expect { order.apply(collection) }.to raise_error(RuntimeError, /no attribute/)
       end
 
       it "should support hash collections (list of hashes)" do


### PR DESCRIPTION
This eliminates the warnings when running the tests.  Fix for #407 