### PR TITLE
Show Page Descriptions & Edit User Access Profiles

### DIFF
--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -226,6 +226,7 @@ class UsersController < ApplicationController
     original_group_ids = @user.group_ids
     original_ap_ids    = @user.access_profile_ids
 
+
     @user.make_all_accessible! if current_user.has_role?(:admin_user)
     if current_user.has_role? :site_manager
       @user.make_accessible!(:group_ids, :type, :account_locked)
@@ -238,6 +239,11 @@ class UsersController < ApplicationController
     end
 
     @user.attributes = params[:user]
+
+    remove_ap_ids     = original_ap_ids - @user.access_profile_ids
+    remove_group_ids  = AccessProfile.find(remove_ap_ids).map(&:group_ids).flatten.uniq
+
+    @user.apply_access_profiles(remove_group_ids: remove_group_ids)
 
     @user = @user.class_update
 

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -240,8 +240,8 @@ class UsersController < ApplicationController
 
     @user.attributes = params[:user]
 
-    remove_ap_ids     = original_ap_ids - @user.access_profile_ids
-    remove_group_ids  = AccessProfile.find(remove_ap_ids).map(&:group_ids).flatten.uniq
+    remove_ap_ids    = original_ap_ids - @user.access_profile_ids
+    remove_group_ids = remove_ap_ids.present? ? AccessProfile.find(remove_ap_ids).map(&:group_ids).flatten.uniq : []
 
     @user.apply_access_profiles(remove_group_ids: remove_group_ids)
 

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -224,6 +224,7 @@ class UsersController < ApplicationController
 
     # For logging
     original_group_ids = @user.group_ids
+    original_ap_ids    = @user.access_profile_ids
 
     @user.make_all_accessible! if current_user.has_role?(:admin_user)
     if current_user.has_role? :site_manager
@@ -244,6 +245,7 @@ class UsersController < ApplicationController
       if @user.save_with_logging(current_user, %w( full_name login email role city country account_locked ) )
         @user.reload
         @user.addlog_object_list_updated("Groups", Group, original_group_ids, @user.group_ids, current_user)
+        @user.addlog_object_list_updated("Access Profiles", AccessProfile, original_ap_ids, @user.access_profile_ids, current_user)
         add_meta_data_from_form(@user, [:pref_bourreau_id, :pref_data_provider_id, :ip_whitelist])
         flash[:notice] = "User #{@user.login} was successfully updated."
         format.html { redirect_to :action => :show }

--- a/BrainPortal/app/helpers/rich_ui_helper.rb
+++ b/BrainPortal/app/helpers/rich_ui_helper.rb
@@ -46,6 +46,12 @@ module RichUiHelper
     link.html_safe
   end
 
+  # Takes a +description+ with multiple lines and shows
+  # the whole thing, including line breaks.
+  def full_description(description)
+    ("<span style=\"white-space: pre-wrap;\">" + description + "</span>").html_safe
+  end
+
   # Create an element that opens a dropdown when it's
   # hovered over.
   def hover_dropdown(header, options = {}, &block)

--- a/BrainPortal/app/helpers/rich_ui_helper.rb
+++ b/BrainPortal/app/helpers/rich_ui_helper.rb
@@ -49,7 +49,7 @@ module RichUiHelper
   # Takes a +description+ with multiple lines and shows
   # the whole thing, including line breaks.
   def full_description(description)
-    ("<span style=\"white-space: pre-wrap;\">" + description + "</span>").html_safe
+    "<span style=\"white-space: pre-wrap;\">".html_safe + description + "</span>".html_safe
   end
 
   # Create an element that opens a dropdown when it's

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -396,8 +396,7 @@ class User < ActiveRecord::Base
   # the user will be removed from these groups as
   # long as they are not also in any of the AccessProfiles.
   #
-  #
-  # Ex: given two access profiles with these (overlapping) group IDs:
+  # Ex: given two AccessProfiles with these (overlapping) group IDs:
   #
   #   ap1.group_ids = [ 11, 12, 13, 99,            ]
   #   ap2.group_ids = [             99, 21, 22, 23 ]

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -53,7 +53,7 @@
     t.column("Projects", :projects) do |s|
       if (s.groups.count > 4)
         s.groups[0..3].sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence + " ... "
