### PR TITLE
Remove task launch time attribute

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -395,7 +395,6 @@ class TasksController < ApplicationController
 
     # Prepare final list of tasks; from the one @task object we have,
     # we get a full array of clones of that task in tasklist
-    @task.launch_time = Time.now # so grouping will work
     tasklist,task_list_message = @task.wrapper_final_task_list
     unless task_list_message.blank?
       messages += "\n" unless messages.blank? || messages =~ /\n$/
@@ -502,7 +501,7 @@ class TasksController < ApplicationController
     # Save old attributes and update the current task to reflect
     # the form's content.
     new_att          = params[:cbrain_task] || {} # not the TASK's params[], the REQUEST's params[]
-    new_att          = new_att.reject { |k,v| k =~ /^(cluster_jobid|cluster_workdir|status|batch_id|launch_time|prerequisites|share_wd_tid|run_number|level|rank|cluster_workdir_size|workdir_archived|workdir_archive_userfile_id)$/ } # some attributes cannot be changed through the controller
+    new_att          = new_att.reject { |k,v| k =~ /^(cluster_jobid|cluster_workdir|status|batch_id|prerequisites|share_wd_tid|run_number|level|rank|cluster_workdir_size|workdir_archived|workdir_archive_userfile_id)$/ } # some attributes cannot be changed through the controller
     old_tool_config  = @task.tool_config
     old_bourreau     = @task.bourreau
     @task.attributes = new_att # just updates without saving
@@ -957,7 +956,6 @@ class TasksController < ApplicationController
       preset.cluster_jobid        = nil
       preset.cluster_workdir      = nil
       preset.cluster_workdir_size = nil
-      preset.launch_time          = nil
       preset.prerequisites        = {}
       preset.rank                 = 0
       preset.level                = 0

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -56,7 +56,7 @@ class CbrainTask < ActiveRecord::Base
   belongs_to            :workdir_archive, :class_name => 'Userfile', :foreign_key => :workdir_archive_userfile_id
 
   attr_accessible       :type, :batch_id, :cluster_jobid, :cluster_workdir, :status, :user_id, :bourreau_id, :description,
-                        :launch_time, :prerequisites, :share_wd_tid, :run_number, :group_id, :tool_config_id, :level, :rank,
+                        :prerequisites, :share_wd_tid, :run_number, :group_id, :tool_config_id, :level, :rank,
                         :results_data_provider_id, :cluster_workdir_size, :workdir_archived, :workdir_archive_userfile_id,
                         :params
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1626,7 +1626,7 @@ class ClusterTask < CbrainTask
         # introduced between "Setting Up" and "Queued"
         # (e.g. "Scheduling"). That would require some more
         # modifications in the bourreau worker logic though, so that
-        # tasks in status "Scheduling" are also picked up. 
+        # tasks in status "Scheduling" are also picked up.
         self.status_transition(self.status,"New")
       end
     end
@@ -1849,7 +1849,6 @@ chmod 755 ./.dockerjob.sh
     raise "Invalid tool class: #{new_task_class_name}" unless new_task.class < ClusterTask
 
     new_task.batch_id     = self.id
-    new_task.launch_time  = Time.now
     self.level            = 0 if self.level.blank?
     new_task.level        = self.level + 1 # New task will be one level up its "parent" task in the task table.
     new_task.share_workdir_with(new_share_wd_tid, "Queued") if new_share_wd_tid # can be nil

--- a/BrainPortal/app/views/tasks/_tasks_display.html.erb
+++ b/BrainPortal/app/views/tasks/_tasks_display.html.erb
@@ -261,13 +261,8 @@
     t.column("Time Submitted", :created_at,
       :sortable => true
     ) do |type,id,count,task|
-      case type
-      when :task
         to_localtime(task.created_at, :datetime)
-      when :batch, :loaded_batch
-        to_localtime(task.launch_time, :datetime)
       end
