### PR TITLE
Fixes in behaviour when CSRF token is wrong

### DIFF
--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -58,7 +58,7 @@ class ApplicationController < ActionController::Base
 
   # This overrides the forgery protection method of
   # the same name; in most situations where a session has already
-  # been created, it just invoke the real method. It's
+  # been created, it just invokes the real method. It's
   # also the case if we are are at the login page of the app,
   # since we need to initialize a new session for sure.
   #
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
   # would create the session object).
   #
   # The problem this solves is that we no longer create empty session
-  # objects for requests that don't need a user to be logged in, sucj
+  # objects for requests that don't need a user to be logged in, such
   # as the service controller, or the credits page, etc.
   def form_authenticity_token
     if session.present? || (params["controller"] == "sessions" && params["action"] == "new")

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -53,14 +53,8 @@ class SessionsController < ApplicationController
   def create #:nodoc:
     # If the csrf token is blank, it was reset by Rails' request forgery protection
     # and we want to prevent login
-    if current_session["_csrf_token"]
-      user = User.authenticate(params[:login], params[:password]) # can be nil if it fails
-      create_from_user(user)
-    else
-      flash[:error] = "Hacking CBRAIN won't work"
-      current_session["_csrf_token"] = session["_csrf_token"] #
-      auth_failed
-    end
+    user = current_session["_csrf_token"].present? && User.authenticate(params[:login], params[:password]) # can be nil if it fails
+    create_from_user(user)
   end
 
   def show #:nodoc:

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -51,8 +51,16 @@ class SessionsController < ApplicationController
   end
 
   def create #:nodoc:
-    user = User.authenticate(params[:login], params[:password]) # can be nil if it fails
-    create_from_user(user)
+    # If the csrf token is blank, it was reset by Rails' request forgery protection
+    # and we want to prevent login
+    if current_session["_csrf_token"]
+      user = User.authenticate(params[:login], params[:password]) # can be nil if it fails
+      create_from_user(user)
+    else
+      flash[:error] = "Hacking CBRAIN won't work"
+      current_session["_csrf_token"] = session["_csrf_token"] #
+      auth_failed
+    end
   end
 
   def show #:nodoc:

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -53,7 +53,7 @@ class SessionsController < ApplicationController
   def create #:nodoc:
     # If the csrf token is blank, it was reset by Rails' request forgery protection
     # and we want to prevent login
-    user = current_session["_csrf_token"].present? && User.authenticate(params[:login], params[:password]) # can be nil if it fails
+    user = current_session["_csrf_token"].presence && User.authenticate(params[:login], params[:password]) # can be nil if it fails
     create_from_user(user)
   end
 

--- a/BrainPortal/lib/authenticated_system.rb
+++ b/BrainPortal/lib/authenticated_system.rb
@@ -110,7 +110,9 @@ module AuthenticatedSystem #:nodoc:
     #
     # We can return to this location by calling #redirect_back_or_default.
     def store_location
-      session[:return_to] = request.fullpath #request.request_uri
+      if request.method == :get
+        session[:return_to] = request.fullpath #request.request_uri
+      end
     end
 
     # Redirect to the URI stored by the most recent store_location call or


### PR DESCRIPTION
Prevents a user from logging in when they had a bad CSRF token.
When a session is invalid due to a bad CSRF token, a user logs back in again, and is returned to the page that triggered the logout. This can no longer be a POST.

Fixes #477 and #478.