### PR TITLE
Fix: same content registered twice on some DPs

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -451,7 +451,7 @@ class UserfilesController < ApplicationController
         end
         respond_to do |format|
           format.html { redirect_to redirect_path }
-          format.json { render :json  => flash[:error], :status  => :unprocessable_entity}
+          format.json { render :json => { :notice => flash[:error] } }
         end
         return
       end

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -148,7 +148,7 @@ class CbrainTask < ActiveRecord::Base
   #  - 'Completed'
   #  - 'Failed' (which covers all failures)
   #
-  # As an aide, note that in a way, a task ID 'n' in the CbrainTask attribute
+  # As an aside, note that in a way, a task ID 'n' in the CbrainTask attribute
   # :share_wd_tid also implies this prerequisite:
   #
   #     :for_setup => { "T#{n}" => "Queued" }

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1632,7 +1632,7 @@ class ClusterTask < CbrainTask
   def remove_cluster_workdir
     raise "Tried to remove a task's work directory while in the wrong Rails app." unless
       self.bourreau_id == CBRAIN::SelfRemoteResourceId
-    return true if ! self.share_wd_tid.blank?  # Do not erase if using some other task's workdir.
+    return true if self.share_wd_tid.present?  # Do not erase if using some other task's workdir.
     full=self.full_cluster_workdir
     return if full.blank?
     self.addlog("Removing workdir '#{full}'.")

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -120,6 +120,7 @@ require 'digest/md5'
 # * is_browsable?(by_user = nil)
 # * is_fast_syncing?
 # * allow_file_owner_change?
+# * content_storage_shared_between_users?
 #
 # == Access restriction methods:
 #
@@ -373,6 +374,26 @@ class DataProvider < ActiveRecord::Base
   # problem, the files are stored in hashes subdirectories with
   # only the ID used for the component paths.
   def allow_file_owner_change?
+    false
+  end
+
+  # This predicate returns +true+ if the content storage
+  # of the data provider share files between users, meaning
+  # that if a file named X belong to a user, no other user
+  # can have a file named X too. Typically, this is the
+  # same as as saying 'files are all in the same directory'.
+  #
+  # In such a case, it means the Userfile assumption that
+  # two files with the same name can coexist on the
+  # same DP if they belong to different users is FALSE.
+  # Normally, the Userfile model is not so strict
+  # (see the Userfile validation rule for names' uniqueness).
+  # The value returned by this method is used by
+  # another Userfile callback, flat_dir_dp_name_uniqueness().
+  #
+  # This true/false value of this method is to be redefined
+  # in subclasses to trigger the proper Userfile behavior.
+  def content_storage_shared_between_users?
     false
   end
 

--- a/BrainPortal/app/models/en_cbrain_ssh_data_provider.rb
+++ b/BrainPortal/app/models/en_cbrain_ssh_data_provider.rb
@@ -51,6 +51,10 @@ class EnCbrainSshDataProvider < SshDataProvider
     true
   end
 
+  def content_storage_shared_between_users? #:nodoc:
+    false
+  end
+
   def impl_sync_to_provider(userfile) #:nodoc:
     threelevels = cache_subdirs_from_id(userfile.id)
     userdir = Pathname.new(remote_dir)

--- a/BrainPortal/app/models/flat_dir_local_data_provider.rb
+++ b/BrainPortal/app/models/flat_dir_local_data_provider.rb
@@ -47,5 +47,9 @@ class FlatDirLocalDataProvider < LocalDataProvider
     by_user.is_member_of_group(self.meta[:browse_gid].to_i)
   end
 
+  def content_storage_shared_between_users? #:nodoc:
+    true
+  end
+
 end
 

--- a/BrainPortal/app/models/local_data_provider.rb
+++ b/BrainPortal/app/models/local_data_provider.rb
@@ -55,6 +55,10 @@ class LocalDataProvider < DataProvider
     true
   end
 
+  def content_storage_shared_between_users? #:nodoc:
+    false
+  end
+
   # Returns true: local data providers are considered fast syncing.
   def is_fast_syncing?
     true

--- a/BrainPortal/app/models/s3_data_provider.rb
+++ b/BrainPortal/app/models/s3_data_provider.rb
@@ -88,6 +88,10 @@ class S3DataProvider < DataProvider
     true
   end
 
+  def content_storage_shared_between_users? #:nodoc:
+    false
+  end
+
   def impl_sync_to_cache(userfile) #:nodoc:
     init_connection  # s3 connection
 

--- a/BrainPortal/app/models/ssh_data_provider.rb
+++ b/BrainPortal/app/models/ssh_data_provider.rb
@@ -62,7 +62,11 @@ class SshDataProvider < DataProvider
   end
 
   def allow_file_owner_change? #:nodoc:
-    true
+    true # some subclasses reset this to false
+  end
+
+  def content_storage_shared_between_users? #:nodoc:
+    true # this class stores all in a flat directory; some subclasses reset this to false
   end
 
   def impl_sync_to_cache(userfile) #:nodoc:

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -52,6 +52,9 @@ class Userfile < ActiveRecord::Base
                           :uniqueness =>  { :scope => [ :user_id, :data_provider_id ] },
                           :filename_format => true
 