-    end
 
     t.column("Last Updated", :updated_at,
       :sortable => true

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/cb_serializer/common/cb_serializer.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/cb_serializer/common/cb_serializer.rb
@@ -160,7 +160,6 @@ class CbrainTask::CbSerializer
         :bourreau_id    => first.bourreau_id,
         :status         => serial_start_state,
         :params         => { :task_ids_enabled => tasks_ids_enabled, :ordered_subtask_ids => ordered_subtask_ids },
-        :launch_time    => first.launch_time,
         :batch_id       => first.batch_id,
         :rank           => rank,
         :level          => level_serial,

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/parallelizer/common/parallelizer.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/parallelizer/common/parallelizer.rb
@@ -152,7 +152,6 @@ class CbrainTask::Parallelizer #:nodoc:
         :bourreau_id    => first.bourreau_id,
         :status         => paral_start_state,
         :params         => { :task_ids_enabled => tasks_ids_enabled },
-        :launch_time    => first.launch_time,
         :batch_id       => first.batch_id,
         :rank           => rank,
         :level          => level_paral,

--- a/BrainPortal/db/migrate/20160907191509_remove_task_launch_time.rb
+++ b/BrainPortal/db/migrate/20160907191509_remove_task_launch_time.rb
@@ -1,0 +1,13 @@
+class RemoveTaskLaunchTime < ActiveRecord::Migration
+  def self.up
+    change_table :cbrain_tasks do |t|
+      t.remove :launch_time
+    end
+  end
+
+  def self.down
+    change_table :cbrain_tasks do |t|
+      t.add :launch_time
+    end
+  end
+end

--- a/BrainPortal/db/migrate/20160907191509_remove_task_launch_time.rb
+++ b/BrainPortal/db/migrate/20160907191509_remove_task_launch_time.rb
@@ -1,13 +1,9 @@
 class RemoveTaskLaunchTime < ActiveRecord::Migration
   def self.up
-    change_table :cbrain_tasks do |t|
-      t.remove :launch_time
-    end
+    remove_column :cbrain_tasks, :launch_time
   end
 
   def self.down
-    change_table :cbrain_tasks do |t|
-      t.add :launch_time
-    end
+    add_column :cbrain_tasks, :launch_time, :datetime
   end
 end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -117,35 +117,6 @@ ActiveRecord::Schema.define(:version => 20160907191509) do
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
 
-  create_table "demands", :force => true do |t|
-    t.string   "title"
-    t.string   "first",         :null => false
-    t.string   "middle"
-    t.string   "last",          :null => false
-    t.string   "institution",   :null => false
-    t.string   "department"
-    t.string   "position"
-    t.string   "email",         :null => false
-    t.string   "website"
-    t.string   "street1"
-    t.string   "street2"
-    t.string   "city"
-    t.string   "province"
-    t.string   "country"
-    t.string   "postal_code"
-    t.string   "time_zone"
-    t.string   "service"
-    t.string   "login"
-    t.string   "comment"
-    t.string   "session_id"
-    t.string   "confirm_token"
-    t.boolean  "confirmed"
-    t.string   "approved_by"
-    t.datetime "approved_at"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
-  end
-
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"
     t.string   "request_controller"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20160811141815) do
+ActiveRecord::Schema.define(:version => 20160907191509) do
 
   create_table "access_profiles", :force => true do |t|
     t.string   "name",        :null => false
@@ -53,7 +53,6 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
     t.integer  "user_id"
     t.integer  "bourreau_id"
     t.text     "description"
-    t.datetime "launch_time"
     t.text     "prerequisites"
     t.integer  "share_wd_tid"
     t.integer  "run_number"
@@ -74,7 +73,6 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
   add_index "cbrain_tasks", ["cluster_workdir_size"], :name => "index_cbrain_tasks_on_cluster_workdir_size"
   add_index "cbrain_tasks", ["group_id", "bourreau_id", "status"], :name => "index_cbrain_tasks_on_group_id_and_bourreau_id_and_status"
   add_index "cbrain_tasks", ["group_id"], :name => "index_cbrain_tasks_on_group_id"
-  add_index "cbrain_tasks", ["launch_time"], :name => "index_cbrain_tasks_on_launch_time"
   add_index "cbrain_tasks", ["status"], :name => "index_cbrain_tasks_on_status"
   add_index "cbrain_tasks", ["type"], :name => "index_cbrain_tasks_on_type"
   add_index "cbrain_tasks", ["user_id", "bourreau_id", "status"], :name => "index_cbrain_tasks_on_user_id_and_bourreau_id_and_status"
@@ -118,6 +116,35 @@ ActiveRecord::Schema.define(:version => 20160811141815) do
   add_index "data_providers", ["group_id"], :name => "index_data_providers_on_group_id"
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
+
+  create_table "demands", :force => true do |t|
+    t.string   "title"
+    t.string   "first",         :null => false
+    t.string   "middle"
+    t.string   "last",          :null => false
+    t.string   "institution",   :null => false
+    t.string   "department"
+    t.string   "position"
+    t.string   "email",         :null => false
+    t.string   "website"
+    t.string   "street1"
+    t.string   "street2"
+    t.string   "city"
+    t.string   "province"
+    t.string   "country"
+    t.string   "postal_code"
+    t.string   "time_zone"
+    t.string   "service"
+    t.string   "login"
+    t.string   "comment"
+    t.string   "session_id"
+    t.string   "confirm_token"
+    t.boolean  "confirmed"
+    t.string   "approved_by"
+    t.datetime "approved_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+  end
 
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"

--- a/BrainPortal/db/seeds_dev.rb
+++ b/BrainPortal/db/seeds_dev.rb
@@ -838,7 +838,6 @@ seeded_users.each do |user|
             :results_data_provider_id => en_dp.id
           },
           {
-            :launch_time => Time.now,
             :description => (tool == diag_tool ? "Some Diagnostics" : "For #{howlong} seconds"),
             :params => { :howlong                => howlong,
                          :interface_userfile_ids => [ Userfile.find_by_user_id(user.id).id ]


### PR DESCRIPTION
Task attribute launch_time used to be used to group tasks into batches, but isn't any more. This PR removes it, and in the one place where it was used, uses created_at instead.

Fix for #471 