### PR TITLE
Fixes POST in Task page

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -852,7 +852,15 @@ class TasksController < ApplicationController
     end
 
     #current_user.addlog_context(self,"Sent '#{operation}' to #{tasklist.size} tasks.")
-    redirect_to :action => :index, :format  => request.format.to_sym
+
+    respond_to do |format|
+      format.html { redirect_to :action => :index }
+      format.js   { redirect_to :action => :index }
+      format.json { head :ok }
+      format.xml  { head :ok }
+    end
+
+
 
   end # method 'operation'
 


### PR DESCRIPTION
A minor formatting issue was causing pagination to fail to render properly after an operation was performed. Fixes #537.  