### PR TITLE
Fixes some tests.

### DIFF
--- a/Bourreau/.rspec
+++ b/Bourreau/.rspec
@@ -3,3 +3,4 @@
 --require spec_helper
 --format documentation
 --order defined
+--fail-fast=50

--- a/BrainPortal/.rspec
+++ b/BrainPortal/.rspec
@@ -3,3 +3,4 @@
 --require spec_helper
 --format documentation
 --order rand
+--fail-fast=50

--- a/BrainPortal/spec/models/en_cbrain_local_data_provider_spec.rb
+++ b/BrainPortal/spec/models/en_cbrain_local_data_provider_spec.rb
@@ -39,20 +39,25 @@ describe EnCbrainLocalDataProvider do
     end
 
     it "should return true if all works correctly" do
+      dp = en_cbrain_local_data_provider
       allow(Dir).to receive(:mkdir)
-      expect(en_cbrain_local_data_provider.cache_prepare(userfile)).to be_truthy
+      expect(dp.cache_prepare(userfile)).to be_truthy
     end
 
     it "should call mkdir if new userdir not already a directory" do
+      dp = en_cbrain_local_data_provider
+      u = userfile
       allow(File).to receive(:directory?).and_return(false)
       expect(Dir).to receive(:mkdir).at_least(4)
-      en_cbrain_local_data_provider.cache_prepare(userfile)
+      dp.cache_prepare(u)
     end
 
     it "should not call mkdir if new userdir is already a directory" do
+      dp = en_cbrain_local_data_provider
+      u = userfile
       allow(File).to receive(:directory?).and_return(true)
       expect(Dir).not_to receive(:mkdir)
-      en_cbrain_local_data_provider.cache_prepare(userfile)
+      dp.cache_prepare(u)
     end
   end
 

--- a/Travis/bootstrap.sh
+++ b/Travis/bootstrap.sh
@@ -13,6 +13,11 @@ if test "$UID" -ne 0 ; then
   exit 2
 fi
 
+MAGENTA='\033[35m'
+NC='\033[0m'
+
+printf "${MAGENTA}Container bootstrap script starting at %s ${NC}\n" "$(date '+%F %T')"
+
 test_user="cbrain"            # normal user to run test suite
 test_script="cb_run_tests.sh" # the script for running the suite
 

--- a/Travis/cb_run_tests.sh
+++ b/Travis/cb_run_tests.sh
@@ -11,6 +11,8 @@ YELLOW='\033[33m'
 BLUE='\033[34m'
 NC='\033[0m'
 
+printf "${YELLOW}Rails code initialization starting at %s ${NC}\n" "$(date '+%F %T')"
+
 # Three copies of the CBRAIN code base:
 cb_base="$HOME/cbrain_base"      # pre-installed and configured in docker container, for efficiency
 cb_travis="$HOME/cbrain_travis"  # docker mount point, where the code to be tested is

--- a/Travis/travis_ci.sh
+++ b/Travis/travis_ci.sh
@@ -43,7 +43,8 @@ fi
 SECONDS=0 # bash is great
 
 # Run the docker containers
-printf "${MAGENTA}Running CBRAIN test container.${NC}\n"
+printf "${MAGENTA}Launching CBRAIN test container at %s ${NC}\n" "$(date '+%F %T')"
+
 docker_name="cb_travis" # pretty name of the process
 docker run -d \
            -v "$cbrain_travis":/home/cbrain/cbrain_travis \


### PR DESCRIPTION
The failures were related to allow() and expect() statements
that were made before the FactoryGirl construction of some
objects were performed, and these interfered with those constructions.
Assigning the constructed objects to variables BEFORE specifying
the test conditions solved that. It's something to remember, in
general.

Also, failures are limited to 50 on each Portal and Bourreau sides.