### PR TITLE
Remove auto alive-checking of DP's, replace with manual checks

### DIFF
--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -185,10 +185,18 @@ class DataProvidersController < ApplicationController
     end
   end
 
-  # Returns information about the aliveness of +dataprovider+.
+  # Returns information about the aliveness of +dataprovider+. First checks if a result for this
+  #+dataprovider+ has been cached, if not it checks directly and updates the cache
   def is_alive
     @provider = DataProvider.find_accessible_by_user(params[:id], current_user)
-    is_alive =  @provider.is_alive?
+
+    if @provider.alive_cached_valid?
+      is_alive = @provider.meta[:alive_cached]
+    else
+      is_alive = @provider.is_alive?
+      @provider.meta[:alive_cached_time] = Time.now.to_i
+      @provider.meta[:alive_cached] = is_alive
+    end
 
     respond_to do |format|
       format.html { render :text => red_if( ! is_alive, "<span>Yes</span>".html_safe, "No" ) }

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -190,13 +190,7 @@ class DataProvidersController < ApplicationController
   def is_alive
     @provider = DataProvider.find_accessible_by_user(params[:id], current_user)
 
-    if @provider.alive_cached_valid?
-      is_alive = @provider.meta[:alive_cached]
-    else
-      is_alive = @provider.is_alive?
-      @provider.meta[:alive_cached_time] = Time.now.to_i
-      @provider.meta[:alive_cached] = is_alive
-    end
+    is_alive = @provider.is_alive_with_caching?
 
     respond_to do |format|
       format.html { render :text => red_if( ! is_alive, "<span>Yes</span>".html_safe, "No" ) }

--- a/BrainPortal/app/helpers/ajax_widget_helper.rb
+++ b/BrainPortal/app/helpers/ajax_widget_helper.rb
@@ -106,30 +106,6 @@ module AjaxWidgetHelper
     "<div #{atts}></div>".html_safe
   end
 
-  # Staggered load elements request their content one at a time.
-  #
-  # Options:
-  # [:error_message] HTML to display if the request fails.
-  # [:replace] whether the entire element should be replaced (as
-  #            opposed to just the content).
-  def staggered_loading(element, url, options={}, &block)
-    options_setup("staggered_loader", options)
-    options["data-url"] = url
-
-    atts = options.to_html_attributes
-    if block_given?
-      initial_content=capture(&block)
-    else
-      initial_content = ""
-    end
-
-    html = "<#{element} #{atts}>"
-    html += h(initial_content)
-    html += "</#{element}>"
-
-    html.html_safe
-  end
-
   ###############################################################
   # Creates an html element which will have its or another element's
   # content updated when it is clicked on
@@ -149,8 +125,7 @@ module AjaxWidgetHelper
   # and the body will be replaced with the content of the html at /data_providers
   # when you click on the span
   #
-  # replace can be used to specify a selector (jQuery) to find the element(s)
-  # replace
+  # replace can be used to specify an id of an html element to replace
   ###############################################################
   def on_click_ajax_replace(options,html_opts={},&block)
     url = options[:url]

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -337,31 +337,6 @@ class DataProvider < ActiveRecord::Base
     return impl_is_alive? ? true : false
   end
 
-  # This method checks whether cache is still good, lasts 1 minute
-  def alive_cached_valid?
-    valid = (Time.now.to_i - self.meta[:alive_cached_time] <= 60)
-    # Check that the alive cache is actually a boolean
-    if !(self.meta[:alive_cached] == true || self.meta[:alive_cached] == false)
-      valid = false
-    end
-    valid
-  rescue
-    false
-  end
-
-  # Checks whether DP is alive, but hits the cache first if it's good
-  def is_alive_with_caching?
-    if self.alive_cached_valid?
-      return self.meta[:alive_cached]
-    else
-      # real check, cache result
-      alive = self.is_alive?
-      self.meta[:alive_cached] = alive
-      self.meta[:alive_cached_time] = Time.now.to_i
-      return alive
-    end
-  end
-
   # Raises an exception if is_alive? is +false+, otherwise
   # it returns +true+.
   def is_alive!
@@ -1046,6 +1021,31 @@ class DataProvider < ActiveRecord::Base
     raise "Internal error: can't parse description!?!" unless description =~ /^(.+\n?)/ # the . doesn't match \n
     header = Regexp.last_match[1].strip
     header
+  end
+
+  # Checks whether DP is alive, but hits the cache first if it's good
+  def is_alive_with_caching?
+    if self.alive_cached_valid?
+      return self.meta[:alive_cached]
+    else
+      # real check, cache result
+      alive = self.is_alive?
+      self.meta[:alive_cached] = alive
+      self.meta[:alive_cached_time] = Time.now.to_i
+      return alive
+    end
+  end
+
+  # This method checks whether cache is still good, lasts 1 minute
+  def alive_cached_valid?
+    valid = (Time.now.to_i - self.meta[:alive_cached_time] <= 60)
+    # Check that the alive cache is actually a boolean
+    if !(self.meta[:alive_cached] == true || self.meta[:alive_cached] == false)
+      valid = false
+    end
+    valid
+  rescue
+    false
   end
 
 

