### PR TITLE
Fixed group_id of subtasks

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2034,6 +2034,7 @@ chmod 755 ./.dockerjob.sh
     new_task.user_id                  = self.user_id
     new_task.results_data_provider_id = self.results_data_provider_id
     new_task.bourreau_id              = self.bourreau_id
+    new_task.group_id                 = self.group_id
 
     # Submits the task
     new_task.status = "New"


### PR DESCRIPTION
Without this fix, sub-tasks are submitted to the default user project which may not be the one in which the main task was submitted.