-      else (s.groups.count > 0)
+      else
         s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence || "(None)"
       end
     end
@@ -61,7 +61,7 @@
     t.column("Users", :users) do |s|
       if (s.users.count > 4)
         s.users[0..3].sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe + " ... "
-      else (s.users.count > 0)
+      else
         s.users.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence || "(None)"
       end
     end

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -51,11 +51,19 @@
     ) { |s| overlay_description(s.description) }
 
     t.column("Projects", :projects) do |s|
-      (s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(None)"
+      if (s.groups.count > 4)
+        s.groups[0..3].sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence + " ... "
+      else (s.groups.count > 0)
+        s.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence || "(None)"
+      end
     end
 
     t.column("Users", :users) do |s|
-      (s.users.count.to_s.html_safe)
+      if (s.users.count > 4)
+        s.users[0..3].sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe + " ... "
+      else (s.users.count > 0)
+        s.users.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence || "(None)"
+      end
     end
   %>
 <% end %>

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -48,7 +48,7 @@
 
     t.column("Description", :description,
       :sortable => true,
-    ) { |s| overlay_description(s.description.html_safe) }
+    ) { |s| overlay_description(s.description) }
 
     t.column("Projects", :projects) do |s|
       if (s.groups.count > 4)

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -55,7 +55,7 @@
     end
 
     t.column("Users", :users) do |s|
-      (s.users.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence) || "(None)"
+      (s.users.count.to_s.html_safe)
     end
   %>
 <% end %>

--- a/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
+++ b/BrainPortal/app/views/access_profiles/_access_profiles_table.html.erb
@@ -48,7 +48,7 @@
 
     t.column("Description", :description,
       :sortable => true,
-    ) { |s| overlay_description(s.description) }
+    ) { |s| overlay_description(s.description.html_safe) }
 
     t.column("Projects", :projects) do |s|
       if (s.groups.count > 4)

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -88,8 +88,8 @@
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
 
-    <% if !myusers.nil? && myusers.count > 0 %>
-      <% user_names = (array_to_table(myusers.map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 4).html_safe) %>
+    <% if myusers.present? && myusers.count > 0 %>
+      <% user_names = (array_to_table(myusers.map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 12).html_safe) %>
     <% else %>
       <% user_names = "(None)" %>
     <% end %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -87,7 +87,13 @@
   <% end %>
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
-    <% user_names = (myusers.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }.join(", ").html_safe.presence) || "(None)" %>
+
+    <% if !myusers.nil? && myusers.count > 0 %>
+      <% user_names = (array_to_table(myusers.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 4).html_safe) %>
+    <% else %>
+      <% user_names = "(None)" %>
+    <% end %>
+
     <% t.edit_cell(:user_ids, :show_width => 2, :no_header => "Users", :content => user_names) do %>
 
       Normal Users<br>
@@ -112,7 +118,7 @@
     <% end %>
   <% end %>
 
-  <P>
+  <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @access_profile.getlog, :title => 'Access Profile Log' } %>
 
 </div>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -53,7 +53,7 @@
       <%= render :partial => 'shared/color_picker', :locals => { :step => 30, :greys => false, :dark => false } %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => full_desciption(@access_profile.description), :show_width => 2 ) do %>
+    <% t.edit_cell(:description, :content => full_description(@access_profile.description), :show_width => 2 ) do %>
       <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
       <span class="field_explanation">These are your private notes about this profile.</span>
     <% end %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -53,14 +53,14 @@
       <%= render :partial => 'shared/color_picker', :locals => { :step => 30, :greys => false, :dark => false } %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => @access_profile.description ) do %>
+    <% t.edit_cell(:description, :content => @access_profile.description, :show_width => 2 ) do %>
       <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
       <span class="field_explanation">These are your private notes about this profile.</span>
     <% end %>
 
   <% end %>
 