--- a/BrainPortal/app/views/data_providers/_data_providers_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_data_providers_table.html.erb
@@ -33,6 +33,8 @@
     <%= link_to "Create New Data Provider", new_data_provider_path, :class => "button menu_button" %>
   <% end %>
 
+  <%= link_to "Check All", nil, {:class => "button check_all_dp",} %>
+
   <%= link_to "User Access Report",
              {:controller  => :data_providers, :action  => :dp_access},
               :datatype  => 'script', :class  => "button"

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -76,8 +76,24 @@
   %>
 
   <% t.column("Alive?", :alive) do |dp| %>
-    <% if dp.online? %>
-      <div id="<%= "alive" + h(dp.id) %>"><%= html_colorize("(...)","magenta") %></div>
+      <% if dp.online? %>
+        <% if dp.alive_cached_valid? %>
+          <%= red_if( !dp.meta[:alive_cached], "Yes", "No") %>
+        <% else %>
+          <span class="dp_alive_btn" id="<%= "alive" + h(dp.id) %>">
+          <%= on_click_ajax_replace( { :element   => "span",
+                                                     :url           => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
+                                                     :replace   => "alive" + h(dp.id)
+                                                   },
+                                                   {
+                                                     :before  => "<span class='loading_message'>Loading...</span>",
+                                                     :class     => "dp_alive_btn"
+                                                   }
+                                                  ) do %>
+            <a href="#" class="action_link">Check</a>
+          <% end %>
+          </span>
+        <% end %>
     <% else %>
       No
     <% end %>
@@ -113,19 +129,6 @@
         <%= link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link' %>
       <% end %>
 
-      <% if dp.online? %>
-        <%= on_click_ajax_replace( { :element   => "div",
-                                                   :url           => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
-                                                   :replace   => "alive" + h(dp.id)
-                                                 },
-                                                 {
-                                                   :before  => "<div class='loading_message'>Loading...</div>",
-                                                   :class     => "dp_alive_btn"
-                                                 }
-                                                ) do %>
-          <a href="#" class="action_link">Check</a>
 
-      <% end %>
-    <% end %>
   <% end %>
 <% end %>

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -76,29 +76,29 @@
   %>
 
   <% t.column("Alive?", :alive) do |dp| %>
-      <% if dp.online? %>
-        <% if dp.alive_cached_valid? %>
-          <%= red_if( !dp.meta[:alive_cached], "Yes", "No") %>
-        <% else %>
-          <span class="dp_alive_btn" id="<%= "alive" + h(dp.id) %>">
+    <% if dp.online? %>
+      <% if dp.alive_cached_valid? %>
+        <%= red_if( !dp.is_alive_with_caching?, "Yes", "No") %>
+      <% else %>
+        <span class="dp_alive_btn" id="<%= "alive" + h(dp.id) %>">
           <%= on_click_ajax_replace( { :element   => "span",
-                                                     :url           => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
-                                                     :replace   => "alive" + h(dp.id)
-                                                   },
-                                                   {
-                                                     :before  => "<span class='loading_message'>Loading...</span>",
-                                                     :class     => "dp_alive_btn"
-                                                   }
-                                                  ) do %>
+                                       :url       => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
+                                       :replace   => "alive" + h(dp.id)
+                                     },
+                                     {
+                                       :before  => "<span class='loading_message'>Loading...</span>",
+                                       :class     => "dp_alive_btn"
+                                     }
+                                   ) do %>
             <a href="#" class="action_link">Check</a>
           <% end %>
-          </span>
-        <% end %>
+        </span>
+      <% end %>
     <% else %>
       No
     <% end %>
-
   <% end %>
+
   <%
     t.column("Files", :files) do |dp|
       file_count = Userfile.find_all_accessible_by_user(current_user, :conditions => { :data_provider_id => dp.id }).count
@@ -128,7 +128,5 @@
       <% if dp.is_browsable?(current_user) && dp.can_be_accessed_by?(current_user) && dp.online? %>
         <%= link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link' %>
       <% end %>
-
-
-  <% end %>
+    <% end %>
 <% end %>

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -77,7 +77,7 @@
 
   <% t.column("Alive?", :alive) do |dp| %>
     <% if dp.online? %>
-      <div class="dp_alive" data-url=<%=url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id) %> id=<%= "alive" + h(dp.id) %>><%= html_colorize("(...)","magenta") %></div>
+      <div id="<%= "alive" + h(dp.id) %>"><%= html_colorize("(...)","magenta") %></div>
     <% else %>
       No
     <% end %>
@@ -107,24 +107,25 @@
       :sortable => true
     ) { |dp| overlay_description(dp.description) }
 
-    t.column("Operations", :operations) do |dp|
-      if dp.is_browsable?(current_user) && dp.can_be_accessed_by?(current_user) && dp.online?
-        link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link'
-      end
+    %>
+    <% t.column("Operations", :operations) do |dp| %>
+      <% if dp.is_browsable?(current_user) && dp.can_be_accessed_by?(current_user) && dp.online? %>
+        <%= link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link' %>
+      <% end %>
 
