### PR TITLE
Hide old signups

### DIFF
--- a/BrainPortal/app/controllers/bourreaux_controller.rb
+++ b/BrainPortal/app/controllers/bourreaux_controller.rb
@@ -136,7 +136,7 @@ class BourreauxController < ApplicationController
     old_dp_cache_dir = @bourreau.dp_cache_dir
 
     if ! @bourreau.update_attributes_with_logging(fields, current_user,
-        RemoteResource.columns_hash.keys.grep(/actres_|cache_trust|cms_|dp_|url|online|proxied_hosts|rr_timeout|ssh_|email|tunnel_|worker/)
+        RemoteResource.columns_hash.keys.grep(/actres_|cache_trust|cms_|dp_|url|online|proxied_hosts|rr_timeout|ssh_|email|tunnel_|worker|logo/)
       )
       @bourreau.reload
       respond_to do |format|

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -175,7 +175,7 @@ class SignupsController < ApplicationController
     end
 
     if @scope.custom[:view_hidden]
-      @base_scope = Signup
+      @base_scope = Signup.where(:hidden => true)
     else
       @base_scope = Signup.where(:hidden => false)
     end

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -217,6 +217,10 @@ class SignupsController < ApplicationController
       return hide_multi
     end
 
+    if params[:commit] =~ /Show/i
+      return show_multi
+    end
+
     # Default: unknown multi action?
     redirect_to :action => :index
   end
@@ -295,6 +299,22 @@ class SignupsController < ApplicationController
     end
 
     flash[:notice] = "Hid " + view_pluralize(count, "record")
+
+    redirect_to :action => :index
+  end
+
+  def show_multi #:nodoc:
+    reqids = params[:reqids] || []
+    reqs   = Signup.find(reqids)
+
+    count = 0
+    reqs.each do |req|
+      req[:hidden] = false
+      req.save
+      count += 1
+    end
+
+    flash[:notice] = "Unhid " + view_pluralize(count, "record")
 
     redirect_to :action => :index
   end

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -166,22 +166,15 @@ class SignupsController < ApplicationController
 
     scope_default_order(@scope, 'created_at', :desc)
 
-    if params[:view_hidden].present?
-      if params[:view_hidden] == "true"
-        @scope.custom[:view_hidden] = true
-        @base_scope = Signup.where(:hidden => true)
-      end
-    else
-      @scope.custom[:view_hidden] = false
-      @base_scope = Signup.where(:hidden => false)
-    end
-
-    @view_scope       = @scope.apply(@base_scope)
+    view_hidden                 = params[:view_hidden].presence == "true" ? true : false
+    @scope.custom[:view_hidden] = view_hidden
+    @base_scope                 = Signup.where(:hidden => view_hidden)
+    @view_scope                 = @scope.apply(@base_scope)
 
     # Prepare the Pagination object
-    @scope.pagination ||= Scope::Pagination.from_hash({ :per_page => 25 })
+    @scope.pagination           ||= Scope::Pagination.from_hash({ :per_page => 25 })
 
-    @signups          = @scope.pagination.apply(@view_scope)
+    @signups                    = @scope.pagination.apply(@view_scope)
 
     scope_to_session(@scope, 'signups')
 
@@ -287,14 +280,12 @@ class SignupsController < ApplicationController
     reqids = params[:reqids] || []
     reqs   = Signup.find(reqids)
 
-    count = 0
     reqs.each do |req|
       req[:hidden] = true
       req.save
-      count += 1
     end
 
-    flash[:notice] = "Hid " + view_pluralize(count, "record")
+    flash[:notice] = "Hid " + view_pluralize(reqs.size, "record")
 
     redirect_to :action => :index
   end
@@ -303,14 +294,12 @@ class SignupsController < ApplicationController
     reqids = params[:reqids] || []
     reqs   = Signup.find(reqids)
 
-    count = 0
     reqs.each do |req|
       req[:hidden] = false
       req.save
-      count += 1
     end
 
