### PR TITLE
Signups Improvements & AccessProfiles bugfixes

### DIFF
--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -27,7 +27,7 @@ class Signup < ActiveRecord::Base
   attr_accessible       :title, :first, :middle, :last,
                         :institution, :department, :position, :email,
                         :street1, :street2, :city, :province, :country, :postal_code,
-                        :login, :time_zone, :comment
+                        :login, :time_zone, :comment, :admin_comment
 
   validates_presence_of :first, :last,
                         :institution, :department, :position, :email,
@@ -86,7 +86,7 @@ class Signup < ActiveRecord::Base
     user = NormalUser.new
 
    #user.title                   = self.title
-    user.full_name               = self.full.try :strip
+    user.full_name               = (self.first + " " + self.last).try :strip
     user.login                   = self.login.try :strip
     user.email                   = self.email.try :strip
    #user.institution             = self.institution

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -65,6 +65,10 @@ class Signup < ActiveRecord::Base
     "#{title} #{first} #{middle} #{last}".strip.gsub(/  +/, " ")
   end
 
+  def user_full #:nodoc:
+    "#{first} #{last}".strip.gsub(/  +/, " ")
+  end
+
   alias full_name full
 
   def approved? #:nodoc:
@@ -86,7 +90,7 @@ class Signup < ActiveRecord::Base
     user = NormalUser.new
 
    #user.title                   = self.title
-    user.full_name               = (self.first.try :strip) + " " + (self.last.try :strip)
+    user.full_name               = user_full
     user.login                   = self.login.try :strip
     user.email                   = self.email.try :strip
    #user.institution             = self.institution

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -86,7 +86,7 @@ class Signup < ActiveRecord::Base
     user = NormalUser.new
 
    #user.title                   = self.title
-    user.full_name               = (self.first + " " + self.last).try :strip
+    user.full_name               = (self.first.try :strip) + " " + (self.last.try :strip)
     user.login                   = self.login.try :strip
     user.email                   = self.email.try :strip
    #user.institution             = self.institution

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -84,6 +84,7 @@ class User < ActiveRecord::Base
   before_create             :add_system_groups
   before_save               :encrypt_password
   before_save               :destroy_sessions_if_locked
+  before_save               :apply_access_profiles
   after_update              :system_group_site_update
   after_destroy             :destroy_system_group
   after_destroy             :destroy_user_sessions
@@ -394,6 +395,9 @@ class User < ActiveRecord::Base
   # Scans the list of AccessProfiles associated
   # with the current user, and makes sure the user
   # is a member of all the groups in all these profiles.
+  # "before save" callback, so that if any changes are made
+  # to the list of AccessProfiles, the group membership will
+  # be properly updated.
   # If a list of +remove_group_ids+ is supplied,
   # the user will be removed from these groups as
   # long as they are not also in any of the AccessProfiles.
@@ -423,7 +427,8 @@ class User < ActiveRecord::Base
   # group 99, because it's present in ap2.
   def apply_access_profiles(remove_group_ids: [])
     gids = union_group_ids_from_access_profiles
-    self.group_ids = self.group_ids - remove_group_ids + gids # - and + are NOT COMMUTATIVE!
+    self.group_ids = self.group_ids - remove_group_ids + gids.to_set.to_a # - and + are NOT COMMUTATIVE!
+    true
   end
 
 

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -386,10 +386,11 @@ class User < ActiveRecord::Base
   # the current user.
   def union_group_ids_from_access_profiles
     aps = self.access_profiles
-    aps.inject([]) do |group_ids,ap|
+    gids = aps.inject([]) do |group_ids,ap|
       group_ids += ap.group_ids  # union of all
       group_ids
     end
+    gids.uniq
   end
 
   # Scans the list of AccessProfiles associated
@@ -427,7 +428,7 @@ class User < ActiveRecord::Base
   # group 99, because it's present in ap2.
   def apply_access_profiles(remove_group_ids: [])
     gids = union_group_ids_from_access_profiles
-    self.group_ids = self.group_ids - remove_group_ids + gids.to_set.to_a # - and + are NOT COMMUTATIVE!
+    self.group_ids = (self.group_ids - remove_group_ids + gids).uniq # - and + are NOT COMMUTATIVE!
     true
   end
 

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -82,7 +82,7 @@
     <%
       t.column("Email", :email,
         :sortable => true
-      ) { |d| red_if(d.dup_email?, d.email) }
+      ) { |d| red_if((d.dup_email? and not d.approved?), d.email) }
     %>
 
     <%

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -49,7 +49,7 @@
       :class      => [ :resource_list ],
       :id         => "signups_table",
       :order_map  => {
-        :creation_date  =>  { :a => 'created_at' },
+        :created_at     =>  { :a => 'signups.created_at' },
         :institution    =>  { :a => 'signups.institution' },
         :email          =>  { :a => 'signups.email' },
       },
@@ -57,6 +57,7 @@
     ) do |t|
   %>
     <%
+      t.paginate
       t.row do |d|
         {
           :select_param => 'reqids[]',
@@ -129,6 +130,14 @@
     %>
 
     <%
+      t.column("Private Comments", :admin_comment) do |d|
+        html_tool_tip(crop_text_to(40, d.admin_comment), :offset_x => 0, :offset_y => 20) do
+          simple_format(d.admin_comment, :sanitize => true)
+        end if d.admin_comment.present?
+      end
+    %>
+
+    <%
       t.column("In CBRAIN", :user) do |d|
         user = User.where(:login => d.login).first
         if (user)
@@ -138,6 +147,15 @@
         end
       end
      %>
+
+    <%
+      t.column("Created", :created_at,
+        :sortable => true,
+        :sort_order => :desc) do |d|
+
+        d.created_at.to_s
+      end
+    %>
 
     <%
       t.column("Status", :status) do |d|

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -153,7 +153,7 @@
         :sortable => true,
         :sort_order => :desc) do |d|
 