-      if dp.online?
-        on_click_ajax_replace( { :element   => "div",
-                                            :url          => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
-                                            :replace   => "alive" + h(dp.id)
-                                          },
-                                          {
-                                            :before  => "<div class='loading_message'>Loading...</div>",
-                                            :class     => 'action_link'
-                                          }
-                                        ) do
-          %><a class="action_link">check</a><%
+      <% if dp.online? %>
+        <%= on_click_ajax_replace( { :element   => "div",
+                                                   :url           => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
+                                                   :replace   => "alive" + h(dp.id)
+                                                 },
+                                                 {
+                                                   :before  => "<div class='loading_message'>Loading...</div>",
+                                                   :class     => "dp_alive_btn"
+                                                 }
+                                                ) do %>
+          <a href="#" class="action_link">Check</a>
 
-      end
-    end
-  end
-end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 -%>
 
@@ -76,15 +76,19 @@
   %>
 
   <% t.column("Alive?", :alive) do |dp| %>
-    <% if dp.online? %>
-      <%= staggered_loading "span", url_for(:action  => :is_alive, :id  => dp.id), :error_message  => "<span class=\"warning\">???</span>" do %>
-        <span class="loading_message"><%= html_colorize("(...)","magenta") %></span>
+    <%= on_click_ajax_replace( { :element  => "div",
+                                                :url      => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id)
+                                             },
+                                             {
+                                               :before   => "<div class='loading_message'>Loading...</div>",
+                                               :class => "dp_alive"
+                                             }
+                                            ) do %>
+      <a>check</a>
       <% end %>
-    <% else %>
-      No
-    <% end %>
-  <% end %>
 
+
+  <% end %>
   <%
     t.column("Files", :files) do |dp|
       file_count = Userfile.find_all_accessible_by_user(current_user, :conditions => { :data_provider_id => dp.id }).count

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -76,17 +76,11 @@
   %>
 
   <% t.column("Alive?", :alive) do |dp| %>
-    <%= on_click_ajax_replace( { :element  => "div",
-                                                :url      => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id)
-                                             },
-                                             {
-                                               :before   => "<div class='loading_message'>Loading...</div>",
-                                               :class => "dp_alive"
-                                             }
-                                            ) do %>
-      <a>check</a>
-      <% end %>
-
+    <% if dp.online? %>
+      <div class="dp_alive" data-url=<%=url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id) %> id=<%= "alive" + h(dp.id) %>><%= html_colorize("(...)","magenta") %></div>
+    <% else %>
+      No
+    <% end %>
 
   <% end %>
   <%
@@ -117,6 +111,20 @@
       if dp.is_browsable?(current_user) && dp.can_be_accessed_by?(current_user) && dp.online?
         link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link'
       end
+
+      if dp.online?
+        on_click_ajax_replace( { :element   => "div",
+                                            :url          => url_for(:controller => :data_providers, :action  => :is_alive, :id => dp.id),
+                                            :replace   => "alive" + h(dp.id)
+                                          },
+                                          {
+                                            :before  => "<div class='loading_message'>Loading...</div>",
+                                            :class     => 'action_link'
+                                          }
+                                        ) do
+          %><a class="action_link">check</a><%
+
+      end
     end
