### PR TITLE
Added support for Bourreau-side tests

### DIFF
--- a/BrainPortal/db/seeds_test_bourreau.rb
+++ b/BrainPortal/db/seeds_test_bourreau.rb
@@ -82,10 +82,7 @@ end
 # Seeding steps starts here
 #------------------------------------------------
 
-raise "The seeding process must be run by a process connected to a terminal" unless
-  STDIN.tty? && STDOUT.tty? && STDERR.tty?
-stty_save = `stty -g`.chomp
-trap('INT') { system('stty', stty_save) ; puts "\n\nInterrupt. Exiting."; exit(0) }
+trap('INT') { puts "\n\nInterrupt. Exiting."; exit(0) }
 hostname = Socket.gethostname
 
 myself = RemoteResource.current_resource
@@ -122,7 +119,7 @@ BASE_DIR
 
 default_support_dir     = "#{rails_home}/seeds_dev_support_dir"
 print "[#{default_support_dir}] "
-seeds_dev_support_dir   = STDIN.gets.strip.presence
+seeds_dev_support_dir   = STDIN.tty? ? STDIN.gets.strip.presence : nil
 seeds_dev_support_dir ||= default_support_dir
 Dir.mkdir(seeds_dev_support_dir) unless Dir.exists?(seeds_dev_support_dir)
 

--- a/Travis/run_tests.sh
+++ b/Travis/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash --login
 
-set -a # bash will exit immediately if any command returns a code other than 0
+set -e # bash will exit immediately if any command returns a code other than 0
 
 #####################
 # Utility functions #
@@ -9,7 +9,7 @@ set -a # bash will exit immediately if any command returns a code other than 0
 # Prints a message and exits with a non-zero code.
 function die {
     echo Fatal: "$*"
-    exit 2
+    exit 5
 }
 
 ###############
@@ -29,16 +29,38 @@ dockerize -template $HOME/cbrain_test/Travis/templates/config_portal.rb.TEMPLATE
 
 # Make sure RVM is loaded
 source /home/cbrain/.bashrc
+export RAILS_ENV=test
+
+
+
+# ------------------------------
+# Portal-Side Initializations
+# ------------------------------
 
 # Go to the new code to test
-cd $HOME/cbrain_test/BrainPortal  || die "Cannot cd to BrainPortal directory"
+cd $HOME/cbrain_test/BrainPortal    || die "Cannot cd to BrainPortal directory"
 
 # Prep all that needs to be prepared. With a bit of luck, bundle install
 # will be quite quick given that when building the docker image we already
 # ran it once in ~/cbrain_base.
-export RAILS_ENV=test
-bundle install
-rake cbrain:plugins:install:plugins || die "Cannot install cbrain:plugins"
+bundle install                      || die "Cannot bundle gems for the BrainPortal"
+rake cbrain:plugins:install:plugins || die "Cannot install cbrain:plugins" # works for Bourreau too
+
+
+
+# ------------------------------
+# Bourreau-Side Initializations
+# ------------------------------
+
+# Go to the new code to test
+cd $HOME/cbrain_test/Bourreau       || die "Cannot cd to Bourreau directory"
+bundle install                      || die "Cannot bundle gems for the Bourreau"
+
+
+
+# ------------------------------
+# Wait for DB
+# ------------------------------
 
 # Waits for DB to be available
 dockerize -wait tcp://${MYSQL_HOST}:${MYSQL_PORT} -timeout 90s || die "Cannot wait for mysql:3306 to be up or timeout was reached"
@@ -53,12 +75,57 @@ do
   sleep 3
 done
 
+
+
+# ------------------------------
+# Seed the DB
+# ------------------------------
+
 # Prep steps that necessitates the DB to be ready.