-        d.created_at.to_s
+        to_localtime(d.created_at, :datetime)
       end
     %>
 
@@ -168,7 +168,7 @@
         <% else %>
           <span class="warning">(Email unconfirmed)</span>
         <% end %>
-        <% if d.dup_email? %>
+        <% if d.dup_email? and not d.approved? %>
           <span  class="warning">(Conflicting email)</span>
         <% end %>
         <% if d.dup_login? %>

--- a/BrainPortal/app/views/signups/new.html.erb
+++ b/BrainPortal/app/views/signups/new.html.erb
@@ -152,6 +152,14 @@
       </td>
     </tr>
 
+    <% if @current_user.present? && current_user.has_role?(:admin_user) %>
+      <tr>
+        <th> <%= f.label(:admin_comment, "Private, admin-only comments:") %> </th>
+        <td> <%= f.text_area :admin_comment, :cols=>80, :rows => 5 %> </td>
+      </tr>
+    <% end %>
+
+
     <tr>
       <td colspan="2">&nbsp;</td>
     </tr>

--- a/BrainPortal/app/views/signups/show.html.erb
+++ b/BrainPortal/app/views/signups/show.html.erb
@@ -164,6 +164,13 @@ Below is a summary of the information in this account request.
     <td>&nbsp;</td>
   </tr>
 
+  <% if @current_user.present? && @current_user.has_role?(:admin_user) %>
+    <tr>
+      <th>Admin Comments</th>
+      <td> <%= @signup.admin_comment %> </td>
+    </tr>
+  <% end %>
+
   <% end %>
 
   <tr>

--- a/BrainPortal/app/views/signups/show.html.erb
+++ b/BrainPortal/app/views/signups/show.html.erb
@@ -167,7 +167,7 @@ Below is a summary of the information in this account request.
   <% if @current_user.present? && @current_user.has_role?(:admin_user) %>
     <tr>
       <th>Admin Comments</th>
-      <td> <%= @signup.admin_comment %> </td>
+      <td> <pre><%= @signup.admin_comment %></pre> </td>
     </tr>
   <% end %>
 

--- a/BrainPortal/db/migrate/20170104222339_add_private_comment_to_signups.rb
+++ b/BrainPortal/db/migrate/20170104222339_add_private_comment_to_signups.rb
@@ -1,0 +1,5 @@
+class AddPrivateCommentToSignups < ActiveRecord::Migration
+  def change
+    add_column :signups, :admin_comment, :string
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20161011184517) do
+ActiveRecord::Schema.define(:version => 20170104222339) do
 
   create_table "access_profiles", :force => true do |t|
     t.string   "name",        :null => false
@@ -116,6 +116,35 @@ ActiveRecord::Schema.define(:version => 20161011184517) do
   add_index "data_providers", ["group_id"], :name => "index_data_providers_on_group_id"
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
+
+  create_table "demands", :force => true do |t|
+    t.string   "title"
+    t.string   "first",         :null => false
+    t.string   "middle"
+    t.string   "last",          :null => false
+    t.string   "institution",   :null => false
+    t.string   "department"
+    t.string   "position"
+    t.string   "email",         :null => false
+    t.string   "website"
+    t.string   "street1"
+    t.string   "street2"
+    t.string   "city"
+    t.string   "province"
+    t.string   "country"
+    t.string   "postal_code"
+    t.string   "time_zone"
+    t.string   "service"
+    t.string   "login"
+    t.string   "comment"
+    t.string   "session_id"
+    t.string   "confirm_token"
+    t.boolean  "confirmed"
+    t.string   "approved_by"
+    t.datetime "approved_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+  end
 
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"
@@ -303,6 +332,7 @@ ActiveRecord::Schema.define(:version => 20161011184517) do
     t.datetime "approved_at"
     t.datetime "created_at",    :null => false
     t.datetime "updated_at",    :null => false
+    t.string   "admin_comment"
   end
 
   create_table "sites", :force => true do |t|

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -117,35 +117,6 @@ ActiveRecord::Schema.define(:version => 20170104222339) do
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
 
-  create_table "demands", :force => true do |t|
-    t.string   "title"
-    t.string   "first",         :null => false
-    t.string   "middle"
-    t.string   "last",          :null => false
-    t.string   "institution",   :null => false
-    t.string   "department"
-    t.string   "position"
-    t.string   "email",         :null => false
-    t.string   "website"
-    t.string   "street1"
-    t.string   "street2"
-    t.string   "city"
-    t.string   "province"
-    t.string   "country"
-    t.string   "postal_code"
-    t.string   "time_zone"
-    t.string   "service"
-    t.string   "login"
-    t.string   "comment"
-    t.string   "session_id"
-    t.string   "confirm_token"
-    t.boolean  "confirmed"
-    t.string   "approved_by"
-    t.datetime "approved_at"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
-  end
-
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"
     t.string   "request_controller"


### PR DESCRIPTION
Changes to Signups:
-First + Last name is used as Users' full name now instead of including their title and middle name
-Private administrator comment field for Signups
-Pagination and default sort order by creation date (descending)
-Added a "Created" column to table on index page

Changes to Access Profiles:
-Applying AccessProfiles as a callback on User save
-Fixed a bug where Users would be added to a group twice if two Access Profiles included that group.

Fixes: #584, #583, #563, #555