-  %>
-<% end %>
+  end
+end %>

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 */
 (function() {
@@ -64,7 +64,7 @@
     var current_target, new_content;
     var width, height;
 
-    if (target) { 
+    if (target) {
       new_content = $(data);
       if (target === "__OVERLAY__") {
         width = parseInt(options["width"], 10); // || 800);
@@ -79,13 +79,13 @@
         });
       } else {
         current_target = $(target);
-        
+
         if (options["replace"]) {
           current_target.replaceWith(new_content);
         } else {
           current_target.html(new_content);
         }
-        
+
         if (options["scroll_bottom"]) {
           current_target.scrollTop(current_target[0].scrollHeight);
         }
@@ -102,7 +102,7 @@
   //NOTE: DO NOT USE .live() or .delegate() in here.
   function load_behaviour(event) {
     var loaded_element = $(event.target);
-    
+
     /////////////////////////////////////////////////////////////////////
     //
     // UI Helper Methods see application_helper.rb for corresponding
@@ -111,7 +111,7 @@
     /////////////////////////////////////////////////////////////////////
 
     loaded_element.find(".scroll_bottom").each(function() {
-      $(this).scrollTop(this.scrollHeight); 
+      $(this).scrollTop(this.scrollHeight);
     });
 
     //All elements with the accordion class will be changed to accordions.
@@ -128,7 +128,7 @@
 
     loaded_element.find(".slider_field").each( function() {
       var slider_text_field = $(this).children().filter("input");
-      $(this).children().filter(".slider").slider({ 
+      $(this).children().filter(".slider").slider({
         change: function(event, ui) {
           $(slider_text_field).val(ui.value);
         }
@@ -142,12 +142,12 @@
     });
 
     loaded_element.find(".sortable_list ul, sortable_list li").disableSelection();
-     
+
     // Tab Bar, div's of type tabs become tab_bars
     // See TabBar class
     loaded_element.find(".tabs").tabs();
-    
-    
+
+
     // //Prevent forms where submit buttons decide behaviour
     // //from submitting on 'enter'.
     // loaded_element.find("form").each(function() {
@@ -158,13 +158,13 @@
     //     });
     //   }
     // });
-     
+
     loaded_element.find(".inline_text_field").each(function() {
       var inline_text_field = $(this);
       var data_type = inline_text_field.attr("data-type") || "script";
       var target = inline_text_field.attr("data-target");
       var method = inline_text_field.attr("data-method") || "POST";
-      
+
       var form = inline_text_field.children("form")
       .hide()
       .ajaxForm({
@@ -174,11 +174,11 @@
           modify_target(data, target);
         }
       });
-      
+
       var input_field = form.find(".inline_text_input");
       var text = inline_text_field.find(".current_text");
       var trigger = inline_text_field.find(inline_text_field.attr("data-trigger"));
-      
+
       var data_type = inline_text_field.attr("data-type") || "script";
       var target = inline_text_field.attr("data-target");
       var method = inline_text_field.attr("data-method") || "POST";
@@ -187,13 +187,13 @@
         text.hide();
         form.show();
         input_field.focus();
-        
+
         return false;
       });
-      
+
       form.focusout(function(event) {
         text.show();
-        form.hide(); 
+        form.hide();
       });
 
     });
@@ -210,12 +210,12 @@
       var button  = menu.closest(".button_with_drop_down");
       var keep_open = button.attr("data-open");
       if (keep_open !== "true") {
-        menu.hide(); 
+        menu.hide();
       }
     });
 
-    loaded_element.find(".button_with_drop_down > div.drop_down_menu").find(".hijacker_submit_button").click(function(e) { 
-      loaded_element.find(".drop_down_menu:visible").siblings(".button_menu").click();   
+    loaded_element.find(".button_with_drop_down > div.drop_down_menu").find(".hijacker_submit_button").click(function(e) {
+      loaded_element.find(".drop_down_menu:visible").siblings(".button_menu").click();
     });
 
 
@@ -230,16 +230,16 @@
       } else {
         loaded_element.find(".drop_down_menu:visible").hide();
         menu.show();
-      }  
+      }
     });
-     
-     
+
+
     /////////////////////////////////////////////////////////////////////
     //
     // Project button behaviour
     //
     /////////////////////////////////////////////////////////////////////
-    
+
     loaded_element.find(".project_button").each(function(event) {
       var project_button = $(this);
       var project_details = project_button.find(".project_button_details");
@@ -254,32 +254,32 @@
 
     }).mouseenter(function() {
       var project_button = $(this);
-      
+
       project_button.css("-webkit-transform", "scale(1.3)");
       project_button.css("-moz-transform", "scale(1.3)");
       project_button.css("-o-transform", "scale(1.3)");
       project_button.css("-ms-transform", "scale(1.3)");
     }).mouseleave(function() {
       var project_button = $(this);
-      
+
       project_button.css("-webkit-transform", "scale(1)");
       project_button.css("-moz-transform", "scale(1)");
       project_button.css("-o-transform", "scale(1)");
-      project_button.css("-ms-transform", "scale(1)");   
+      project_button.css("-ms-transform", "scale(1)");
     }).mousedown(function(event) {
       if (event.target.nodeName === "A") {
         return true;
       }
-      
+
       var project_button = $(this);
-      
+
       project_button.css("-webkit-transform", "scale(1.2)");
       project_button.css("-moz-transform", "scale(1.2)");
       project_button.css("-o-transform", "scale(1.2)");
       project_button.css("-ms-transform", "scale(1.2)");
     }).mouseup(function() {
       var project_button = $(this);
-    
+
       project_button.css("-webkit-transform", "scale(1.1)");
       project_button.css("-moz-transform", "scale(1.1)");
       project_button.css("-o-transform", "scale(1.1)");
@@ -293,18 +293,18 @@
       var url = project_button.attr("data-href");
       var method = project_button.attr("data-method");
       var link = $("<a href=\"" + url + "\" data-method=\"" + method + "\"></a>");
-      
+
       link.appendTo("body");
       link.click();
     });
-    
-    
+
+
     /////////////////////////////////////////////////////////////////////
     //
     // Delayed loading of content
     //
     /////////////////////////////////////////////////////////////////////
-    
+
     function fetch_update(current_element, method, url, error_message, replace, data, scroll_bottom) {
       jQuery.ajax({
         type: method,
@@ -325,7 +325,7 @@
         },
         error: function(e) {
           if (!error_message) {
-            error_message = "<span class='loading_message'>Error loading element</span>"; 
+            error_message = "<span class='loading_message'>Error loading element</span>";
           }
           if (replace === "true") {
             current_element.replaceWith(error_message);
@@ -336,7 +336,7 @@
         timeout: 50000
       });
     }
-     
+
     function update_ajax_element(element) {
       var current_element = $(element);
       var method = current_element.attr("data-method") || "GET";
@@ -349,7 +349,7 @@
 
       if (data) data = jQuery.parseJSON(data);
       if (scroll_bottom === "false") scroll_bottom = false;
-        
+
       if (interval) {
         interval = parseInt(interval, 10) * 1000;
         setInterval(function() {
@@ -359,8 +359,8 @@
         fetch_update(current_element, method, url, error_message, replace, data, scroll_bottom);
       }
     }
-      
-      
+
+
     //See ajax_element() in application_helper.rb
     //The ajax element will have its contents loaded by the response from an
     //ajax request (so the element's conents will be loaded later with respect
@@ -374,7 +374,7 @@
       var button = $(this);
       var target = $(button.attr("data-target"));
       update_ajax_element(target);
-      
+
       return false;
     });
 
@@ -393,39 +393,6 @@
       });
     });
 