+  before_create           :flat_dir_dp_name_uniqueness # this method is also used as a validator (see below)
+  validate                :flat_dir_dp_name_uniqueness # this method is also used as a before_create callback (see above)
+
   validates_presence_of   :user_id
   validates_presence_of   :data_provider_id
   validates_presence_of   :group_id
@@ -902,24 +905,41 @@ class Userfile < ActiveRecord::Base
 
   def validate_associations #:nodoc:
     unless DataProvider.where( :id => self.data_provider_id ).first
-      errors.add(:data_provider, "does not exist.")
+      errors.add(:data_provider, "does not exist")
     end
     unless User.where( :id => self.user_id ).first
-      errors.add(:user, "does not exist.")
+      errors.add(:user, "does not exist")
     end
     unless Group.where( :id => self.group_id ).first
-      errors.add(:group, "does not exist.")
+      errors.add(:group, "does not exist")
     end
   end
 
+  # before_destroy callback
   def erase_data_provider_content_and_cache #:nodoc:
     self.cache_erase rescue true
     self.provider_erase
     true
   end
 
+  # before_destroy callback
   def nullify_children #:nodoc:
     self.children.each(&:remove_parent)
+  end
+
+  # This method is used as a validator, and as a before_create callback.
+  # Files on data providers where all files are in the same directory
+  # cannot be registered or created such that the same filename is
+  # used by two entries in the DB.
+  def flat_dir_dp_name_uniqueness #:nodoc:
+    return true if self.data_provider_id.blank?   # no check to make
+    dp_class_name = self.data_provider.class.to_s # must compare as strings... :-(
+    return true if dp_class_name !~ /^FlatDir|^SshDataProvider$/ # ... the FlatDir classes are not in a hierarchy :-(
+    check_dup = Userfile.where(:name => self.name, :data_provider_id => self.data_provider_id)
+    check_dup = check_dup.where(["id <> ?", self.id]) if self.id # if current file is registered, ignore that one
+    return true unless check_dup.exists?
+    errors.add(:name, "already exists on data provider")
+    false
   end
 
 end

--- a/BrainPortal/app/models/vault_ssh_data_provider.rb
+++ b/BrainPortal/app/models/vault_ssh_data_provider.rb
@@ -49,6 +49,10 @@ class VaultSshDataProvider < SshDataProvider
     false # nope, because files are stored in subdirectories named after the owner's name.
   end
 
+  def content_storage_shared_between_users? #:nodoc:
+    false # each user has a private subdir
+  end
+
   def impl_sync_to_provider(userfile) #:nodoc:
     username = userfile.user.login
     userdir = Pathname.new(remote_dir) + username

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -53,20 +53,20 @@ module SmartDataProviderInterface
       @real_provider = networkclass.new
     end
 
+    # Copy attributes to the internal real provider object
     @real_provider.make_all_accessible!
-    @real_provider.attributes = self.attributes.reject{ |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! @real_provider.class.columns_hash[k] }
+    @real_provider.attributes = self.attributes.reject { |k,v| k.to_sym == :type ||  k.to_sym == :id  || ! @real_provider.class.columns_hash[k] }
     @real_provider.id = self.id # the real provider gets the id of the ActiveRecord object, even if it's never saved in the DB
     @real_provider.readonly!
 
-    # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects    
+    # These methods are used to intercept and prevent calls to 'save' on the two internal providers objects
     @real_provider.class_eval do
       [ :save, :save!, :update_attribute, :update_attributes, :update_attributes! ].each do |bad_method|
-        define_method(bad_method) do |*args|   
-          cb_error "Internal error: attempt to invoke method '#{bad_method}' on internal #{@real_provider.class == localclass ? "local" : "network"} provider object for SmartDataProvider '#{@real_provider.name}'"   
-        end    
-      end    
+        define_method(bad_method) do |*args|
+          cb_error "Internal error: attempt to invoke method '#{bad_method}' on internal #{@real_provider.class == localclass ? "local" : "network"} provider object for SmartDataProvider '#{@real_provider.name}'"
+        end
+      end
     end
-
 
     @real_provider
   end
@@ -88,23 +88,27 @@ module SmartDataProviderInterface
   ####################################
 
   def is_alive? #:nodoc:
-    @real_provider && @real_provider.is_alive?
+    @real_provider.is_alive?
   end
 
   def is_alive! #:nodoc:
-    @real_provider && @real_provider.is_alive!
+    @real_provider.is_alive!
   end
 
   def is_browsable?(by_user = nil) #:nodoc:
-    @real_provider && @real_provider.is_browsable?(by_user)
+    @real_provider.is_browsable?(by_user)
   end
 
   def is_fast_syncing? #:nodoc:
-    @real_provider && @real_provider.is_fast_syncing?
+    @real_provider.is_fast_syncing?
   end
 
   def allow_file_owner_change? #:nodoc:
-    @real_provider && @real_provider.allow_file_owner_change?
+    @real_provider.allow_file_owner_change?
+  end
+
+  def content_storage_shared_between_users? #:nodoc:
+    @real_provider.content_storage_shared_between_users?
   end
 
   def sync_to_cache(userfile) #:nodoc:


### PR DESCRIPTION
On data providers using a flat directory layout, it was
sometimes possible for two users to register files
with the same names, and then get their contents mixed up.
This is prevented by new callbacks, and also the upload
operation has been modified to handle this a bit more
gracefully.

Fixes #180 