-  <% myusers = @access_profile.users.all %>
+  <% myusers = @access_profile.users.all.sort_by(&:login) %>
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
     <% group_names = (@access_profile.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(None)" %>
@@ -89,7 +89,7 @@
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
 
     <% if !myusers.nil? && myusers.count > 0 %>
-      <% user_names = (array_to_table(myusers.sort_by(&:login).map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 4).html_safe) %>
+      <% user_names = (array_to_table(myusers.map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 4).html_safe) %>
     <% else %>
       <% user_names = "(None)" %>
     <% end %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -53,7 +53,7 @@
       <%= render :partial => 'shared/color_picker', :locals => { :step => 30, :greys => false, :dark => false } %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => @access_profile.description, :show_width => 2 ) do %>
+    <% t.edit_cell(:description, :content => full_desciption(@access_profile.description), :show_width => 2 ) do %>
       <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
       <span class="field_explanation">These are your private notes about this profile.</span>
     <% end %>

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -53,7 +53,7 @@
       <%= render :partial => 'shared/color_picker', :locals => { :step => 30, :greys => false, :dark => false } %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => overlay_description(@access_profile.description), :show_width => 2 ) do %>
+    <% t.edit_cell(:description, :content => @access_profile.description ) do %>
       <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
       <span class="field_explanation">These are your private notes about this profile.</span>
     <% end %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -60,7 +60,7 @@
       </div>
     <% end %>
 
-    <% t.edit_cell(:description, :content =>  @bourreau.description) do %>
+    <% t.edit_cell(:description, :content =>  full_description(@bourreau.description)) do %>
       <%= text_area_tag "bourreau[description]", @bourreau.description, :rows => 10, :cols => 40 %><br>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -60,7 +60,7 @@
       </div>
     <% end %>
 
-    <% t.edit_cell(:description, :content =>  overlay_description(@bourreau.description)) do %>
+    <% t.edit_cell(:description, :content =>  @bourreau.description) do %>
       <%= text_area_tag "bourreau[description]", @bourreau.description, :rows => 10, :cols => 40 %><br>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -60,7 +60,7 @@
       <%= text_field_tag "data_provider[name]", @provider.name %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => overlay_description(@provider.description)) do %>
+    <% t.edit_cell(:description, :content => @provider.description) do %>
       <%= text_area_tag "data_provider[description]", @provider.description, :rows => 10, :cols => 40 %><br>
     <% end %>
 

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -60,7 +60,7 @@
       <%= text_field_tag "data_provider[name]", @provider.name %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => @provider.description) do %>
+    <% t.edit_cell(:description, :content => full_description(@provider.description)) do %>
       <%= text_area_tag "data_provider[description]", @provider.description, :rows => 10, :cols => 40 %><br>
     <% end %>
 

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -60,7 +60,7 @@
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
 
-    <% t.edit_cell(:description, :content =>  @group.description) do %>
+    <% t.edit_cell(:description, :content =>  full_description(@group.description)) do %>
         <%= text_area_tag "group[description]", @group.description, :rows => 4, :cols => 40 %><br>
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
     <% end %>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -60,7 +60,7 @@
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
 
-    <% t.edit_cell(:description, :content =>  overlay_description(@group.description)) do %>
+    <% t.edit_cell(:description, :content =>  @group.description) do %>
         <%= text_area_tag "group[description]", @group.description, :rows => 4, :cols => 40 %><br>
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
     <% end %>
@@ -91,14 +91,10 @@
 
   <% end %>
 
-  <% # Access Profile List %>
-  <% if current_user.has_role?(:admin_user) && @group.access_profiles.count > 0 %>
-    <%= show_table(@group, :header => 'Access profiles') do |t| %>
-      <% t.cell("Access Profiles", :no_header => true) do %>
-        <%= array_to_table(@group.access_profiles.order(:name).all, :table_class => "simple", :cols => 4) do |access_profile| %>
-          <%= access_profile_label(access_profile, :with_link => true) %>
-        <% end %>
-      <% end %>
+  <% if current_user.has_role?(:admin_user) %>
+    <% group_access_profiles = (@group.access_profiles.map { |ap| access_profile_label(ap) }.join("&nbsp&nbsp").html_safe.presence) || "(None)" %>
+    <%= show_table(@group, :header => 'Access Profiles') do |t| %>
+      <% t.cell("Access Profiles") { group_access_profiles } %>
     <% end %>
   <% end %>
 

