### PR TITLE
Adding environment variable support for boutiques

### DIFF
--- a/Bourreau/spec/boutiques/boutiques_tester_spec.rb
+++ b/Bourreau/spec/boutiques/boutiques_tester_spec.rb
@@ -79,7 +79,7 @@ describe "Bourreau Boutiques Tests" do
 
       # Test some basic properties
       it "creates a tool" do
-        expect( Tool.exists?( :cbrain_task_class => @task_const.to_s ) ).to be true
+        expect( Tool.exists?( :cbrain_task_class_name => @task_const.to_s ) ).to be true
       end
 
       it "makes the tool accessible as a Cbrain Task object" do
@@ -387,13 +387,13 @@ describe "Bourreau Boutiques Tests" do
         @task_const_name = "CbrainTask::#{SchemaTaskGenerator.classify(@boutiquesTask.name)}"
         # Destroy any tools/toolconfigs for the tool, if any exist
         ToolConfig.where(tool_id: CbrainTask::BoutiquesTest.tool.id).destroy_all rescue nil
-        Tool.where(:cbrain_task_class => @task_const_name).destroy_all rescue nil
+        Tool.where(:cbrain_task_class_name => @task_const_name).destroy_all rescue nil
       end
 
       after(:each) do
         # Destroy any tools/toolconfigs for the tool, if any exist
         ToolConfig.where(tool_id: @task_const_name.constantize.tool.id).destroy_all
-        Tool.where(:cbrain_task_class => @task_const_name).destroy_all
+        Tool.where(:cbrain_task_class_name => @task_const_name).destroy_all
         # Ensure the Bourreau does not have docker installed by default
         resource = RemoteResource.current_resource
         resource.docker_present = false

--- a/Bourreau/spec/boutiques/boutiques_tester_spec.rb
+++ b/Bourreau/spec/boutiques/boutiques_tester_spec.rb
@@ -167,6 +167,17 @@ describe "Bourreau Boutiques Tests" do
         expect( NormedTaskCmd.(@task) ).to eq( './' + TestScriptName + ' -A A_VAL -p e1 e2 e3' )
       end
 
+      # Test that export commands work and are in the right place
+      it "exports environment variables" do
+        expect( @task.cluster_commands[0] ).to eq("export ev1='nice_value'")
+      end
+
+      # It properly escapes environment variables
+      # Note that we only have to worry about inappropriate values that are still valid JSON
+      it "escapes environment variables" do
+        expect( @task.cluster_commands[1] ).to eq("export ev2='ta- 9\"'\\''_%^&$@]['")
+      end
+
     end
 
     # Testing Boutiques via the mock 'submission' of a local script, using the output of cluster_commands
@@ -190,8 +201,8 @@ describe "Bourreau Boutiques Tests" do
           rescue OptionParser::MissingArgument => e
             next # after_form does not need to check this here, since rails puts a value in the hash
           end
-          # Run the generated command line from cluster_commands
-          exit_code = runTestScript( @task.cluster_commands[0].gsub('./'+TestScriptName,''), test[3] || [] )
+          # Run the generated command line from cluster_commands (-2 to ignore export lines and the echo log at -1)
+          exit_code = runTestScript( @task.cluster_commands[-2].gsub('./'+TestScriptName,''), test[3] || [] )
           # Check that the exit code is appropriate
           expect( exit_code ).to eq( test[2] )
         end

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -54,6 +54,7 @@ class CbrainTask::<%= name %> < <%= descriptor['cbrain:inherits-from-class'] || 
 % out_keys = outputs.select { |o| o['command-line-key'] }
 % flags    = (inputs + outputs).select { |p| p['command-line-flag'] }
 % seps     = inputs.select { |i| i['command-line-flag-separator'] }
+% eVars    = descriptor['environment-variables'].dup rescue []
 %
   # Task properties are special boolean properties of your task, returned as a
   # hash table. Used internally by CBRAIN to enable/disable special task
@@ -125,6 +126,19 @@ class CbrainTask::<%= name %> < <%= descriptor['cbrain:inherits-from-class'] || 
   # Note that this function also generates the list of output filenames
   # in params.
   def cluster_commands #:nodoc:
+
+    # Environment variables from Boutiques descriptor
+% if eVars.empty?
+    envVars = []
+% else
+    envVars = [
+%    eVars.each do |v|
+%# The value is escaped for bash; the whole cmd is then escaped to be written into the ruby code
+      <%= ("export %s=%s" % [v['name'], v['value'].bash_escape(always_quote=true)]).inspect %>,
+%    end
+    ]
+% end
+
 % if in_keys.empty? && out_keys.empty?
 %   unless outputs.empty?
     # Output filenames
@@ -143,10 +157,10 @@ class CbrainTask::<%= name %> < <%= descriptor['cbrain:inherits-from-class'] || 
 %   end
 %   if descriptor['cbrain:ignore-exit-status']
     # Command-line
-    [ <<-'CMD' ]
+    envVars + [ <<-'CMD' ]
 %   else
     # Command-line to run <%= name %> and save its exit status
-    [ <<-'CMD', "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
+    envVars + [ <<-'CMD', "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
 %   end
       <%= descriptor['command-line'] %>
     CMD
@@ -253,7 +267,7 @@ class CbrainTask::<%= name %> < <%= descriptor['cbrain:inherits-from-class'] || 
 %   end
 %   if descriptor['cbrain:ignore-exit-status']
     # Generate the final command-line to run <%= name %>
-    [ apply_template(<<-'CMD', keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>) ]
+    envVars + [ apply_template(<<-'CMD', keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>) ]
       <%= descriptor['command-line'] %>
     CMD
 %   else
@@ -263,7 +277,7 @@ class CbrainTask::<%= name %> < <%= descriptor['cbrain:inherits-from-class'] || 
     CMD
 
     # And save its exit status
-    [ command, "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
+    envVars + [ command, "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
 %   end
 % end
   end

--- a/BrainPortal/spec/boutiques/descriptor_test.json
+++ b/BrainPortal/spec/boutiques/descriptor_test.json
@@ -4,6 +4,14 @@
 	"description" : "Simple test task for Boutiques",
 	"command-line" : "./boutiquesTestApp.rb [A] [B] [C] [a] [b] [c] [d] [e] [f] [g] [i] [j] [k] [l] [m] [n] [p] [q] [u] [v] [w] [x] [o] [r] [y] [E] [I] [N] [L]",
 	"schema-version" : "0.2",
+  "environment-variables" : [{
+    "name" : "ev1",
+    "value" : "nice_value"
+  }, {
+    "name" : "ev2",
+    "value" : "ta- 9\"\'_%^&$@][",
+    "description" : "Test escaping"
+  }],
 	"inputs" : [{
 		"id" : "A",
 		"name" : "A",

--- a/BrainPortal/spec/boutiques/test_helpers.rb
+++ b/BrainPortal/spec/boutiques/test_helpers.rb
@@ -321,8 +321,9 @@ module TestHelpers
   end
 
   # Helper for cleaning spaces after key subsitution, to make it easier to write the correct test result
+  # Ignores the export commands and assumes the final command is the log writer
   NormedTaskCmd = lambda do |task|
-    task.cluster_commands[0].split.join(' ')
+    task.cluster_commands[-2].split.join(' ')
   end
 
   # A mock json task object, to test possible problems that the full mock app cannot be used to reproduce


### PR DESCRIPTION
Small update allowing task developers to specify environment variables in Boutiques descriptors.

Works by prepending `export` commands to the front of the cluster_commands array. Also added some tests for it. 

For Boutiques issue boutiques/boutiques#56, based on additions in pull request boutiques/boutiques#57.