### PR TITLE
Checking exit status file for boutiques integration.

### DIFF
--- a/BrainPortal/config/console_rc/lib/reports.rb
+++ b/BrainPortal/config/console_rc/lib/reports.rb
@@ -33,7 +33,7 @@ def trans
        printf "%10.10s %s %-10.10s (%9s) [%8.8s] \"%s\" for %s\n",
                what.name, dir, file.data_provider.name,
                pretty_size(file.size), file.user.login, file.name,
-               pretty_elapsed(Time.now - ss.accessed_at, :num_components => 3)
+               pretty_elapsed(Time.now - ss.updated_at, :num_components => 3)
      end
    end
    true

--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -192,6 +192,11 @@ module SchemaTaskGenerator
       # generate a Tool and ToolConfig to register the tool into CBRAIN.
       register(task) if register
 
+      # For debugging templates, it helps to view the code generated.
+      # You can simply create an empty directory some place and provide its
+      # path to the method below.
+      #to_directory("/home/myself/cbrain/tmp") # adjust here
+
       task
     end
 

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -363,24 +363,34 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 % unless (descriptor['custom'] || {})['cbrain:ignore-exit-status']
     # Make sure <%= name %> completed successfully by checking its exit status
     # in +exit_cluster_filename+.
-    unless File.exists?(exit_cluster_filename)
+    if ! File.exists?(exit_cluster_filename)
       self.addlog("Missing exit status file #{exit_cluster_filename}")
 %   if outputs.empty?
       return false
 %   else
-      succeeded &&= false
+      succeeded = false
 %   end
-    end
-
-    exit_status = IO.read(exit_cluster_filename).strip.to_i
-    unless SystemExit.new(exit_status).success?
-      self.addlog("Command failed, exit status #{exit_status}")
+    else # Check exit status file content is a number.
+      status_file_content = File.read(exit_cluster_filename).strip
+      if status_file_content.blank? || status_file_content !~ /\A^\d+\z/
+        self.addlog("Exit status file #{exit_cluster_filename} has unexpected content")
 %   if outputs.empty?
-      return false
+        return false
 %   else
-      succeeded &&= false
+        succeeded = false
 %   end
-    end
+      else # Check exit status value
+        exit_status = status_file_content.to_i
+        unless SystemExit.new(exit_status).success?
+          self.addlog("Command failed, exit status #{exit_status}")
+%   if outputs.empty?
+          return false
+%   else
+          succeeded = false
+%   end
+        end # content is success
+      end # content exists
+    end # file exists
 
 % end
     # Additional checks to see if <%= name %> succeeded would belong here.


### PR DESCRIPTION
This replaces the pull request #580 with slightly better code (though it's still a bunch of if-else statements). Since this is templated code, and comparison is difficult, I'm including here two screenshot for two tasks, one without outputs (fsl_sub) and one with outputs (qeeg). The resulting code is slight different: the first one returns false immediately, the second sets `succeeded = false`.

The screenshots show the diff between the rendered templated code before, and after my change.

![screen shot 2017-06-09 at 17 16 59](https://user-images.githubusercontent.com/777588/26995490-f22da646-4d3a-11e7-9b92-c0d11b35e64a.png)

![screen shot 2017-06-09 at 17 17 22](https://user-images.githubusercontent.com/777588/26995494-f5885214-4d3a-11e7-9483-8aa77564d3e4.png)


