### PR TITLE
Log Filters

### DIFF
--- a/BrainPortal/app/controllers/portal_controller.rb
+++ b/BrainPortal/app/controllers/portal_controller.rb
@@ -95,10 +95,13 @@ class PortalController < ApplicationController
     remove_egrep << "^ *Redirected"   if params[:hide_redirected].presence == "1"
     remove_egrep << "^User:"          if params[:hide_user].presence       == "1"
     remove_egrep << "^Completed"      if params[:hide_completed].presence  == "1"
-    # Note that in production, 'SQL', 'CACHE', 'AREL' and 'LOAD' are never shown.
+    # Note that in production, 'SQL', 'CACHE' and 'LOAD' are never shown.
     remove_egrep << "^ *SQL "         if params[:hide_sql].presence        == "1"
+    remove_egrep << "BEGIN"           if params[:hide_sql].presence        == "1"
+    remove_egrep << "SELECT"          if params[:hide_sql].presence        == "1"
+    remove_egrep << "UPDATE"          if params[:hide_sql].presence        == "1"
+    remove_egrep << "COMMIT"          if params[:hide_sql].presence        == "1"
     remove_egrep << "^ *CACHE "       if params[:hide_cache].presence      == "1"
-    remove_egrep << "^ *AREL "        if params[:hide_arel].presence       == "1"
     remove_egrep << "^ *[^ ]* Load"   if params[:hide_load].presence       == "1"
 
     # Hiding some lines disable some filters, because we hide before we filter. :-(

--- a/BrainPortal/app/controllers/portal_controller.rb
+++ b/BrainPortal/app/controllers/portal_controller.rb
@@ -88,29 +88,26 @@ class PortalController < ApplicationController
 
     # Hide some less important lines
     remove_egrep = []
-    remove_egrep << "^Started "       if params[:hide_started].presence    == "1"
-    remove_egrep << "^ *Processing "  if params[:hide_processing].presence == "1"
-    remove_egrep << "^ *Parameters: " if params[:hide_parameters].presence == "1"
-    remove_egrep << "^ *Rendered"     if params[:hide_rendered].presence   == "1"
-    remove_egrep << "^ *Redirected"   if params[:hide_redirected].presence == "1"
-    remove_egrep << "^User:"          if params[:hide_user].presence       == "1"
-    remove_egrep << "^Completed"      if params[:hide_completed].presence  == "1"
+    remove_egrep << "^Started "                                      if params[:hide_started].presence    == "1"
+    remove_egrep << "^ *Processing "                                 if params[:hide_processing].presence == "1"
+    remove_egrep << "^ *Parameters: "                                if params[:hide_parameters].presence == "1"
+    remove_egrep << "^ *Rendered"                                    if params[:hide_rendered].presence   == "1"
+    remove_egrep << "^ *Redirected"                                  if params[:hide_redirected].presence == "1"
+    remove_egrep << "^User:"                                         if params[:hide_user].presence       == "1"
+    remove_egrep << "^Completed"                                     if params[:hide_completed].presence  == "1"
     # Note that in production, 'SQL', 'CACHE' and 'LOAD' are never shown.
-    remove_egrep << "^ *SQL "         if params[:hide_sql].presence        == "1"
-    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+BEGIN"          if params[:hide_sql].presence        == "1"
-    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+COMMIT"         if params[:hide_sql].presence        == "1"
-    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+SELECT"         if params[:hide_sql].presence        == "1"
-    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+UPDATE"         if params[:hide_sql].presence        == "1"
-    remove_egrep << "^\\s+\\w+\\s+Exists \\(\\d+\\.\\d+ms\\) "   if params[:hide_exists].presence    == "1"
-    remove_egrep << "^ *CACHE "       if params[:hide_cache].presence      == "1"
-    remove_egrep << "^ *[^ ]* Load"   if params[:hide_load].presence       == "1"
+    remove_egrep << "^ *SQL "                                        if params[:hide_sql].presence        == "1"
+    remove_egrep << '^[\s\d\.ms\(\)]+(BEGIN|COMMIT|SELECT|UPDATE)'   if params[:hide_sql].presence        == "1"
+    remove_egrep << '^[\s\w]*Exists'                                 if params[:hide_exists].presence     == "1"
+    remove_egrep << "^ *CACHE "                                      if params[:hide_cache].presence      == "1"
+    remove_egrep << "^ *[^ ]* Load"                                  if params[:hide_load].presence       == "1"
 
     # Hiding some lines disable some filters, because we hide before we filter. :-(
-    meth_name = nil if params[:hide_started].presence   == "1"
-    ctrl_name = nil if params[:hide_started].presence   == "1"
-    user_name = nil if params[:hide_user].presence      == "1"
-    inst_name = nil if params[:hide_user].presence      == "1"
-    ms_min    = nil if params[:hide_completed].presence == "1"
+    meth_name = nil                                                  if params[:hide_started].presence    == "1"
+    ctrl_name = nil                                                  if params[:hide_started].presence    == "1"
+    user_name = nil                                                  if params[:hide_user].presence       == "1"
+    inst_name = nil                                                  if params[:hide_user].presence       == "1"
+    ms_min    = nil                                                  if params[:hide_completed].presence  == "1"
 
     # Extract the raw data with escape sequences filtered.
 