-    (function staggered_loading(index, element_array) {
-      if (index >= element_array.length) return;
-    
-      var current_element = $(element_array[index]);
-      var url = current_element.attr("data-url");
-      var error_message = current_element.attr("data-error");
-      var replace = current_element.attr("data-replace");
-      jQuery.ajax({
-        dataType: 'html',
-        url: url,
-        target: current_element,
-        timeout: 50000,
-        success: function(data) {
-            var new_content = $(data);
-            if (replace === "true") {
-              current_element.replaceWith(new_content);
-            } else {
-              current_element.html(new_content);
-            }
-            new_content.trigger("new_content");
-        },
-        error: function(e) {
-          if (!error_message) {
-            error_message = "<span class='loading_message'>Error loading element</span>";
-          }
-          current_element.html(error_message);
-        },
-        complete: function(e) {
-          staggered_loading(index+1, element_array);
-        }
-      });
-    })(0, loaded_element.find(".staggered_loader"));
-     
     //Overlay dialogs
     //See overlay_dialog_with_button()
     loaded_element.find(".overlay_dialog").each( function(index,element) {
@@ -434,17 +401,17 @@
       var dialog = enclosing_div.children(".overlay_content")
       var content_width = parseInt(dialog_link.attr('data-width'), 10);
       var content_height = parseInt(dialog_link.attr('data-height'), 10);
-    
-      dialog.dialog({ 
+
+      dialog.dialog({
         autoOpen: false,
         position: "center",
         width:  content_width  || 'auto',
         height: content_height || 'auto'
       });
-    
+
       dialog_link.click(function() {
         dialog.dialog('open');
-        return false; 
+        return false;
       });
     });
 
@@ -455,7 +422,7 @@
       var slide_effect = checkbox.attr("data-slide-effect");
       var slide_duration = checkbox.attr("data-slide-duration") || "fast";
       var invert = checkbox.attr("data-invert");
-      
+
       if (slide_duration !== "slow" && slide_duration !== "fast") {
         slide_duration = parseInt(slide_duration, 10);
       }
@@ -497,53 +464,53 @@
   $(function() {
     $("body").bind("new_content", load_behaviour);
     $("body").trigger("new_content");
-    
-    
+
+
     /////////////////////////////////////////////////////////////////////
     //
     // Ajax Pagination
     //
     /////////////////////////////////////////////////////////////////////
-    
+
     function get_page_parameter(query_string) {
       if (!query_string) query_string = "";
       var page = query_string.match(/(\?|\&)(page\=\d+)(\&)?/);
-      if (page) page = page[2]; 
+      if (page) page = page[2];
       if (!page) page = "";
-      
+
       return page;
     }
-    
+
     $(document).delegate(".page_links > a", "click", function() {
       var link = $(this);
       var url = link.attr("href");
       var page_param = get_page_parameter(url);
       var pagination_div = link.closest(".pagination");
-       
+
       url = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + page_param;
-      
+
       var title  = "";
       if (page_param) {
         var page_num = page_param.match(/\d+/);
         if (page_num) title = "Page: " + page_num[0];
       }
-      
+
       history.pushState({"paginating" : true}, "", url);
       $.ajax({
         url: url,
         dataType: "script"
       });
-      
+
       return false;
     });
-    
+
     $(window).bind("popstate", function(evt) {
       var state = evt.originalEvent.state || {};
-      
+
       if (state.paginating) {
         var url = location.href;
         var page_param = get_page_parameter(url);
-        
+
         url = window.location.protocol + "//" + window.location.host + window.location.pathname + "?" + page_param;
         $.ajax({
           url: url,
@@ -551,25 +518,25 @@
         });
       }
     });
-    
-    var filter_header_timeout = null; 
-    
+
+    var filter_header_timeout = null;
+
     $(document).delegate(".filter_header", "mouseenter", function() {
-      
+
       if (filter_header_timeout) {
         clearTimeout(filter_header_timeout);
         filter_header_timeout = null;
       }
-      
+
       var header = $(this);
       var target = $(header.attr("data-target"));
       var search = target.find(".filter_search");
-      
+
       filter_header_timeout = setTimeout(function() {
         target.show();
         search.focus();
       }, 500);
-      
+
       header.closest("th").mouseleave(function() {
         if (filter_header_timeout) {
           clearTimeout(filter_header_timeout);
@@ -578,38 +545,38 @@
         target.hide();
         return false;
       });
-      
+
       return false;
     });
-    
+
     $(document).delegate(".hover_open", "mouseenter", function() {
       var header = $(this);
       var target = $(header.attr("data-target"));
-      
+
       target.show();
       header.mouseleave(function() {
         target.hide();
         return false;
       });
-      
+
       return false;
      });
-    
+
     $(document).delegate(".filter_search", "input", function() {
       var text_field = $(this);
-      var cur_value  = text_field.val();   
+      var cur_value  = text_field.val();
       var filter_list = text_field.closest(".filter_list");
-      
+
       filter_list.find(".filter_item").each(function() {
         var filter = $(this);
         var link   = $(filter).find("a");
-        
+
         if (link.html().match(new RegExp("^" + cur_value, "i"))) {
           filter.show();
         } else {
           filter.hide();
         }
-      }); 
+      });
     }).delegate(".filter_search", "keypress", function(event) {
       if (event.keyCode === 13) {
         var text_field = $(this);
@@ -618,7 +585,7 @@
         return false;
       }
     });
-         
+
     $(document).delegate(".show_toggle", "click", function() {
       var current_element = $(this);
       var target_element = $(current_element.attr("data-target"));
@@ -626,17 +593,17 @@
       var slide_effect   = current_element.attr("data-slide-effect");
       var slide_duration   = current_element.attr("data-slide-duration");
       var current_text;
-      
+
       if (slide_duration !== 'slow' && slide_duration !== 'fast') {
         slide_duration = parseInt(slide_duration, 10);
       }
-      
+
       if (alternate_text) {
         current_text = current_element.html();
         current_element.attr("data-alternate-text", current_text);
         current_element.html(alternate_text);
       }
-      
+
       if (target_element.is(":visible")) {
         if (slide_effect) {
           target_element.slideUp(slide_duration);
@@ -651,7 +618,7 @@
         }
       }
 
-      return false;  
+      return false;
     });
 
     $(document).delegate(".inline_edit_field_link", "click", function() {
@@ -662,9 +629,9 @@
       var group = link.closest(".inline_edit_field_group");
 
       link.data("visible", !visible);
-      
+
       if (!alternate_text) alternate_text = "Cancel";
-      
+
       if (visible) {
         group.find(".inline_edit_field_default_text").show();
         group.find(".inline_edit_field_input").hide();
@@ -672,10 +639,10 @@
         group.find(".inline_edit_field_default_text").hide();
         group.find(".inline_edit_field_input").show();
       }
-      
+
       link.html(alternate_text);
       link.data("alternate-text", current_text);
-      
+
       return false;
     });
 
@@ -694,14 +661,14 @@
     $(document).delegate(".ajax_link", "ajax:success", function(event, data, status, xhr) {
       var link     = $(this);
       var target   = link.attr("data-target");
-      var datatype = link.attr("data-type"); 
+      var datatype = link.attr("data-type");
       var remove_target = link.attr("data-remove-target");
       var other_options = {};
 
       if (link.attr("data-width")) other_options["width"] = link.attr("data-width");
       if (link.attr("data-height")) other_options["height"] = link.attr("data-height");
       if (link.attr("data-replace")) other_options["replace"] = link.attr("data-replace");
-      
+
       if (remove_target) {
          $(remove_target).remove();
       } else if (datatype !== "script") {
@@ -726,7 +693,7 @@
         element.checked = header_box.prop('checked');
       });
     });
-    
+
     $(document).delegate(".select_master", "change", function() {
       var master_select = $(this);
       var select_class = master_select.attr("data-select-class");
@@ -739,7 +706,7 @@
         });
       });
     });
