### PR TITLE
Batch tasks index checkboxes. Fixes #473.

### DIFF
--- a/BrainPortal/app/helpers/dynamic_table_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_table_helper.rb
@@ -372,6 +372,12 @@ module DynamicTableHelper
     #  Defaults to 'selection'.
     #  Marks the row as selectable if specified.
     #
+    # [select_hidden]
+    #  If true, when rows are selectable, the table cell for the check box will be
+    #  left emtpy; the values for :selected, :select_value and :select_params will
+    #  all be ignored. This option allows the layout of a table to include a placeholder
+    #  for the check box even when it is not there.
+    #
     # [override]
     #  Lambda function to call for generating table rows instead of the table's
     #  automatic row generation mechanism. The lambda will be passed 3
@@ -394,12 +400,13 @@ module DynamicTableHelper
     # select_value and select_param row options, with +value+ corresponding to
     # select_value and +param+ to select_param. See the corresponding +row+
     # method options for further information.
-    def selectable(param = nil, value = nil, selected = nil)
+    def selectable(param = nil, value = nil, selected = nil, hidden = nil)
       self.row(
-        :selectable   => true,
-        :selected     => selected,
-        :select_param => param,
-        :select_value => value
+        :selectable    => true,
+        :selected      => selected,
+        :select_param  => param,
+        :select_value  => value,
+        :select_hidden => hidden,
       )
     end
 
@@ -628,7 +635,9 @@ module DynamicTableHelper
       # Parameter name in the request to send select_value as.
       :select_param,
       # Assuming this row is selectable, whether it is initially selected or not.
-      :selected
+      :selected,
+      # Override rendering code to NOT show the select checkbox at all (but the table cell will still be present)
+      :select_hidden,
     ) do
       # Apply a set of +options+, possibly returned by calling +block+
       # on the row's collection object, to the row. Available options are
@@ -653,6 +662,7 @@ module DynamicTableHelper
           self.select_value ||= obj[:id] if obj.respond_to?(:[]) && (obj[:id] rescue nil)
           self.select_value ||= obj.hash
           self.select_param   = options[:select_param] || 'selection'
+          self.select_hidden  = true if options[:select_hidden]
         end
       end
 

--- a/BrainPortal/app/views/shared/_dynamic_table.html.erb
+++ b/BrainPortal/app/views/shared/_dynamic_table.html.erb
@@ -168,18 +168,20 @@
       <% if table.has_row_selection? %>
         <% if row.selectable? %>
           <td class="dt-sel">
-            <% id = table.generate_id %>
-            <input class="dt-sel-check"
-                   type="checkbox"
-                   id="<%= id %>"
-                   name="<%= row.select_param %>"
-                   value="<%= row.select_value %>"
-                   <% if row.selected %>
-                     checked="checked"
-                   <% end %> />
-            <label class="dt-sel-lbl" for="<%= id %>">
-              <span class="dt-sel-icon ui-icon ui-icon-check"></span>
-            </label>
+            <% unless row.select_hidden %>
+              <% id = table.generate_id %>
+              <input class="dt-sel-check"
+                     type="checkbox"
+                     id="<%= id %>"
+                     name="<%= row.select_param %>"
+                     value="<%= row.select_value %>"
+                     <% if row.selected %>
+                       checked="checked"
+                     <% end %> />
+              <label class="dt-sel-lbl" for="<%= id %>">
+                <span class="dt-sel-icon ui-icon ui-icon-check"></span>
+              </label>
+            <% end %>
           </td>
         <% else %>
           <td class="dt-sel-disabled"></td>

--- a/BrainPortal/app/views/tasks/_tasks_display.html.erb
+++ b/BrainPortal/app/views/tasks/_tasks_display.html.erb
@@ -60,14 +60,15 @@
     t.paginate(:collection => @tasks) unless @row_fetch
 
     t.row do |type,id,count,task|
+      available = @bourreau_status[task.bourreau.id]
       case type
       when :task
-        available = @bourreau_status[task.bourreau.id]
         {
           :id    => "task_#{task.id}",
           :class => [:task, (available ? :available : :unavailable)],
-          :select_param => ('tasklist[]' if available),
-          :select_value => (task.id      if available),
+          :select_param => 'tasklist[]',
+          :select_value => task.id,
+          :select_hidden => !available,  # don't even show checkbox, yet allocate cell for it
           :html => {
             :'data-task-id'  => task.id,
             :'data-batch-id' => id,
@@ -79,6 +80,7 @@
           :class => [ :batch ],
           :select_param => 'batch_ids[]',
           :select_value => id,
+          :select_hidden => !available,  # don't even show checkbox, yet allocate cell for it
           :html => {
             :'data-batch-id' => id
           }


### PR DESCRIPTION
When the bourreau was offline, the table was missing a column
for the checkboxes. Added new option to the dynamic table
framework's handling of rows.