### PR TITLE
Collection downloads

### DIFF
--- a/BrainPortal/app/helpers/userfiles_helper.rb
+++ b/BrainPortal/app/helpers/userfiles_helper.rb
@@ -80,17 +80,14 @@ module UserfilesHelper
   # of type TextFile or ImageFile
   # Generates download link for any other type of file
   def data_link(file_name, userfile)
-    dp = DataProvider.find(userfile.data_provider_id)
-    cache_path = dp.cache_full_path(userfile)
-
-    full_path_name  = Pathname.new(cache_path.dirname + file_name)
-
-    file_lstat = full_path_name.lstat  # lstat doesn't follow symlinks, so we can tell if it is one
+    full_path_name  = Pathname.new(userfile.cache_full_path.dirname + file_name)
 
     display_name  = full_path_name.basename.to_s
     return h(display_name) unless userfile.is_locally_synced?
+
+    file_lstat = full_path_name.lstat  # lstat doesn't follow symlinks, so we can tell if it is one
+
     return h(display_name) unless file_lstat.file?
-    return h(display_name) if file_lstat.symlink?
 
     matched_class = SingleFile.descendants.unshift(SingleFile).find { |c| file_name =~ c.file_name_pattern }
 

--- a/BrainPortal/app/helpers/userfiles_helper.rb
+++ b/BrainPortal/app/helpers/userfiles_helper.rb
@@ -77,16 +77,14 @@ module UserfilesHelper
   end
 
   # Generates links to pretty file content for userfiles
-  # of type TextFile or ImageFile; this method is going to
-  # be replaced by a proper generic framework in 4.3.0 !
+  # of type TextFile or ImageFile, downloads any other type of content
   def data_link(file_name, userfile)
     display_name  = Pathname.new(file_name).basename.to_s
     return h(display_name) unless userfile.is_locally_synced?
 
     matched_class = SingleFile.descendants.unshift(SingleFile).find { |c| file_name =~ c.file_name_pattern }
-    return h(display_name) unless matched_class
 
-    if matched_class <= TextFile
+    if matched_class && matched_class <= TextFile
       link_to h(display_name),
               display_userfile_path(userfile,
                 :content_loader        => :collection_file,
@@ -96,7 +94,7 @@ module UserfilesHelper
                 :content_viewer        => "off",
               ),
               :target => "_blank"
-    elsif matched_class <= ImageFile
+    elsif matched_class && matched_class <= ImageFile
       link_to h(display_name),
               display_userfile_path(userfile,
                 :content_loader        => :collection_file,
@@ -107,7 +105,8 @@ module UserfilesHelper
               ),
               :target => "_blank"
     else
-       h(display_name)
+      link_to h(display_name),
+              url_for(:action  => :content, :content_loader => :collection_file, :arguments => file_name)
     end
   end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/file_collection/views/_plain_file_list_row.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/file_collection/views/_plain_file_list_row.html.erb
@@ -41,7 +41,7 @@
     <% else %>
       <%= image_tag "/images/file_icon.png" %>
     <% end %>
-    <% if file.size > 0 && file.symbolic_type != :directory %>
+    <% if file.size > 0 %>
       <%= data_link file.name, @userfile %>
     <% else %>
       <%= Pathname.new(file.name).basename.to_s %>

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/file_collection/views/_plain_file_list_row.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/file_collection/views/_plain_file_list_row.html.erb
@@ -41,7 +41,7 @@
     <% else %>
       <%= image_tag "/images/file_icon.png" %>
     <% end %>
-    <% if file.size > 0%>
+    <% if file.size > 0 && file.symbolic_type != :directory %>
       <%= data_link file.name, @userfile %>
     <% else %>
       <%= Pathname.new(file.name).basename.to_s %>
@@ -57,4 +57,3 @@
     <%= colored_pretty_size(file.size) %>
   <% end %>
 </td>
-


### PR DESCRIPTION
Refactors the `data_link` method to add download links to objects within file collections, only for real files and not for symlinks. Fixes #519. 
