### PR TITLE
BourreauWorkers checks task output before postproc.

### DIFF
--- a/Bourreau/app/models/bourreau_worker.rb
+++ b/Bourreau/app/models/bourreau_worker.rb
@@ -337,6 +337,9 @@ class BourreauWorker < Worker
 
       #####################################################################
       when 'Data Ready'
+        # If the status Data Ready is very recent and we don't find the stdout file from qsub, we wait.
+        return unless task.ready_to_post_process?
+
         action = task.prerequisites_fulfilled?(:for_post_processing)
         if action == :go
           # We need to raise an exception if we cannot successfully

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -200,7 +200,8 @@ class SessionsController < ApplicationController
         addrinfo  = Rails.cache.fetch("host_addr/#{from_ip}") do
           Socket.gethostbyaddr(from_ip.split(/\./).map(&:to_i).pack("CCCC")) rescue [ from_ip ]
         end
-        from_host = addrinfo[0]
+        from_host = addrinfo[0].presence
+        from_host = from_ip if from_host.blank? || from_host.size < 2 # seen weird "." as a result of lookup
       else
         from_host = from_ip # already got name?!?
       end

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -926,6 +926,7 @@ class RemoteResource < ActiveRecord::Base
         userfile = ss.userfile
         $0 = "CacheCleanup ID=#{userfile.id} #{i+1}/#{syncs.size}\0"
         userfile.cache_erase rescue nil
+        ss.delete rescue nil
       end
     end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/bash_scriptor/portal/bash_scriptor.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/bash_scriptor/portal/bash_scriptor.rb
@@ -52,6 +52,9 @@ class CbrainTask::BashScriptor < PortalTask
     if self.new_record? && (params[:num_files_per_task].blank? || params[:num_files_per_task].to_i < 1)
       params_errors.add(:num_files_per_task, "must be a number greater than 1.")
     end
+    if ((params[:bash_script].presence || "") !~ /\{cbrain_touch_when_completed\}/)
+      params_errors.add(:bash_script, "must include at least one instance of substitution of the keyword {cbrain_touch_when_completed}.")
+    end
     return ""
   end
 


### PR DESCRIPTION
The ClusterTask class now has a method ready_to_post_process?
which is invoked by the BourreauWorker before trying to trigger
post processing.

This will fix #577 

There are a few misc other changes I bundled in the commit too.