### PR TITLE
Many fixes to session maintenance.

### DIFF
--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -54,8 +54,29 @@ class ApplicationController < ActionController::Base
   after_filter  :log_user_info
 
   # See ActionController::RequestForgeryProtection for details
-  # Uncomment the :secret if you're not using the cookie session store
-  protect_from_forgery :secret => 'b5e7873bd1bd67826a2661e01621334b'
+  protect_from_forgery
+
+  # This overrides the forgery protection method of
+  # the same name; in most situations where a session has already
+  # been created, it just invoke the real method. It's
+  # also the case if we are are at the login page of the app,
+  # since we need to initialize a new session for sure.
+  #
+  # In all other cases, it returns a plausible token while preventing
+  # the the key "_csrf_token" to be assigned in the session (which
+  # would create the session object).
+  #
+  # The problem this solves is that we no longer create empty session
+  # objects for requests that don't need a user to be logged in, sucj
+  # as the service controller, or the credits page, etc.
+  def form_authenticity_token
+    if session.present? || (params["controller"] == "sessions" && params["action"] == "new")
+      super # this ALWAYS creates a session object with key "_csrf_token"
+    else
+      @_cbrain_fat ||= SecureRandom.base64(32) # dummy FAT
+    end
+  end
+
 
   ########################################################################
   # Controller Filters

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -31,7 +31,7 @@ class SessionsController < ApplicationController
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  before_filter :no_logged_in_user, :only => [:new, :create]
+  before_filter :user_already_logged_in, :only => [:new, :create]
 
   api_available
 
@@ -44,24 +44,23 @@ class SessionsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.xml
-      format.json { render :json => {:authenticity_token => form_authenticity_token} }
+      format.xml  { render :xml  => { :authenticity_token => form_authenticity_token } }
+      format.json { render :json => { :authenticity_token => form_authenticity_token } }
       format.txt
     end
   end
 
   def create #:nodoc:
     user = User.authenticate(params[:login], params[:password]) # can be nil if it fails
-    user[:authentication_mechanism] = "password" if user.is_a?(User) # not a real attribute
     create_from_user(user)
   end
 
   def show #:nodoc:
     if current_user
       respond_to do |format|
-        format.html { render :nothing => true, :status => 200 }
-        format.xml  { render :xml  => {:user_id => current_user.id}, :status => 200 }
-        format.json { render :json => {:user_id => current_user.id}, :status => 200 }
+        format.html { render :nothing => true,                            :status => 200 }
+        format.xml  { render :xml     => { :user_id => current_user.id }, :status => 200 }
+        format.json { render :json    => { :user_id => current_user.id }, :status => 200 }
       end
     else
       render :nothing  => true, :status  => 401
@@ -89,15 +88,6 @@ class SessionsController < ApplicationController
     end
   end
 
-  # Send a proper HTTP error code
-  def auth_failed
-    respond_to do |format|
-      format.html { render :action => 'new' }
-      format.json { render :nothing => true, :status  => 401 }
-      format.xml  { render :nothing => true, :status  => 401 }
-    end
-  end
-
   ###############################################
   #
   # Private methods
@@ -106,12 +96,14 @@ class SessionsController < ApplicationController
 
   private
 
-  def no_logged_in_user #:nodoc:
+  def user_already_logged_in #:nodoc:
     if current_user
       redirect_to start_page_path
     end
   end
 
+  # Does all sort of housekeeping and checks when +user+ logs in.
+  # If user is nil, tells the framework the authentication has failed.
   def create_from_user(user) #:nodoc:
 
     # Bad login/password?
@@ -155,6 +147,16 @@ class SessionsController < ApplicationController
       format.xml  { render :nothing => true, :status  => 200 }
     end
 
+  end
+
+  # Send a proper HTTP error code
+  # when a user has not properly authenticated
+  def auth_failed
+    respond_to do |format|
+      format.html { render :action => 'new' }
+      format.json { render :nothing => true, :status  => 401 }
+      format.xml  { render :nothing => true, :status  => 401 }
+    end
   end
 
   def portal_or_account_locked?(portal) #:nodoc:
@@ -212,9 +214,9 @@ class SessionsController < ApplicationController
        pretty_host = "#{from_host} (#{pretty_host})"
     end
 
