### PR TITLE
Added ability to clean caches by file type.

### DIFF
--- a/BrainPortal/app/controllers/bourreaux_controller.rb
+++ b/BrainPortal/app/controllers/bourreaux_controller.rb
@@ -368,6 +368,7 @@ class BourreauxController < ApplicationController
   # with date filtering if wanted.
   def rr_disk_usage
     date_filtering = params[:date_range] || {}
+    type_filtering = params[:types]      || []
 
     # Time:     Present ............................................................ Past
     # In Words: now .......... older_limit ..... younger_limit ................. long ago
@@ -398,7 +399,8 @@ class BourreauxController < ApplicationController
     stats_options  = { :users            => userlist,
                        :remote_resources => rrlist,
                        :accessed_before  => accessed_before,
-                       :accessed_after   => accessed_after
+                       :accessed_after   => accessed_after,
+                       :types            => type_filtering
                     }
 
     @report_stats    = ModelsReport.rr_usage_statistics(stats_options)
@@ -504,6 +506,9 @@ class BourreauxController < ApplicationController
       clean_cache = [ clean_cache ]
     end
 
+    # The fourth params is a list of Userfile types (strings)
+    typeslist        = Array(params[:types].presence || []) # Array(nil) is []
+
     # List of acceptable users
     userlist         = current_user.available_users.all
 
@@ -534,7 +539,7 @@ class BourreauxController < ApplicationController
       userids = userlist.keys.each { |uid| uid.to_s }.join(",")  # "uid,uid,uid"
       flash[:notice] += "\n" unless flash[:notice].blank?
       begin
-        remote_resource.send_command_clean_cache(userids,cleanup_older.ago,cleanup_younger.ago)
+        remote_resource.send_command_clean_cache(userids,typeslist,cleanup_older.ago,cleanup_younger.ago)
         flash[:notice] += "Sending cleanup command to #{remote_resource.name}."
       rescue
         flash[:notice] += "Could not contact #{remote_resource.name}."
@@ -545,7 +550,7 @@ class BourreauxController < ApplicationController
     date_filtering["relative_from"]             = cleanup_younger
     date_filtering["relative_to"]               = cleanup_older
 
-    redirect_to :action => :rr_disk_usage, :date_range => date_filtering
+    redirect_to :action => :rr_disk_usage, :date_range => date_filtering, :types => typeslist
 
   end
 

--- a/BrainPortal/app/models/remote_command.rb
+++ b/BrainPortal/app/models/remote_command.rb
@@ -17,7 +17,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
 # This model encapsulates a record with a precise list
@@ -89,6 +89,9 @@ class RemoteCommand < RestrictedHash
 
     # Not really used right now
     :group_ids,
+
+    # Userfile types, single string with commas.
+    :types,
 
     # Date of effect; for clean_cache it means cleans files older than this..
     :before_date,  # Time object

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -707,7 +707,7 @@ class RemoteResource < ActiveRecord::Base
 
   # Utility method to send a clean_cache command to a
   # RemoteResource, whether local or not.
-  def send_command_clean_cache(userlist,older_than,younger_than)
+  def send_command_clean_cache(userlist,typelist,older_than,younger_than)
     if older_than.is_a?(Fixnum)
        time_older = older_than.seconds.ago
     elsif older_than.is_a?(Time)
@@ -727,6 +727,7 @@ class RemoteResource < ActiveRecord::Base
     command = RemoteCommand.new(
       :command     => 'clean_cache',
       :user_ids    => useridlist,
+      :types       => Array(typelist).join(","),
       :before_date => time_older,
       :after_date  => time_younger
     )
@@ -907,17 +908,21 @@ class RemoteResource < ActiveRecord::Base
   # last accessed before the +before_date+ ; the task
   # is started in background, as it can be long.
   def self.process_command_clean_cache(command)
-    user_ids    = command.user_ids    || 'all'
-    before_date = command.before_date
-    after_date  = command.after_date
+    user_ids    = command.user_ids.presence
+    before_date = command.before_date.presence
+    after_date  = command.after_date.presence
+    types       = command.types.presence
 
-    user_id_list = (user_ids =~ /all/) ? nil : user_ids.split(/,/)
+    user_id_list = user_ids ? user_ids.split(",") : nil
+    types_list   = types    ? types.split(",")    : nil
 
     CBRAIN.spawn_with_active_records(:admin, "Cache Cleanup") do
       syncs = SyncStatus.where( :remote_resource_id => RemoteResource.current_resource.id )