--- a/BrainPortal/app/views/shared/_access_profile_checkbox_table.html.erb
+++ b/BrainPortal/app/views/shared/_access_profile_checkbox_table.html.erb
@@ -23,15 +23,23 @@
 -%>
 
 <%
+   # This partial renders a table of access profile names with checkboxes
+   # Partial locals:
+   #
+   #   access_profiles => [ access_profile, access_profile, ... ]
+   #   checked         => [ access_profile, access_profile, ... ]
+   #   variable_name   => "somemodel[group_ids][]"  # for instance; must end with '[]'
+   #   boxids          => "some_dom_id"             # will be appened with _{id}
+   #   html_class      => "someclass"               # for checkboxes
    checked    ||= []
    boxids     ||= "id_#{rand(1000000)}"
    html_class ||= ""
  %>
 
 <%
-  # Convenience helper to render a single checkbox and a user name
-  access_profile_check_box = lambda do |access_profile|
-    check_box_tag( variable_name,                                # html var name
+  # Convenience helper to render a single checkbox and an access profile name
+    access_profile_check_box = lambda do |access_profile|
+    check_box_tag( variable_name,                                          # html var name
                    access_profile.id.to_s,                                 # value
                    checked.include?(access_profile),                       # checked or not
                    :id => "#{boxids}_#{access_profile.id}",                # unique DOM id
@@ -44,7 +52,7 @@
 
 <%= hidden_field_tag variable_name, [], :id => "#{boxids}_unchecked" %>
 
-<%= array_to_table(access_profiles, :cols => 4) do |access_profile,r,c| %>
+<%= array_to_table(access_profiles, :cols => 12) do |access_profile,r,c| %>
   <%= access_profile_check_box.(access_profile) %>
 <% end %>
 

--- a/BrainPortal/app/views/shared/_access_profile_checkbox_table.html.erb
+++ b/BrainPortal/app/views/shared/_access_profile_checkbox_table.html.erb
@@ -30,20 +30,21 @@
 
 <%
   # Convenience helper to render a single checkbox and a user name
-  user_check_box = lambda do |user|
+  access_profile_check_box = lambda do |access_profile|
     check_box_tag( variable_name,                                # html var name
-                   user.id.to_s,                                 # value
-                   checked.include?(user),                       # checked or not
-                   :id => "#{boxids}_#{user.id}",                # unique DOM id
+                   access_profile.id.to_s,                                 # value
+                   checked.include?(access_profile),                       # checked or not
+                   :id => "#{boxids}_#{access_profile.id}",                # unique DOM id
                    :class => html_class,
                  ).html_safe +
-    (" <label for=\"#{boxids}_#{user.id}\">" + h(user.login) + "</label>").html_safe
+    (" <label for=\"#{boxids}_#{access_profile.id}\">" + access_profile_label(access_profile) + "</label>").html_safe
+
   end
 %>
 
 <%= hidden_field_tag variable_name, [], :id => "#{boxids}_unchecked" %>
 
-<%= array_to_table(users, :cols => 4, :td_class => 'left_align no_wrap') do |user,r,c| %>
-  <%= user_check_box.(user) %>
+<%= array_to_table(access_profiles, :cols => 4) do |access_profile,r,c| %>
+  <%= access_profile_check_box.(access_profile) %>
 <% end %>
 

--- a/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
+++ b/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
@@ -23,6 +23,14 @@
 -%>
 
 <%
+   # This partial renders a table of users logins with checkboxes
+   # Partial locals:
+   #
+   #   users         => [ user, user, ... ]
+   #   checked       => [ user, user, ... ]
+   #   variable_name => "somemodel[group_ids][]"  # for instance; must end with '[]'
+   #   boxids        => "some_dom_id"             # will be appened with _{id}
+   #   html_class    => "someclass"               # for checkboxes
    checked    ||= []
    boxids     ||= "id_#{rand(1000000)}"
    html_class ||= ""

--- a/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
+++ b/BrainPortal/app/views/shared/_users_checkbox_table.html.erb
@@ -51,7 +51,7 @@
 
 <%= hidden_field_tag variable_name, [], :id => "#{boxids}_unchecked" %>
 
-<%= array_to_table(users, :cols => 4, :td_class => 'left_align no_wrap') do |user,r,c| %>
+<%= array_to_table(users, :cols => 12, :td_class => 'left_align no_wrap') do |user,r,c| %>
   <%= user_check_box.(user) %>
 <% end %>
 

--- a/BrainPortal/app/views/sites/show.html.erb
+++ b/BrainPortal/app/views/sites/show.html.erb
@@ -18,14 +18,14 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 -%>
 
 <% title "Site" %>
 
 <div class="menu_bar">
-  <%= overlay_ajax_link "Help", "/doc/sites/site_info.html", :class  => "button" %>    
+  <%= overlay_ajax_link "Help", "/doc/sites/site_info.html", :class  => "button" %>
   <%= link_to 'Delete', site_path(@site),  { :confirm => "Are you sure you want to delete '#{@site.name}' ?", :method => :delete, :class => "button"} %>
 </div>
 
@@ -36,7 +36,7 @@
 
   <%= show_table(@site, :edit_condition => check_role(:admin_user)) do |t| %>
     <% t.edit_cell(:name) { text_field_tag "site[name]", @site.name } %>
-    <% t.edit_cell(:description, :content => overlay_description(@site.description) ) do %>
+    <% t.edit_cell(:description, :content => @site.description ) do %>
       <%= text_area_tag "site[description]", @site.description, :rows => 10, :cols => 40 %><br/>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>
@@ -45,7 +45,7 @@
     <% t.cell("Managers", :show_width => 2) do %>
       <%= array_to_table(@site.managers.sort{|a, b| a.login.casecmp(b.login)}, :min_data => 6, :table_class => 'simple bordered') {|u,r,c| link_to_user_with_tooltip(u)} %>
     <% end %>
-    <% 
+    <%
       t.blank_row
       t.cell("Users")            { index_count_filter @site.users.count,  :users,  {:site_id => @site.id} }
       t.cell("Projects")         { index_count_filter @site.groups.count, :groups, {:site_id => @site.id} }
@@ -54,7 +54,7 @@
       t.cell("Remote Resources") { @site.remote_resources_find_all.count }
     %>
   <% end %>
-  
+
   <br>
 
   <table class="resource_list">

--- a/BrainPortal/app/views/sites/show.html.erb
+++ b/BrainPortal/app/views/sites/show.html.erb
@@ -36,7 +36,7 @@
 
   <%= show_table(@site, :edit_condition => check_role(:admin_user)) do |t| %>
     <% t.edit_cell(:name) { text_field_tag "site[name]", @site.name } %>
-    <% t.edit_cell(:description, :content => @site.description ) do %>
+    <% t.edit_cell(:description, :content => full_description(@site.description)) do %>
       <%= text_area_tag "site[description]", @site.description, :rows => 10, :cols => 40 %><br/>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>

--- a/BrainPortal/app/views/tool_configs/show.html.erb
+++ b/BrainPortal/app/views/tool_configs/show.html.erb
@@ -49,7 +49,7 @@
         <strong>Config #<%= @tool_config.id %></strong>
         (<%= link_to "edit", edit_tool_config_path(@tool_config) %>):
         For tool <strong><%= @tool_config.tool.name %></strong> running on Execution Server <strong><%= @tool_config.bourreau.name %></strong>
-        <br>Named: <%= @tool_config.description %>
+        <br>Named: <%= full_description(@tool_config.description) %>
         <br>Available to members of project <%= link_to_group_if_accessible(@tool_config.group) %>
         <% if @tool_config.ncpus.present? && @tool_config.ncpus.to_i > 0 %>
           <br>Suggested number of CPUs: <%= @tool_config.ncpus.to_i.to_s %>

--- a/BrainPortal/app/views/tool_configs/show.html.erb
+++ b/BrainPortal/app/views/tool_configs/show.html.erb
@@ -18,7 +18,7 @@
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.  
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 -%>
 
@@ -29,34 +29,34 @@
 <div class="generalbox">
 
   Configurations shown here:
-  <UL>
+  <ul>
     <% if @bourreau_glob_config %>
-      <LI>
+      <li>
         <strong>Config #<%= @bourreau_glob_config.id %></strong>
         (<%= link_to "edit", edit_tool_config_path(@bourreau_glob_config) %>):
         For <strong>ALL tools</strong> running on Execution Server <strong><%= @bourreau_glob_config.bourreau.name %></strong>
-      </LI>
+      </li>
     <% end %>
     <% if @tool_glob_config %>
-      <LI>
+      <li>
         <strong>Config #<%= @tool_glob_config.id %></strong>
         (<%= link_to "edit", edit_tool_config_path(@tool_glob_config) %>):
         For tool <strong><%= @tool_glob_config.tool.name %></strong> running on <strong>ALL Execution Servers</strong>
-      </LI>
+      </li>
     <% end %>
     <% if @tool_config %>
-      <LI>
+      <li>
         <strong>Config #<%= @tool_config.id %></strong>
         (<%= link_to "edit", edit_tool_config_path(@tool_config) %>):
         For tool <strong><%= @tool_config.tool.name %></strong> running on Execution Server <strong><%= @tool_config.bourreau.name %></strong>
-        <br>Named: <%= overlay_description(@tool_config.description) %>
+        <br>Named: <%= @tool_config.description %>
         <br>Available to members of project <%= link_to_group_if_accessible(@tool_config.group) %>
         <% if @tool_config.ncpus.present? && @tool_config.ncpus.to_i > 0 %>
           <br>Suggested number of CPUs: <%= @tool_config.ncpus.to_i.to_s %>
         <% end %>
-      </LI>
+      </li>
     <% end %>
-  </UL>
+  </ul>
 
   <p>
   <strong>Important note:</strong>
@@ -73,17 +73,17 @@
 </div>
 
 <% if @bourreau_glob_config %>
-  <P>
+  <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @bourreau_glob_config.getlog, :title => "Log of Global Bourreau Tool Config ##{@bourreau_glob_config.id}" } %>
 <% end %>
 
 <% if @tool_glob_config %>
-  <P>
+  <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @tool_glob_config.getlog, :title => "Log of Global Tool Config ##{@tool_glob_config.id}" } %>
 <% end %>
 
 <% if @tool_config %>