-    flash[:notice] = "Unhid " + view_pluralize(count, "record")
+    flash[:notice] = "Unhid " + view_pluralize(reqs.size, "record")
 
     redirect_to :action => :index
   end

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -169,14 +169,10 @@ class SignupsController < ApplicationController
     if params[:view_hidden].present?
       if params[:view_hidden] == "true"
         @scope.custom[:view_hidden] = true
-      else
-        @scope.custom[:view_hidden] = false
+        @base_scope = Signup.where(:hidden => true)
       end
-    end
-
-    if @scope.custom[:view_hidden]
-      @base_scope = Signup.where(:hidden => true)
     else
+      @scope.custom[:view_hidden] = false
       @base_scope = Signup.where(:hidden => false)
     end
 

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -166,7 +166,7 @@ class SignupsController < ApplicationController
 
     scope_default_order(@scope, 'created_at', :desc)
 
-    view_hidden                 = params[:view_hidden].presence == "true" ? true : false
+    view_hidden                 = ( params[:view_hidden].presence == "true" )
     @scope.custom[:view_hidden] = view_hidden
     @base_scope                 = Signup.where(:hidden => view_hidden)
     @view_scope                 = @scope.apply(@base_scope)

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -141,12 +141,13 @@ class UsersController < ApplicationController
       flash[:notice] = "User successfully created."
 
       # Find signup record matching login name, and log creation and transfer some info.
-      if signup = Signup.where(:login => @user.login, :approved_at => nil, :approved_by => nil).first
+      if signup = Signup.where(:id => params[:signup_id]).first
         current_user.addlog("Approved [[signup request][#{signup_path(signup)}]] for user '#{@user.login}'")
         @user.addlog("Account created after signup request approved by '#{current_user.login}'")
         signup.add_extra_info_for_user(@user)
         signup.approved_by = current_user.login
         signup.approved_at = Time.now
+        signup.user_id     = @user.id
         signup.save
       else # account was not created from a signup request? Still log some info.
         current_user.addlog_context(self,"Created account for user '#{@user.login}'")

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -141,7 +141,7 @@ class UsersController < ApplicationController
       flash[:notice] = "User successfully created."
 
       # Find signup record matching login name, and log creation and transfer some info.
-      if signup = Signup.where(:id => params[:signup_id]).first
+      if signup = Signup.where(:login => @user.login, :approved_at => nil, :approved_by => nil).first
         current_user.addlog("Approved [[signup request][#{signup_path(signup)}]] for user '#{@user.login}'")
         @user.addlog("Account created after signup request approved by '#{current_user.login}'")
         signup.add_extra_info_for_user(@user)

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -107,7 +107,7 @@ class RemoteResource < ActiveRecord::Base
                         :cms_default_queue, :cms_extra_qsub_args, :cms_shared_dir, :workers_instances,
                         :workers_chk_time, :workers_log_to, :workers_verbose, :help_url, :rr_timeout, :proxied_host,
                         :spaced_dp_ignore_patterns, :license_agreements, :support_email, :system_from_email, :external_status_page_url,
-                        :docker_executable_name, :docker_present
+                        :docker_executable_name, :docker_present, :small_logo, :large_logo
 
 
 

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -27,7 +27,7 @@ class Signup < ActiveRecord::Base
   attr_accessible       :title, :first, :middle, :last,
                         :institution, :department, :position, :email,
                         :street1, :street2, :city, :province, :country, :postal_code,
-                        :login, :time_zone, :comment, :admin_comment
+                        :login, :time_zone, :comment, :admin_comment, :hide
 
   validates_presence_of :first, :last,
                         :institution, :department, :position, :email,

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -72,7 +72,7 @@ class Signup < ActiveRecord::Base
   alias full_name full
 
   def approved? #:nodoc:
-    self.user_id.present?
+    self.approved_by.present? && self.approved_at.present?
   end
 
   def dup_email? #:nodoc:

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -27,7 +27,7 @@ class Signup < ActiveRecord::Base
   attr_accessible       :title, :first, :middle, :last,
                         :institution, :department, :position, :email,
                         :street1, :street2, :city, :province, :country, :postal_code,