@@ -120,7 +117,7 @@ class PortalController < ApplicationController
 
     # Version 2: filter first, tail after. Bad if log file is really large, but perl is fast.
     command  = "perl -pe 's/\\e\\[[\\d;]*\\S//g' #{Rails.configuration.paths["log"].first.to_s.bash_escape}"
-    command += " | grep -E -v '#{remove_egrep.join("|")}'" if remove_egrep.size > 0
+    command += " | perl -n -e 'print unless /#{remove_egrep.join("|")}/'" if remove_egrep.size > 0
     command += " | tail -#{num_lines}"
 
     # Slurp it all

--- a/BrainPortal/app/controllers/portal_controller.rb
+++ b/BrainPortal/app/controllers/portal_controller.rb
@@ -97,10 +97,11 @@ class PortalController < ApplicationController
     remove_egrep << "^Completed"      if params[:hide_completed].presence  == "1"
     # Note that in production, 'SQL', 'CACHE' and 'LOAD' are never shown.
     remove_egrep << "^ *SQL "         if params[:hide_sql].presence        == "1"
-    remove_egrep << "BEGIN"           if params[:hide_sql].presence        == "1"
-    remove_egrep << "SELECT"          if params[:hide_sql].presence        == "1"
-    remove_egrep << "UPDATE"          if params[:hide_sql].presence        == "1"
-    remove_egrep << "COMMIT"          if params[:hide_sql].presence        == "1"
+    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+BEGIN"          if params[:hide_sql].presence        == "1"
+    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+COMMIT"         if params[:hide_sql].presence        == "1"
+    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+SELECT"         if params[:hide_sql].presence        == "1"
+    remove_egrep << "^\\s+\\(\\d+\\.\\d+ms\\)\\s+UPDATE"         if params[:hide_sql].presence        == "1"
+    remove_egrep << "^\\s+\\w+\\s+Exists \\(\\d+\\.\\d+ms\\) "   if params[:hide_exists].presence    == "1"
     remove_egrep << "^ *CACHE "       if params[:hide_cache].presence      == "1"
     remove_egrep << "^ *[^ ]* Load"   if params[:hide_load].presence       == "1"
 

--- a/BrainPortal/app/views/portal/portal_log.html.erb
+++ b/BrainPortal/app/views/portal/portal_log.html.erb
@@ -22,8 +22,8 @@
          # In development env, only the controllers accessed at least once show up as descendants of
          # ApplicationController, so we hardcode a initial 'good enough' list.
          controller_list = %w( access_profiles bourreaux custom_filters data_providers feedbacks groups
-                               help_documents invitations messages portal session_data sessions sites
-                               tags tasks tools tool_configs userfiles users ) # what we have at 4.5.0
+                               help_documents invitations messages portal session_data sessions signups
+                               sites tags tasks tools tool_configs userfiles users ) # what we have at 4.5.0
          # The line below adds any other controllers we might have missed (at least in production env).
          controller_list += ApplicationController.descendants.map(&:name).map { |n| n.sub(/Controller$/,"").underscore }
          controller_list = controller_list.uniq.sort
@@ -43,7 +43,6 @@
       | 'SQL':        <%= check_box_tag :hide_sql,        "1", params[:hide_sql]        == "1" %>
       | 'Load':       <%= check_box_tag :hide_load,       "1", params[:hide_load]       == "1" %>
       | 'CACHE':      <%= check_box_tag :hide_cache,      "1", params[:hide_cache]      == "1" %>
-      | 'AREL':       <%= check_box_tag :hide_arel,       "1", params[:hide_arel]       == "1" %>
     <% end %>
 
   </div>

--- a/BrainPortal/app/views/portal/portal_log.html.erb
+++ b/BrainPortal/app/views/portal/portal_log.html.erb
@@ -42,6 +42,7 @@
     <% if Rails.env == 'development' %>
       | 'SQL':        <%= check_box_tag :hide_sql,        "1", params[:hide_sql]        == "1" %>
       | 'Load':       <%= check_box_tag :hide_load,       "1", params[:hide_load]       == "1" %>
+      | 'Exists':     <%= check_box_tag :hide_exists,     "1", params[:hide_exists]     == "1" %>
       | 'CACHE':      <%= check_box_tag :hide_cache,      "1", params[:hide_cache]      == "1" %>
     <% end %>
 


### PR DESCRIPTION
Changed the log filters so they will filter out the relevant log lines again. The SQL filter may pick up more than just the SQL statements, as it matches `SELECT`, but I don't think this is a problem as if you're trying to remove SQL statements you probably don't care about cache SQL statements. Fixes #515.
