### PR TITLE
Fixed bug with container working directory

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1914,7 +1914,7 @@ exit $status
   # Returns the command line(s) associated with the task, wrapped in
   # a Docker call if a Docker image has to be used.
   def docker_commands
-    work_dir = self.container_working_directory || '${PWD}'
+    work_dir = ( self.respond_to?("container_working_directory")? self.container_working_directory : nil )  || '${PWD}'
     commands = self.cluster_commands
     commands_joined = commands.join("\n");
 


### PR DESCRIPTION
Only Boutiques tasks have a `container_working_directory` method. Without this fix, non-Boutiques Docker tasks crash (try adding a Docker images to a Diagnostics ToolConfig). Should be a hotfix in my opinion.