-                        :login, :time_zone, :comment, :admin_comment, :hide
+                        :login, :time_zone, :comment, :admin_comment, :hidden, :user_id
 
   validates_presence_of :first, :last,
                         :institution, :department, :position, :email,
@@ -72,7 +72,7 @@ class Signup < ActiveRecord::Base
   alias full_name full
 
   def approved? #:nodoc:
-    self.approved_by.present? && self.approved_at.present?
+    self.user_id.present?
   end
 
   def dup_email? #:nodoc:
@@ -80,7 +80,7 @@ class Signup < ActiveRecord::Base
   end
 
   def dup_login? #:nodoc:
-    User.exists?(:login => self.login)
+    !self.approved? && User.exists?(:login => self.login)
   end
 
   # Returns a new NormalUser (not saved in the DB yet) based

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -44,7 +44,7 @@
   </div>
 <% end %>
 
-<P>
+<p>
 
 <%= error_messages_for @bourreau, :header_message => "Server could not be updated." %>
 
@@ -117,6 +117,20 @@
       <% t.edit_cell(:help_url, :header => "User Manual URL", :show_width => 1) do %>
         <%= text_field_tag "bourreau[help_url]", @bourreau.help_url, :size => 40 %><br/>
         <div class="field_explanation">If set, the portal will show a link called 'User Manual' in the account bar at the top.</div>
+      <% end %>
+
+      <% t.edit_cell :small_logo,
+                     :header => "Small logo",
+                     :content => (@bourreau.small_logo.blank? ? "(None)" : @bourreau.small_logo),
+                     :show_width => 1 do %>
+        <%= text_field_tag "bourreau[small_logo]", @bourreau.small_logo, :size => 40 %><br/>
+      <% end %>
+
+      <% t.edit_cell :large_logo,
+                     :header => "Large logo",
+                     :content => (@bourreau.large_logo.blank? ? "(None)" : @bourreau.large_logo),
+                     :show_width => 1 do %>
+        <%= text_field_tag "bourreau[large_logo]", @bourreau.large_logo, :size => 40 %><br/>
       <% end %>
 
       <% t.edit_cell 'meta[large_upload_url]',

--- a/BrainPortal/app/views/layouts/_section_menu.html.erb
+++ b/BrainPortal/app/views/layouts/_section_menu.html.erb
@@ -33,7 +33,9 @@
        # Old link based on portal name; to be made customizable soon.
        # link_to_if(current_user.present?, RemoteResource.current_resource.name.presence || "CBRAIN", start_page_path)
     %>
-    <%= link_to_if(current_user.present?, image_tag("custom_logos/cbrain-large_white_alpha.png", :id => "header_logo").html_safe , start_page_path) %>
+    <% logo = RemoteResource.current_resource.large_logo.present? ? RemoteResource.current_resource.large_logo : "/images/custom_logos/cbrain-large_white_alpha.png" %>
+
+    <%= link_to_if(current_user.present?, image_tag(logo, :id => "header_logo").html_safe , start_page_path) %>
 
     <% if current_user && (params[:controller] == "userfiles" || params[:controller] == "tasks") %>
       <span>-</span>

--- a/BrainPortal/app/views/layouts/application.html.erb
+++ b/BrainPortal/app/views/layouts/application.html.erb
@@ -25,9 +25,13 @@
 
   <head>
     <title><%= RemoteResource.current_resource.name.presence || "CBRAIN" %><%= yield :title %></title>
