### PR TITLE
Task buttons

### DIFF
--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -60,7 +60,7 @@
     <% end %>
 
     <!-- FAILURE RECOVERY -->
-    <% if CbrainTask::FAILED_STATUS.include?(@task.status) %>
+    <% if @task.status =~ /^Failed*/ %>
       <%= link_to 'Retry Failed', { :action => 'operation', :operation => 'recover', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
       <span class="vertical_bar">&#x2503;</span>
     <% end %>

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -66,7 +66,7 @@
     <% end %>
 
     <!-- RESTART -->
-    <% if CbrainTask::FAILED_STATUS.include?(@task.status) or @task.status =~ /Completed|Terminated|Duplicated/ %>
+    <% if @task.status =~ /Completed|Terminated|Duplicated/ %>
       <%= link_to 'Restart At Setup', { :action => 'operation', :operation => 'restart_setup', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
       <% if !(@task.status =~ /Completed/) %>
         <span class="vertical_bar">&#x2503;</span>
@@ -74,7 +74,7 @@
     <% end %>
     <% if @task.status == 'Completed' %>
       <%= link_to 'Restart On Cluster', { :action => 'operation', :operation => 'restart_cluster', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
-      <%= link_to 'Restart At PostProcessing', { :action => 'operation', :operation => 'restart_postprocess', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
+      <%= link_to 'Restart At Post-Processing', { :action => 'operation', :operation => 'restart_postprocess', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
       <span class="vertical_bar">&#x2503;</span>
     <% end %>
 

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -61,16 +61,7 @@
 
     <!-- FAILURE RECOVERY -->
     <% if CbrainTask::FAILED_STATUS.include?(@task.status) %>
-      <%
-        label = (
-          case @task.status
-          when /Setup/       then "Retry Setting Up"
-          when /Cluster/     then "Retry Processing"
-          when /PostProcess/ then "Retry Post Processing"
-          end
-        )
-      %>
-      <%= link_to label, { :action => 'operation', :operation => 'recover', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
+      <%= link_to 'Retry Failed', { :action => 'operation', :operation => 'recover', 'tasklist[]' => @task.id }, :class  => "button menu_button", :method => :post %>
       <span class="vertical_bar">&#x2503;</span>
     <% end %>
 

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -92,7 +92,7 @@
     <% if CbrainTask::QUEUED_STATUS.include?(@task.status) %>
       <%= link_to 'Terminate Task', { :action => 'operation', :operation => 'terminate', 'tasklist[]' => @task.id }, :confirm => "Are you sure you want to terminate this task?", :class  => "button menu_button", :method => :post %>
     <% end %>
-    <% if CbrainTask::QUEUED_STATUS.include?(@task.status) or CbrainTask::FAILED_STATUS.include?(@task.status) %>
+    <% if CbrainTask::QUEUED_STATUS.include?(@task.status) or CbrainTask::FAILED_STATUS.include?(@task.status) or CbrainTask::COMPLETED_STATUS.include?(@task.status) %>
       <% confirm  = "Are you sure you want to remove this task?" %>
       <% confirm += "\n\nIMPORTANT NOTE: This will also remove its archived work directory." if @task.workdir_archive %>
       <%= link_to 'Remove Task',  { :action => 'operation', :operation => 'delete', 'tasklist[]' => @task.id }, :confirm => confirm, :class  => "button menu_button", :method => :post %>


### PR DESCRIPTION
Fixes #588, where failed tasks could be restarted in show page and the label for the retry button was wrong.