-    
+
     $(document).delegate(".request_on_change", "change", function() {
       var input_element        = $(this);
       var param_name           = input_element.attr("name");
@@ -757,29 +724,29 @@
 
       method = method || "GET";
       data_type = data_type || "html";
-      
+
       if (optgroup_change && optgroup_label && optgroup_label === old_onchange_value) {
         return false;
       } else {
         input_element.data("old-onchange-value",optgroup_label);
       }
-      
+
       if (target && update_text) {
         $(target).html(update_text);
       }
-      
+
       parameters[param_name] = current_value;
-       
+
       $.ajax({
         url       : url,
         type      : method,
         dataType  : data_type,
         success: function(data) {
-          modify_target(data, target);     
+          modify_target(data, target);
         },
         data: parameters
       });
-      
+
       return false;
     });
 
@@ -787,7 +754,7 @@
       var select = $(this);
       var commit_value = select.attr("data-commit");
       var form   = select.closest("form");
-      
+
       if (commit_value) {
         $("<input name=\"commit\" type=\"hidden\" value=\"" + commit_value +  "\">").appendTo(form);
       }
@@ -795,7 +762,7 @@
       form.submit();
     });
 
-    
+
     //html_tool_tip_code based on xstooltip provided by
     //http://www.texsoft.it/index.php?%20m=sw.js.htmltooltip&c=software&l=it
     $(document).delegate(".html_tool_tip_trigger", "mouseenter", function(event) {
@@ -804,22 +771,22 @@
       var tool_tip = $("#" + tool_tip_id);
       var offset_x = trigger.attr("data-offset-x") || '30';
       var offset_y = trigger.attr("data-offset-y") || '0';
-      
+
       var x = trigger.position().left + parseInt(offset_x, 10);
       var y = trigger.position().top  + parseInt(offset_y, 10);
-      
+
       // Fixed position bug.
       tool_tip.remove().appendTo(trigger.parent());
-      
+
       tool_tip.css('top',  y + 'px');
       tool_tip.css('left', x + 'px');
-      
+
       tool_tip.show();
     }).delegate(".html_tool_tip_trigger", "mouseleave", function(event) {
       var trigger = $(this);
       var tool_tip_id = trigger.attr("data-tool-tip-id");
       var tool_tip = $("#" + tool_tip_id);
-      
+
       tool_tip.hide();
     });
 