-    <link rel="shortcut icon"                    type="image/png" href="/images/custom_logos/cb-small_white_blue.png">
-    <link rel="apple-touch-icon" sizes="96x96"   type="image/png" href="/images/custom_logos/cb-small_white_blue.png">
-    <link rel="apple-touch-icon" sizes="145x145" type="image/png" href="/images/custom_logos/cb-large_white_blue.png">
+
+    <% small_logo = RemoteResource.current_resource.small_logo.blank? ? "/images/custom_logos/cb-small_white_blue.png" : RemoteResource.current_resource.small_logo %>
+    <% large_logo = RemoteResource.current_resource.large_logo.blank? ? "/images/custom_logos/cb-large_white_blue.png" : RemoteResource.current_resource.large_logo %>
+
+    <link rel="shortcut icon"                    type="image/png" href=<% small_logo %>>
+    <link rel="apple-touch-icon" sizes="96x96"   type="image/png" href=<% small_logo %>>
+    <link rel="apple-touch-icon" sizes="145x145" type="image/png" href=<% large_logo %>>
 
     <%
         # Get the CSRF meta tags, but add IDs to them

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -33,6 +33,14 @@
     <%= submit_tag "Delete",                :class => "button" %>
     <%= submit_tag "Adjust Login",          :class => "button" %>
     <%= submit_tag "Resend Confirm Email",  :class => "button" %>
+    <%= submit_tag "Hide",                  :class => "button" %>
+
+    <% if @scope.custom[:view_hidden] %>
+      <%= link_to "Hide Hidden", { :action => :index, :params => {:view_hidden => false} }, :class => "button" %>
+    <% else %>
+      <%= link_to "Show Hidden", { :action => :index, :params => {:view_hidden => true} }, :class => "button" %>
+    <% end %>
+
   </div>
 
   <hr>

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -35,7 +35,7 @@
     <%= submit_tag "Resend Confirm Email",  :class => "button" %>
 
     <% if @scope.custom[:view_hidden] %>
-      <%= submit_tag "Unhide", :class => "button" %>
+      <%= submit_tag "Show", :class => "button" %>
       <%= link_to "Hide Hidden", { :action => :index, :params => {:view_hidden => false} }, :class => "button" %>
     <% else %>
       <%= submit_tag "Hide", :class => "button" %>
@@ -174,6 +174,9 @@
     <%
       t.column("Status", :status) do |d|
     %>
+      <% if d[:hidden] %>
+        <%= hidden_icon %>
+      <% end %>
       <% if d.approved? %>
         Approved by <%= d.approved_by %> at <%= d.approved_at %>
       <% else %>

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -34,6 +34,7 @@
     <%= submit_tag "Adjust Login",          :class => "button" %>
     <%= submit_tag "Resend Confirm Email",  :class => "button" %>
     <%= submit_tag "Hide",                  :class => "button" %>
+    <%= submit_tag "Show",                  :class => "button" %>
 
     <% if @scope.custom[:view_hidden] %>
       <%= link_to "Hide Hidden", { :action => :index, :params => {:view_hidden => false} }, :class => "button" %>

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -33,15 +33,14 @@
     <%= submit_tag "Delete",                :class => "button" %>
     <%= submit_tag "Adjust Login",          :class => "button" %>
     <%= submit_tag "Resend Confirm Email",  :class => "button" %>
-    <%= submit_tag "Hide",                  :class => "button" %>
-    <%= submit_tag "Show",                  :class => "button" %>
 
     <% if @scope.custom[:view_hidden] %>
+      <%= submit_tag "Unhide", :class => "button" %>
       <%= link_to "Hide Hidden", { :action => :index, :params => {:view_hidden => false} }, :class => "button" %>
     <% else %>
+      <%= submit_tag "Hide", :class => "button" %>
       <%= link_to "Show Hidden", { :action => :index, :params => {:view_hidden => true} }, :class => "button" %>
     <% end %>
-
   </div>
 
   <hr>
@@ -154,7 +153,7 @@
 
     <%
       t.column("In CBRAIN", :user) do |d|
-        user = User.where(:login => d.login).first
+        user = User.where(:id => d.user_id).first
         if (user)
           link_to_user_with_tooltip(user)
         else