-      syncs = syncs.where([ "sync_status.accessed_at < ?", before_date])          if before_date.present?
-      syncs = syncs.where([ "sync_status.accessed_at > ?", after_date])           if after_date.present?
-      syncs = syncs.joins(:userfile).where( 'userfiles.user_id' => user_id_list ) if user_id_list
+      syncs = syncs.where([ "sync_status.accessed_at < ?", before_date])          if before_date
+      syncs = syncs.where([ "sync_status.accessed_at > ?", after_date])           if after_date
+      syncs = syncs.joins(:userfile)                                              if user_id_list || types_list
+      syncs = syncs.where( 'userfiles.user_id' => user_id_list )                  if user_id_list
+      syncs = syncs.where( 'userfiles.type'    => types_list )                    if types_list
 
       syncs = syncs.all
       syncs.each_with_index do |ss,i|

--- a/BrainPortal/app/views/bourreaux/rr_disk_usage.html.erb
+++ b/BrainPortal/app/views/bourreaux/rr_disk_usage.html.erb
@@ -128,10 +128,14 @@
       </tr>
     </table>
 
-    <p/><%= disk_usage_legend %>
+    <p>
+    <%= disk_usage_legend %>
 
     <%= hidden_field_tag "cleanup_older",    @cache_older %>
     <%= hidden_field_tag "cleanup_younger",  @cache_younger %>
+    <% (params[:types] || []).each do |type| %>
+      <%= hidden_field_tag "types[]", type  %>
+    <% end %>
 
     <% end %> <!-- form -->
   </span>
@@ -143,14 +147,23 @@
 <!-- *********************************** -->
 
 <%= form_tag({ :action  => :rr_disk_usage }, :method => :get) do %>
-  Files reported in the <em>Caches</em> report were last accessed:
-  <div class="display_table">
-  <% params[:date_range] ||= {} %>
-  <% params[:date_range]["relative_from"] ||= 50.years.to_i.to_s %>
-  <% params[:date_range]["relative_to"]   ||= 1.week.to_i.to_s %>
-  <%= date_range_panel(params[:date_range], "date_range", :date_attributes => [], :without_abs => true) %>
+  <h4>Filter this report: files reported above...</h4>
+  <div class="display_cell">
+    ... are of type:<br>
+    <%= userfile_type_select :types, {:selector => params[:types]} , :multiple => true, :size => 10 %>
+    <br>(None selected means <em>any</em>)
   </div>
-  </p>
-  <%= submit_tag 'Refresh' %>
+  <div class="box_spacer"></div>
+  <div class="display_cell">
+    ... were last accessed:<br>
+    <% params[:date_range] ||= {} %>
+    <% params[:date_range]["relative_from"] ||= 50.years.to_i.to_s %>
+    <% params[:date_range]["relative_to"]   ||= 1.week.to_i.to_s %>
+    <%= date_range_panel(params[:date_range], "date_range", :date_attributes => [], :without_abs => true) %>
+    <p>
+    <center>
+      <%= submit_tag 'Refresh Report' %>
+    </center>
+  </div>
 <% end %>
 

--- a/BrainPortal/lib/models_report.rb
+++ b/BrainPortal/lib/models_report.rb
@@ -44,6 +44,7 @@ class ModelsReport
     remote_resources = options[:remote_resources]
     accessed_before  = options[:accessed_before]
     accessed_after   = options[:accessed_after]
+    types            = options[:types]
 
     # Internal constants
     all_users_label = "TOTAL" # used as a key in the table's hash
@@ -66,9 +67,10 @@ class ModelsReport
     base_rel = SyncStatus.joins(:userfile).group([ 'userfiles.user_id', 'sync_status.remote_resource_id'])
 #    base_rel = base_rel.where(:status => [ 'InSync', 'Corrupted', 'CacheNewer', 'ToCache', 'ToProvider' ])
     base_rel = base_rel.where("userfiles.user_id" => userlist.map(&:id)) if users.present?
+    base_rel = base_rel.where("userfiles.type"    => types)              if types.present?
     base_rel = base_rel.where(:remote_resource_id => rrlist.map(&:id))   if remote_resources.present?
-    base_rel = base_rel.where([ "accessed_at < ?", accessed_before])     if accessed_before.present?
-    base_rel = base_rel.where([ "accessed_at > ?", accessed_after])      if accessed_after.present?
+    base_rel = base_rel.where( ["accessed_at < ?", accessed_before] )    if accessed_before.present?
+    base_rel = base_rel.where( ["accessed_at > ?", accessed_after] )     if accessed_after.present?
 
     # The four queries with the stats
     num_entries_hash = base_rel.count


### PR DESCRIPTION
The cache cleaning panel now has a selection box
to filter out the report based on file types, and
when sending the clean command to a remote resource
the types selected will also be sent along.