@@ -836,7 +803,7 @@
       var target = current_form.attr("data-target");
       var reset_form = current_form.attr("data-reset-form");
       var scroll_bottom = current_form.attr("data-scroll-bottom")
-      
+
       if (reset_form !== "false") {
         current_form.resetForm();
       }
@@ -850,7 +817,7 @@
     //key is pressed.
     $(document).delegate(".search_box", "keypress", function(event) {
       if (event.keyCode !== 13) return true;
-      
+
       var text_field = $(this);
       var data_type = text_field.attr("data-type") || "script";
       var url = text_field.attr("data-url");
@@ -872,7 +839,7 @@
 
       return false;
     });
-         
+
     //Allows for the creation of form submit buttons that can hijack
     //the form and send its contents elsewhere, changing the datatype,
     //target, http method as needed.
@@ -893,12 +860,12 @@
       data_type = data_type || enclosing_form.attr("data-type") || "html";
       url = url || enclosing_form.attr("action");
       method = method || enclosing_form.attr("data-method") || "POST";
-      
+
       if (button.attr("data-width")) other_options["width"] = button.attr("data-width");
       if (button.attr("data-height")) other_options["height"] = button.attr("data-height");
-      
-      data[submit_name] = submit_value;          
-   
+
+      data[submit_name] = submit_value;
+
       if (ajax_submit !== "false") {
         enclosing_form.ajaxSubmit({
           url: url,
@@ -931,12 +898,12 @@
 
       form.append(hidden_field);
       form.append(submit_button)
-      
+
       submit_button.click();
-      
+
       hidden_field.remove();
       submit_button.remove();
-      
+
       return false;
     });
 
@@ -953,21 +920,21 @@
       if (!parents) {
         parents = ""
       }
-      
+
       parents += " __cbrain_parent_" + onclick_elem.attr("id");
-      
+
       if (!replace_selector) {
         replace_elem = onclick_elem;
       } else {
         replace_elem = $("#" + replace_selector);
       }
-      
+
       if (!before_content) {
         before_content = "<span class='loading_message'>Loading...</span>";
       }
-      
+
       before_content = $(before_content);
-      
+
       if (replace_position === "after") {
         replace_elem.after(before_content);
       } else if (replace_position === "replace") {
@@ -979,13 +946,13 @@
       onclick_elem.removeClass("ajax_onclick_show_element");
       onclick_elem.unbind('click');
       onclick_elem.addClass("ajax_onclick_hide_element");
-      $.ajax({ 
+      $.ajax({
         type: 'GET',
         url: $(onclick_elem).attr("data-url"),
         dataType: 'html',
         success: function(data) {
           var new_data = $(data);
-          
+
           new_data.attr("data-parents", parents);
           new_data.addClass(parents);
           before_content.replaceWith(new_data);
@@ -995,7 +962,7 @@
         },
         error:function(e) {
           var new_data = $("Error occured while processing this request");
-          
+
           new_data.attr("data-parents", parents);
           new_data.addClass(parents);
           before_content.replaceWith(new_data);
@@ -1014,7 +981,7 @@
     function ajax_onclick_hide(event) {
       var onclick_elem = $(this);
       var parental_id = "__cbrain_parent_" + onclick_elem.attr("id");
-      
+
       $("." + parental_id).remove();
       onclick_elem.removeClass("ajax_onclick_hide_element");
       onclick_elem.unbind('click');
@@ -1024,14 +991,57 @@
     }
 
     $(document).delegate(".ajax_onclick_show_element", "click", ajax_onclick_show);
-    $(document).delegate(".ajax_onclick_hide_element", "click", ajax_onclick_hide);    
-    
-    // Allows to submit an interval of two dates, uses 
-    // datepicker of jquery-ui, see:  
+    $(document).delegate(".ajax_onclick_hide_element", "click", ajax_onclick_hide);
+
+
+    $(document).delegate(".check_all_dp", "click", function (event) {
+      var dp_status_elems = $("body").find(".dp_alive");
+
+      staggered_loading(0, dp_status_elems);
+      event.preventDefault();
+    });
+
+    function staggered_loading(index, element_array) {
+      if (index >= element_array.length) return;
+
+      var current_element = $(element_array[index]);
+      var url = current_element.attr("data-url");
+      var error_message = current_element.attr("data-error");
+      var replace = current_element.attr("data-replace");
+      jQuery.ajax({
+        dataType: 'html',
+        url: url,
+        target: current_element,
+        timeout: 50000,
+        success: function(data) {
+            var new_content = $(data);
+            if (replace === "true") {
+              current_element.replaceWith(new_content);
+            } else {
+              current_element.html(new_content);
+            }
+            new_content.trigger("new_content");
+        },
+        error: function(e) {
+          if (!error_message) {
+            error_message = "<span class='loading_message'>Error loading element</span>";
+          }
+          current_element.html(error_message);
+        },
+        complete: function(e) {
+          staggered_loading(index+1, element_array);
+        }
+      });
+    }
+
+
+
+    // Allows to submit an interval of two dates, uses
+    // datepicker of jquery-ui, see:
     // http://jqueryui.com/demos/datepicker/#date-range
     $(document).delegate('.daterangepicker', 'click', function (event) {
       var datepicker = $(this);
-      
+
       $(".daterangepicker").not(".hasDatepicker").datepicker({
         defaultDate: "+1w",
         changeMonth: true,
@@ -1040,16 +1050,16 @@
           var type  = datepicker.attr("data-datefieldtype");
           var option = type === "from" ? "minDate" : "maxDate";
           var dates;
-            
+
           instance = datepicker.data( "datepicker" ),
           date = $.datepicker.parseDate(
             instance.settings.dateFormat || $.datepicker._defaults.dateFormat,
             selectedDate,
             instance.settings
           );
-            
+
           dates = datepicker.parent().children(".daterangepicker");
-          
+
           $(dates).each(function(n) {
             if ($(this).attr("data-datefieldtype") !== type) {
               $(this).datepicker("option",option,date);
@@ -1057,20 +1067,20 @@
           });
         }
       });
-      
+
       datepicker.focus();
     });
-    
+
     $(document).delegate('.datepicker', 'click', function (event) {
       $(".datepicker").not(".hasDatepicker").datepicker({
         defaultDate: "+1w",
         changeMonth: true,
         dateFormat: "dd/mm/yy",
       });
-      
+
       $(this).focus();
     });
-     
+
   });
 
 })();

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -1019,9 +1019,6 @@
         timeout: 50000,
         success: function(data) {
           replace_elem.html(data);
-          replace_elem.trigger("new_content");
-          current_element.removeClass("dp_alive_btn");
-          current_element.hide();
         },
         error: function(e) {
           if (!error_message) {
@@ -1034,12 +1031,6 @@
         }
       });
     }
-
-    // Hides "Check" btn so that "Check All" doesn't re-check it
-    $(document).delegate(".dp_alive_btn", "click", function(event){
-      $(this).removeClass("dp_alive_btn");
-      $(this).hide();
-    });
 
     // Allows to submit an interval of two dates, uses
     // datepicker of jquery-ui, see:

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -993,7 +993,9 @@
     $(document).delegate(".ajax_onclick_show_element", "click", ajax_onclick_show);
     $(document).delegate(".ajax_onclick_hide_element", "click", ajax_onclick_hide);
 
-
+    // For checking the alive status of all DataProviders
+    // The staggered_loading function is called sequentially
+    // with the id of each DataProvider that is online
     $(document).delegate(".check_all_dp", "click", function (event) {
       var dp_status_elems = $("body").find(".dp_alive");
 
@@ -1008,10 +1010,11 @@
       var url = current_element.attr("data-url");
       var error_message = current_element.attr("data-error");
       var replace = current_element.attr("data-replace");
+      var target = current_element.attr("data-target")
       jQuery.ajax({
         dataType: 'html',
         url: url,
-        target: current_element,
+        target: target,
         timeout: 50000,
         success: function(data) {
             var new_content = $(data);
@@ -1033,8 +1036,6 @@
         }
       });
     }
-
-
 
     // Allows to submit an interval of two dates, uses
     // datepicker of jquery-ui, see:

--- a/BrainPortal/public/javascripts/userfiles.js
+++ b/BrainPortal/public/javascripts/userfiles.js
@@ -773,6 +773,20 @@ $(function() {
             $('#up-type').val(data).trigger('change.uf');
           });
         })