--- a/BrainPortal/app/views/users/new.html.erb
+++ b/BrainPortal/app/views/users/new.html.erb
@@ -76,6 +76,8 @@
     <p><label for="no_password_reset_needed">No need to reset initial password:</label>
     <%= check_box_tag :no_password_reset_needed, "1", params[:no_password_reset_needed] == "1" %>
 
+    <%= hidden_field_tag :signup_id, params[:signup_id] %>
+
   </div>
 
   <div class="box_spacer"></div>

--- a/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
+++ b/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
@@ -1,0 +1,10 @@
+class SignupsTweaks < ActiveRecord::Migration
+  def up
+    change_column :signups, :admin_comment, :text
+    change_column :signups, :comment, :text
+    add_column    :signups, :hidden, :boolean, :default => false
+  end
+
+  def down
+  end
+end

--- a/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
+++ b/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
@@ -5,6 +5,13 @@ class SignupsTweaks < ActiveRecord::Migration
     add_column    :signups, :user_id, :integer
     add_column    :signups, :hidden, :boolean, :default => false
 
+    Signup.all.each do |d|
+      user = User.where(:login => d.login).first
+      if user.present?
+        user[:signup_id] = user.id
+        user.save
+      end
+    end
   end
 
   def down

--- a/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
+++ b/BrainPortal/db/migrate/20170220152128_signups_tweaks.rb
@@ -2,9 +2,13 @@ class SignupsTweaks < ActiveRecord::Migration
   def up
     change_column :signups, :admin_comment, :text
     change_column :signups, :comment, :text
+    add_column    :signups, :user_id, :integer
     add_column    :signups, :hidden, :boolean, :default => false
+
   end
 
   def down
+    remove_column :signups, :user_id
+    remove_column :signups, :hidden
   end
 end

--- a/BrainPortal/db/migrate/20170306210331_logos.rb
+++ b/BrainPortal/db/migrate/20170306210331_logos.rb
@@ -1,0 +1,11 @@
+class Logos < ActiveRecord::Migration
+  def up
+    add_column :remote_resources, :small_logo, :string
+    add_column :remote_resources, :large_logo, :string
+  end
+
+  def down
+    remove_column :remote_resources, :small_logo
+    remove_column :remote_resources, :large_logo
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -118,35 +118,6 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
 
-  create_table "demands", :force => true do |t|
-    t.string   "title"
-    t.string   "first",         :null => false
-    t.string   "middle"
-    t.string   "last",          :null => false
-    t.string   "institution",   :null => false
-    t.string   "department"
-    t.string   "position"
-    t.string   "email",         :null => false
-    t.string   "website"
-    t.string   "street1"
-    t.string   "street2"
-    t.string   "city"
-    t.string   "province"
-    t.string   "country"
-    t.string   "postal_code"
-    t.string   "time_zone"
-    t.string   "service"
-    t.string   "login"
-    t.string   "comment"
-    t.string   "session_id"
-    t.string   "confirm_token"
-    t.boolean  "confirmed"
-    t.string   "approved_by"
-    t.datetime "approved_at"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
-  end
-
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"
     t.string   "request_controller"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,6 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
+
 ActiveRecord::Schema.define(:version => 20170308220959) do
 
   create_table "access_profiles", :force => true do |t|
@@ -116,6 +117,35 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
   add_index "data_providers", ["group_id"], :name => "index_data_providers_on_group_id"
   add_index "data_providers", ["type"], :name => "index_data_providers_on_type"
   add_index "data_providers", ["user_id"], :name => "index_data_providers_on_user_id"
+
+  create_table "demands", :force => true do |t|
+    t.string   "title"
+    t.string   "first",         :null => false
+    t.string   "middle"
+    t.string   "last",          :null => false
+    t.string   "institution",   :null => false
+    t.string   "department"
+    t.string   "position"
+    t.string   "email",         :null => false
+    t.string   "website"
+    t.string   "street1"
+    t.string   "street2"
+    t.string   "city"
+    t.string   "province"
+    t.string   "country"
+    t.string   "postal_code"
+    t.string   "time_zone"
+    t.string   "service"
+    t.string   "login"
+    t.string   "comment"
+    t.string   "session_id"
+    t.string   "confirm_token"
+    t.boolean  "confirmed"
+    t.string   "approved_by"
+    t.datetime "approved_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+  end
 
   create_table "exception_logs", :force => true do |t|
     t.string   "exception_class"