-  <P>
+  <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @tool_config.getlog, :title => "Log of Specific Tool Config ##{@tool_config.id}" } %>
 <% end %>
 

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -211,11 +211,9 @@
 
     </div>
 
-    <P>
+    <p>
 
   <% end %>
-
-
 
   <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @log, :title => 'User activity report' } %>

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -153,13 +153,21 @@
 
   <% end %>
 
-  <% # Access Profile List %>
-  <% if current_user.has_role?(:admin_user) && @user.access_profiles.count > 0 %>
-    <%= show_table(@user, :header => 'Access profiles') do |t| %>
-      <% t.cell("Access Profiles", :no_header => true) do %>
-        <%= array_to_table(@user.access_profiles.order(:name).all, :table_class => "simple", :cols => 4) do |access_profile| %>
-          <%= access_profile_label(access_profile, :with_link => true) %>
-        <% end %>
+  <% if current_user.has_role?(:admin_user) %>
+
+    <% user_access_profiles = (@user.access_profiles.map { |ap| access_profile_label(ap) }.join("&nbsp&nbsp").html_safe.presence) || "(None)" %>
+
+    <%= show_table(@user, :header => 'Access Profiles') do |t| %>
+      <% t.edit_cell(:access_profile_ids, :show_width => 2, :no_header => "Access Profiles", :content => user_access_profiles ) do %>
+
+        <%= render :partial => 'shared/access_profile_checkbox_table',
+                   :locals => {
+                                :access_profiles  => AccessProfile.all,
+                                :checked          => @user.access_profiles,
+                                :variable_name    => "user[access_profile_ids][]",
+                              }
+        %>
+
       <% end %>
     <% end %>
   <% end %>
@@ -207,7 +215,9 @@
 
   <% end %>
 
-  <P>
+
+
+  <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @log, :title => 'User activity report' } %>
 </div>
 


### PR DESCRIPTION
Allows admins to edit Users' Access Profiles from their show page, and displays full descriptions on show pages.

Fixes #533 and #531.
