### PR TITLE
Mostly Docker and Singularity fixes

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -1139,7 +1139,7 @@ class UserfilesController < ApplicationController
     send_file tarfile, :stream  => true, :filename => tarfile_name
     CBRAIN.spawn_fully_independent("Download Clean Tmp #{current_user.login}") do
       sleep 3000
-      File.unlink(tarfile)
+      File.delete(tarfile)
     end
   end
 

--- a/BrainPortal/app/helpers/resource_link_helper.rb
+++ b/BrainPortal/app/helpers/resource_link_helper.rb
@@ -65,8 +65,10 @@ module ResourceLinkHelper
   # the link (the default is the user's login name) and a
   # :path (the default is the show path).
   def link_to_user_if_accessible(user, cur_user = current_user, options = {})
-    user = User.find(user) unless user.is_a?(User)
-    (options[:html_options] ||= {})[:class] = 'error_link' if user.account_locked
+    if user.present?
+      user = User.find(user) unless user.is_a?(User)
+      (options[:html_options] ||= {})[:class] = 'error_link' if user.account_locked
+    end
     link_to_model_if_accessible(User,user,:login,cur_user,options)
   end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1139,7 +1139,7 @@ class ClusterTask < CbrainTask
 
     # Task outputs incomplete? Point to science output captured
     return science_outerr if ! File.exists?(qsub_outerr)
-    qsub_content = check_task_ending_keyword(qsub_outerr) # returns nil unless content contains "CBRAIN Task Exiting"
+    qsub_content = check_content_substitution_keyword(qsub_outerr) # returns nil unless content contains "__CBRAIN_CAPTURE_PLACEHOLDER__"
     return science_outerr if qsub_content.blank?
 
     # Create combined report
@@ -1157,6 +1157,16 @@ class ClusterTask < CbrainTask
     return nil unless File.exists?(basename)
     content = File.read(basename)
     return nil if content !~ /CBRAIN Task Exiting/
+    content
+  end
+
+  # Checks that the content of some output file properly
+  # has the keyword "__CBRAIN_CAPTURE_PLACEHOLDER__".
+  # Returns the file's content if it's true, otherwise returns nil
+  def check_content_substitution_keyword(basename)
+    return nil unless File.exists?(basename)
+    content = File.read(basename)
+    return nil if content !~ /__CBRAIN_CAPTURE_PLACEHOLDER__/
     content
   end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2198,7 +2198,7 @@ mkdir #{basename_dp_cache.bash_escape}
     run                                                      \\
     -H #{task_workdir}                                       \\
     -B #{cache_dir.bash_escape}:#{singularity_dp_cache_path.bash_escape} \\
-    #{local_image_basename.name.bash_escape}                 \\
+    #{local_image_basename.bash_escape}                      \\
     #{singularity_wrapper_basename.bash_escape}
 
     SINGULARITY_COMMANDS

--- a/BrainPortal/lib/cbrain_extensions/active_record_extensions/api_attr_visible.rb
+++ b/BrainPortal/lib/cbrain_extensions/active_record_extensions/api_attr_visible.rb
@@ -35,7 +35,7 @@ module CBRAINExtensions #:nodoc:
         end
       end
 
-      module ClassMethods #:nodoc:
+      module ClassMethods
 
         # Register a list of attributes to be whitelisted for the current model.
         # The :id attribute is implicit and always whitelisted.
@@ -46,7 +46,7 @@ module CBRAINExtensions #:nodoc:
         # returns:
         #
         #   { :id => true, :name => true, :description => true }
-        def api_attr_visible(*args) #:nodoc:
+        def api_attr_visible(*args)
           @api_attr_visible ||= { :id => true } # , :updated_at => true, :created_at => true }
           Array(args).each do |attr|
             raise "Argument '#{attr}' not a symbol or a proper attribute of the model." unless
@@ -58,7 +58,7 @@ module CBRAINExtensions #:nodoc:
 
         # Returns a list of whitelisted attributes which is the union
         # of the ones in the current class, and all those in the superclasses.
-        def cumulative_api_attr_visible #:nodoc:
+        def cumulative_api_attr_visible
           return @cumulative_api_attr_visible if @cumulative_api_attr_visible
           local_visible_list = api_attr_visible.keys
           super_visible_list = superclass.respond_to?(:cumulative_api_attr_visible) ? superclass.cumulative_api_attr_visible : []

--- a/BrainPortal/lib/cbrain_extensions/array_extensions/miscellaneous.rb
+++ b/BrainPortal/lib/cbrain_extensions/array_extensions/miscellaneous.rb
@@ -32,6 +32,28 @@ module CBRAINExtensions #:nodoc:
         map(&:for_api)
       end
 
+      # Just like each_with_index(), but also provides the size of the array
+      # in a third argument. This code:
+      #
+      #   x=('f'..'m').to_a
+      #   x.each_with_index_and_size do |l,i,t|
+      #     puts "#{i+1}/#{t} => #{l}"
+      #   end
+      #
+      # will print:
+      #
+      #   1/8 => f
+      #   2/8 => g
+      #   3/8 => h
+      #   4/8 => i
+      #   5/8 => j
+      #   6/8 => k
+      #   7/8 => l
+      #   8/8 => m
+      def each_with_index_and_size
+        each_with_index { |elem,idx| yield(elem,idx,size) }
+      end
+
     end
   end
 end

--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -230,7 +230,7 @@ module SchemaTaskGenerator
       ToolConfig.new(
         :tool_id                 => task.tool.id,
         :bourreau_id             => resource.id,
-        :group_id                => Group.everyone.id,
+        :group_id                => User.admin.own_group.id,
         :version_name            => version,
         :description             => "#{name} #{version} on #{resource.name}",
         :container_engine        => "Docker",

--- a/BrainPortal/spec/controllers/userfiles_controller_spec.rb
+++ b/BrainPortal/spec/controllers/userfiles_controller_spec.rb
@@ -847,7 +847,7 @@ RSpec.describe UserfilesController, :type => :controller do
       it "should delete the tar file" do
         allow(CBRAIN).to   receive(:spawn_fully_independent).and_yield
         allow(Userfile).to receive(:find_accessible_by_user).and_return([mock_userfile, mock_userfile])
-        expect(File).to    receive(:unlink)
+        expect(File).to    receive(:delete)
         get :download, :file_ids => [1,2]
       end
     end


### PR DESCRIPTION
Code was cleaned, variables renamed, and some bug fixes and improvements.

* Launched container scripts checks for proper UID, refuse to work otherwise
* Boutique integration creates its tool configs with group_id limited to 'admin'.
* All special basenames used in docker and singularity have proper run_id in them, to prevent collisions.
* diagnostics tasks enhanced with a write test, and test input files using both the cache_full_path and the relative symlink created with make_available()

KNOWN ISSUE: For singularity, tasks that work with the cache_full_path of a userfile won't work, it will work only if the task creates a link with make_available(). That's because singularity has no mechanism for binding a arbitrary path if the path components don't already exist in the container. Darn.