-    # The authentication_mechanism is a string stored temporarily in the current_user object as a pseudo attribute;
-    # it's supposed to describe which mechanism was used by the user to log in.
-    authentication_mechanism = user[:authentication_mechanism] || "(Unknown)"
+    # The authentication_mechanism is a string which describes
+    # the mechanism that was used by the user to log in.
+    authentication_mechanism = "password" # in future this could change
     user.addlog("Logged in with #{authentication_mechanism} from #{pretty_host} using #{pretty_brow}")
     portal.addlog("User #{user.login} logged in with #{authentication_mechanism} from #{pretty_host} using #{pretty_brow}")
     user.update_attribute(:last_connected_at, Time.now)

--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -66,7 +66,6 @@ class CbrainSession
   def self.internal_keys
     @internal_keys ||= Set.new([
       :_csrf_token,
-      :cbrain_toggle,
       :user_id,
     ].map(&:to_s) + self.tracking_keys.to_a)
   end

--- a/BrainPortal/app/views/layouts/application.html.erb
+++ b/BrainPortal/app/views/layouts/application.html.erb
@@ -27,13 +27,14 @@
     <title><%= RemoteResource.current_resource.name.presence || "CBRAIN" %><%= yield :title %></title>
     <link rel="shortcut icon" type="image/png" href="/images/neuro.png" />
 
-    <% id_csrf_meta_tag = csrf_meta_tag
-       id_csrf_meta_tag.sub!('name="csrf-token"', 'name="csrf-token" id="csrf-token"')
-       id_csrf_meta_tag.sub!('name="csrf-param"', 'name="csrf-param" id="csrf-param"')
+    <%
+        # Get the CSRF meta tags, but add IDs to them
+        id_csrf_meta_tag = csrf_meta_tag || ""
+        id_csrf_meta_tag.sub!('name="csrf-token"', 'name="csrf-token" id="csrf-token"')
+        id_csrf_meta_tag.sub!('name="csrf-param"', 'name="csrf-param" id="csrf-param"')
     %>
-
-
     <%= id_csrf_meta_tag.html_safe %>
+
     <%= stylesheet_link_tag  "cbrain", "dynamic-table", "jquery-ui", :media => "all" %>
     <%= javascript_include_tag "jquery", "jquery-ui", "jquery.form" %>
 

--- a/BrainPortal/config/initializers/session_store.rb
+++ b/BrainPortal/config/initializers/session_store.rb
@@ -1,6 +1,3 @@
-# Be sure to restart your server when you modify this file.
-
-#CbrainRailsPortal::Application.config.session_store :cookie_store, :key => '_BrainPortal_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information
@@ -8,4 +5,6 @@
 CbrainRailsPortal::Application.config.session_store :active_record_store, {
     :key          => 'BrainPortalSession',
     :expire_after => 3.days,
+    :cookie_only  => false,
   }
+

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -25,7 +25,7 @@
 CbrainRailsPortal::Application.routes.draw do
 
   # Session
-  resource  :session
+  resource  :session, :only => [ :new, :create, :show, :destroy ]
 
   # Control channel
   resources :controls,       :controller => :controls
@@ -68,7 +68,7 @@ CbrainRailsPortal::Application.routes.draw do
     end
   end
 
-  resources :invitations, :only => [:new, :create, :update, :destroy]
+  resources :invitations, :only => [ :new, :create, :update, :destroy ]
 
   resources :bourreaux do
     member do
@@ -146,7 +146,7 @@ CbrainRailsPortal::Application.routes.draw do
     end
   end
 
-  resources :exception_logs, :only => [:index, :show] do
+  resources :exception_logs, :only => [ :index, :show ] do
     delete :destroy, :on => :collection
   end
 

--- a/BrainPortal/lib/session_helpers.rb
+++ b/BrainPortal/lib/session_helpers.rb
@@ -28,7 +28,6 @@ module SessionHelpers
   def self.included(includer) #:nodoc:
     includer.class_eval do
       helper_method :current_session,   :current_project
-      before_filter :always_activate_session
     end
   end
 
@@ -48,11 +47,6 @@ module SessionHelpers
     end
 
     @current_project
-  end
-
-  def always_activate_session #:nodoc:
-    session[:cbrain_toggle] = (1 - (session[:cbrain_toggle] || 0))
-    true
   end
 
 end


### PR DESCRIPTION
* CSRF authenticity token is not stored in session
  pages that do not require authentication
* removed some historical crud
* prep for API where session ID will be passed as params
* session no longer forced to be updated at each request