-rake db:schema:load   || die "Cannot load DB schema"
-rake db:seed          || die "Cannot seed DB"
-rake db:sanity:check  || die "Cannot sanity check DB"
+cd $HOME/cbrain_test/BrainPortal || die "Cannot cd to BrainPortal directory"
+rake "db:schema:load"        || die "Cannot load DB schema"
+rake "db:seed"               || die "Cannot seed DB for BrainPortal"
+rake "db:seed:test:bourreau" || die "Cannot seed the DB for Bourreau"
+rake "db:sanity:check"       || die "Cannot sanity check DB"
+
+# In order to always run both rspec commands, we save the failures in a string.
+fail_portal=""
+fail_bourreau=""
+
+
+# ------------------------------
+# Portal-Side Testing
+# ------------------------------
+cd $HOME/cbrain_test/BrainPortal || die "Cannot cd to BrainPortal directory"
 
 # Eventually, it would be nice if from a ENV variable set in Travis,
 # we could run only a subset of the tests.
-rspec spec            || die "Failed running rspec"
+rspec spec                       || fail_portal="rspec on BrainPortal failed with return code $?"
+
+
+
+# ------------------------------
+# Bourreau-Side Testing
+# ------------------------------
+cd $HOME/cbrain_test/Bourreau    || die "Cannot cd to Bourreau directory"
+
+# Eventually, it would be nice if from a ENV variable set in Travis,
+# we could run only a subset of the tests.
+# -> NOTE FIXME TODO : hardcoded 'spec/boutiques' for <-
+# -> the moment because no other test files work on Bourreau. <-
+rspec spec/boutiques             || fail_bourreau="rspec on Bourreau failed with return code $?"
+
+
+
+# ------------------------------
+# Return status of both rspec
+# ------------------------------
+test -z "$fail_portal$fail_bourreau" && exit 0  # Pangloss
+echo ""
+echo "**** rspec commands failures summary ****"
+test -n "$fail_portal"   && echo "$fail_portal"
+test -n "$fail_bourreau" && echo "$fail_bourreau"
+echo "**** ------------------------------- ****"
+echo ""
+exit 2
 

--- a/Travis/travis_ci.sh
+++ b/Travis/travis_ci.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ###############################################################################
 #                                                                             #
@@ -46,19 +46,21 @@ SECONDS=0 # bash is great
 printf "${MAGENTA}Running containers in Docker Compose.${NC}\n"
 compose_project_name='travis' # used to refer to docker services: travis_cbrain_1, travis_mysql_1
 cbrain_service="${compose_project_name}_cbrain_1" # docker compose convention
-env CBRAIN_CI_IMAGE_NAME=$CBRAIN_CI_IMAGE_NAME docker-compose -p $compose_project_name up -d
+env CBRAIN_CI_IMAGE_NAME=$CBRAIN_CI_IMAGE_NAME docker-compose -p $compose_project_name up -d --force-recreate
 if [ $? -ne 0 ] ; then
   printf "${RED}Docker Compose Failed. So sorry.${NC}\n"
   exit 10 # partial abomination
 fi
-test_exit_code=$(docker wait ${cbrain_service})
-printf "${MAGENTA}Docker Compose finished after $SECONDS seconds.${NC}\n"
 
-# Print logs (always, by request)
+# Print logs (always, by request).
+# Also Travis CI will abort the test if nothing is printed for too long.
 echo ""
 printf "${MAGENTA}==== Docker logs start here ====${NC}\n"
-docker logs travis_cbrain_1
+docker logs ${cbrain_service} --follow
 printf "${MAGENTA}==== Docker logs end here ====${NC}\n"
+echo ""
+test_exit_code=$(docker wait ${cbrain_service})
+printf "${MAGENTA}Docker Compose finished after $SECONDS seconds.${NC}\n"
 echo ""
 
 # Final Results


### PR DESCRIPTION
Hi. I added support for running the tests on the Bourreau side now in Travis.

For the moment I hardcoded that only `spec/boutiques` is supplied in argument to `rspec` because other files we have in the `spec/` subdirectory are all broken; only the boutiques files work.

The test script will run rspec on the portal side, and then on the bourreau side EVEN if there were failures on the portal side.

Everything is reported nice and clean at the end. I didn't even have to rebuild the Docker image for CBRAIN, it was usable as-is.

Eventually I'd like to have a lot more tests on the bourreau side and then we'll run them all.