+        .undelegate('#up-file', 'change.uf.up-file-space')
+        .delegate('#up-file', 'change.uf.up-file-space', function (event) {
+          var file_name = $(this).val();
+          var includes_space = file_name.includes(" ");
+
+          $('#up-file-warn').text("Filename cannot contain spaces!")
+          $('#up-file-warn').css({
+            visibility: includes_space ? 'visible' : 'hidden'
+          })
+
+          upload_button
+            .prop('ui-state-disabled', includes_space)
+            .prop('disabled', includes_space);
+        })
         /* only activate the upload button if a file is selected */
         .undelegate('#up-file', 'change.uf.toggle-up-btn')
         .delegate(  '#up-file', 'change.uf.toggle-up-btn', function () {

--- a/BrainPortal/public/javascripts/userfiles.js
+++ b/BrainPortal/public/javascripts/userfiles.js
@@ -773,20 +773,6 @@ $(function() {
             $('#up-type').val(data).trigger('change.uf');
           });
         })
-        .undelegate('#up-file', 'change.uf.up-file-space')
-        .delegate('#up-file', 'change.uf.up-file-space', function (event) {
-          var file_name = $(this).val();
-          var includes_space = file_name.includes(" ");
-
-          $('#up-file-warn').text("Filename cannot contain spaces!")
-          $('#up-file-warn').css({
-            visibility: includes_space ? 'visible' : 'hidden'
-          })
-
-          upload_button
-            .prop('ui-state-disabled', includes_space)
-            .prop('disabled', includes_space);
-        })
         /* only activate the upload button if a file is selected */
         .undelegate('#up-file', 'change.uf.toggle-up-btn')
         .delegate(  '#up-file', 'change.uf.toggle-up-btn', function () {


### PR DESCRIPTION
There is now a "Check All" button at the top of the page which will replicate the previous behaviour, and individual Data Providers can be checked by clicking the "check" link within the table.

Fix for #368 