### PR TITLE
Change Creator of a Project

### DIFF
--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -130,6 +130,7 @@ class GroupsController < ApplicationController
     end
 
     original_user_ids = @group.user_ids
+    original_creator = @group.creator_id
 
     params[:group] ||= {}
 
@@ -161,6 +162,9 @@ class GroupsController < ApplicationController
     respond_to do |format|
       if @group.update_attributes_with_logging(params[:group],current_user)
         @group.reload
+        if params[:group][:creator_id].present?
+          @group.addlog_object_list_updated("Creator", User, original_creator, @group.creator_id, current_user, :login)
+        end
         @group.addlog_object_list_updated("Users", User, original_user_ids, @group.user_ids, current_user, :login)
         flash[:notice] = 'Project was successfully updated.'
         format.html { redirect_to :action => "show" }

--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -151,8 +151,11 @@ class GroupsController < ApplicationController
       end
     end
 
+    unless (current_user.available_users.map{ |u| u.id } | @group.user_ids).include?(params[:group][:creator_id].to_i )
+      params[:group].delete :creator_id
+    end
+
     @group.make_accessible!(:invisible) if current_user.has_role?(:admin_user)
-    params[:group].delete :creator_id #creator_id is immutable
 
     @users = current_user.available_users.where( "users.login <> 'admin'" ).order(:login)
     respond_to do |format|

--- a/BrainPortal/app/views/groups/_groups_table.html.erb
+++ b/BrainPortal/app/views/groups/_groups_table.html.erb
@@ -182,6 +182,11 @@
         :filters  => default_filters_for(@base_scope, Site)
       ) { |g| link_to_site_if_accessible(g.site) }
 
+      t.column("Creator", :creator_id,
+        :sortable => true,
+        :filters => default_filters_for(@base_scope, @custom_scope, :creator_id)
+      ) { |g| link_to_user_if_accessible(g.creator) }
+
       t.column("Users", :users) do |g|
         @group_id_2_user_counts[g.id].to_s.presence || html_colorize("(none)", "red")
       end

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -52,7 +52,10 @@
       <%= text_field_tag "group[name]", @group.name %>
     <% end %>
 
-    <% t.cell("Creator") { @group.creator.try(:login)} %>
+    <% t.edit_cell(:creator_id, :content => link_to_user_with_tooltip(@group.creator), :header => "Creator") do %>
+      <%= user_select "group[creator_id]", { :users => ( current_user.available_users | @group.users), :selector => @group.creator } %>
+      <div class="field_explanation"><span class="warning">Warning</span>: If you change the Creator to someone else you won't be able to edit this project any more</div>
+    <% end %>
 
     <% t.edit_cell(:site_id, :content => link_to_site_if_accessible(@group.site), :disabled => !current_user.has_role?(:admin_user)) do %>
       <%= site_select "group[site_id]", @group.site_id, :prompt => "(Select a site)" %>


### PR DESCRIPTION
From the details page of a project, the Creator field is now editable, and includes users that the current user has access to, and all members of the project. Fixes #501