@@ -274,13 +304,13 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
 
   create_table "signups", :force => true do |t|
     t.string   "title"
-    t.string   "first",         :null => false
+    t.string   "first",                            :null => false
     t.string   "middle"
-    t.string   "last",          :null => false
-    t.string   "institution",   :null => false
+    t.string   "last",                             :null => false
+    t.string   "institution",                      :null => false
     t.string   "department"
     t.string   "position"
-    t.string   "email",         :null => false
+    t.string   "email",                            :null => false
     t.string   "website"
     t.string   "street1"
     t.string   "street2"
@@ -291,15 +321,16 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
     t.string   "time_zone"
     t.string   "service"
     t.string   "login"
-    t.string   "comment"
+    t.text     "comment"
     t.string   "session_id"
     t.string   "confirm_token"
     t.boolean  "confirmed"
     t.string   "approved_by"
     t.datetime "approved_at"
-    t.datetime "created_at",    :null => false
-    t.datetime "updated_at",    :null => false
-    t.string   "admin_comment"
+    t.datetime "created_at",                       :null => false
+    t.datetime "updated_at",                       :null => false
+    t.text     "admin_comment"
+    t.boolean  "hidden",        :default => false
   end
 
   create_table "sites", :force => true do |t|

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,8 +11,8 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-
 ActiveRecord::Schema.define(:version => 20170306210331) do
+
   create_table "access_profiles", :force => true do |t|
     t.string   "name",        :null => false
     t.string   "description"
@@ -135,14 +135,6 @@ ActiveRecord::Schema.define(:version => 20170306210331) do
     t.datetime "updated_at"
   end
 
-  create_table "feedbacks", :force => true do |t|
-    t.string   "summary"
-    t.text     "details"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.integer  "user_id"
-  end
-
   create_table "groups", :force => true do |t|
     t.string   "name"
     t.datetime "created_at"
@@ -252,6 +244,10 @@ ActiveRecord::Schema.define(:version => 20170306210331) do
     t.boolean  "docker_present"
     t.string   "small_logo"
     t.string   "large_logo"
+    t.string   "actres_host"
+    t.integer  "actres_port"
+    t.string   "actres_user"
+    t.string   "actres_dir"
   end
 
   add_index "remote_resources", ["type"], :name => "index_remote_resources_on_type"

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -330,6 +330,7 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
     t.datetime "created_at",                       :null => false
     t.datetime "updated_at",                       :null => false
     t.text     "admin_comment"
+    t.integer  "user_id"
     t.boolean  "hidden",        :default => false
   end
 

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -12,8 +12,7 @@
 # It's strongly recommended to check this file into your version control system.
 
 
-ActiveRecord::Schema.define(:version => 20170308220959) do
-
+ActiveRecord::Schema.define(:version => 20170306210331) do
   create_table "access_profiles", :force => true do |t|
     t.string   "name",        :null => false
     t.string   "description"
@@ -251,6 +250,8 @@ ActiveRecord::Schema.define(:version => 20170308220959) do
     t.string   "external_status_page_url"
     t.string   "docker_executable_name"
     t.boolean  "docker_present"
+    t.string   "small_logo"
+    t.string   "large_logo"
   end
 
   add_index "remote_resources", ["type"], :name => "index_remote_resources_on_type"


### PR DESCRIPTION
Provides a mechanism to hide/show Signups
Comments are now type text instead of string
Association between Signup and User by storing the user_id in the Signup
Adds fields to BrainPortal show pages to edit the filename of the logo for custom logos.

Fixes #596 and #595.
Also fixes #472.