### PR TITLE
Added SCIR for Cobalt compatibility

### DIFF
--- a/Bourreau/lib/scir_cobalt.rb
+++ b/Bourreau/lib/scir_cobalt.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/scir_cobalt.rb

--- a/BrainPortal/lib/scir_cobalt.rb
+++ b/BrainPortal/lib/scir_cobalt.rb
@@ -1,0 +1,160 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This is a replacement for the drmaa.rb library; this particular subclass
+# of class Scir implements the Cobalt interface.
+#
+# Original author: Pierre Rioux
+# Adapted from scir_pbs.rb by: Greg Kiar
+class ScirCobalt < Scir
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  class Session < Scir::Session #:nodoc:
+
+    def update_job_info_cache #:nodoc:
+      qstat_command = "qstat -u #{CBRAIN::Rails_UserName.to_s.bash_escape} -f"
+      # In some cases, the standard output of the qstat command
+      # is blank even though jobs are still running on the cluster. In this situation,
+      # all the active jobs will be marked completed while they are not.
+      # To address this issue, we retry the qstat command up to 3 times with a 3-second interval
+      # as long as the output of qstat is blank.
+      out = ""
+      3.times do
+        out, err = bash_this_and_capture_out_err(qstat_command)
+        raise "Cannot get output of '#{qstat_command}' ?!?" if out.blank? && err.present? # if no stdout yet there is stderr!
+        break if out.present?
+        sleep 3
+      end
+      jid = 'Dummy'
+      @job_info_cache = {}
+      out.split(/\s*\n\s*/).each do |line|
+        line.force_encoding('ASCII-8BIT')  # some pbs 'qstat' commands output junk binary data!
+        if line =~ /\AJob\s+id\s*:\s*(\S+)/i
+          jid = Regexp.last_match[1]
+          if jid =~ /\A(\d+)/
+            jid = Regexp.last_match[1]
+          end
+          next
+        end
+        next unless line =~ /\A\s*job_state\s*=\s*(\S+)/i
+        state = statestring_to_stateconst(Regexp.last_match[1])
+        @job_info_cache[jid.to_s] = { :drmaa_state => state }
+      end
+      true
+    end
+
+    def statestring_to_stateconst(state) #:nodoc:
+      return Scir::STATE_RUNNING        if state.match(/R/i)
+      return Scir::STATE_QUEUED_ACTIVE  if state.match(/Q/i)
+      return Scir::STATE_USER_ON_HOLD   if state.match(/H/i)
+      return Scir::STATE_USER_SUSPENDED if state.match(/S/i)
+      return Scir::STATE_UNDETERMINED
+    end
+
+    def hold(jid) #:nodoc:
+      IO.popen("qhold #{shell_escape(jid)} 2>&1","r") do |i|
+        p = i.readlines
+        raise "Error holding: #{p.join("\n")}" if p.size > 0
+        return
+      end
+    end
+
+    def release(jid) #:nodoc:
+      IO.popen("qrls #{shell_escape(jid)} 2>&1","r") do |i|
+        p = i.readlines
+        raise "Error releasing: #{p.join("\n")}" if p.size > 0
+        return
+      end
+    end
+
+    def suspend(jid) #:nodoc:
+      raise "There is no 'suspend' action available for Cobalt clusters"
+    end
+
+    def resume(jid) #:nodoc:
+      raise "There is no 'resume' action available for Cobalt clusters"
+    end
+
+    def terminate(jid) #:nodoc:
+      IO.popen("qdel #{shell_escape(jid)} 2>&1","r") do |i|
+        p = i.readlines
+        raise "Error deleting: #{p.join("\n")}" if p.size > 0
+        return
+      end
+    end
+
+    def queue_tasks_tot_max #:nodoc:
+      queue = Scir.cbrain_config[:default_queue]
+      queue = "default" if queue.blank?
+      queueinfo = `qstat -Q #{shell_escape(queue)} | tail -1`
+			# JobID  User      WallTime  Nodes  State      Location
+      # =======================================================
+      # 42342  user1     00:15:00  16     user hold  None
+      # 45273  user2     00:35:00  1024   queued     None
+			#
+			# "What portion of the cluster is currently being used"
+			# TODO GK: find a cobalt command that returns {in-use, total} node info
+
+      fields = queueinfo.split(/\s+/) #TODO: fix with above
+      [ fields[2], fields[1] ] #TODO: fix with above
+    rescue
+      [ "exception", "exception" ]
+    end
+
+    private
+
+    def qsubout_to_jid(txt) #:nodoc:
+      if txt && txt.strip =~ /\A(\d+)/
+        return Regexp.last_match[1]
+      end
+      raise "Cannot find job ID from qsub output.\nOutput: #{txt}"
+    end
+
+  end
+
+  class JobTemplate < Scir::JobTemplate #:nodoc:
+
+    def qsub_command #:nodoc:
+      raise "Error, this class only handle 'command' as /bin/bash and a single script in 'arg'" unless
+        self.command == "/bin/bash" && self.arg.size == 1
+      raise "Error: stdin not supported" if self.stdin
+
+      command  = "qsub "
+      command += "--cwd #{shell_escape(self.wd)} "          if self.wd
+      command += "-O #{shell_escape(self.name)} "           if self.name
+      command += "-o #{shell_escape(self.stdout)} "         if self.stdout
+      command += "-e #{shell_escape(self.stderr)} "         if self.stderr
+      command += "-t #{(self.walltime.to_i+60) / 60} "      unless self.walltime.blank?
+      command += "-q #{shell_escape(self.queue)} "          unless self.queue.blank?
+      command += "#{Scir.cbrain_config[:extra_qsub_args]} " unless Scir.cbrain_config[:extra_qsub_args].blank?
+      command += "#{self.tc_extra_qsub_args} "              unless self.tc_extra_qsub_args.blank?
+      command += "#{shell_escape(self.arg[0])}"
+      command += " 2>&1"
+
+      return command
+    end
+
+  end
+
+end
+

--- a/BrainPortal/lib/scir_cobalt.rb
+++ b/BrainPortal/lib/scir_cobalt.rb
@@ -106,17 +106,16 @@ class ScirCobalt < Scir
     def queue_tasks_tot_max #:nodoc:
       queue = Scir.cbrain_config[:default_queue]
       queue = "default" if queue.blank?
-      queueinfo = `qstat -Q #{shell_escape(queue)} | tail -1`
-			# JobID  User      WallTime  Nodes  State      Location
-      # =======================================================
-      # 42342  user1     00:15:00  16     user hold  None
-      # 45273  user2     00:35:00  1024   queued     None
-			#
-			# "What portion of the cluster is currently being used"
-			# TODO GK: find a cobalt command that returns {in-use, total} node info
+      queueform = `export QSTAT_HEADER=User:Nodes:MaxUserNodes:State`
+      queueinfo = `#{shell_escape(queueform)}; qstat #{shell_escape(queue)} | grep #{CBRAIN::Rails_UserName.to_s.bash_escape} | tail -1`
+      # User   Nodes  MaxUserNodes  State
+      # =====================================
+      # user   32     1024          running
+      #
+      # "What portion of the cluster is currently being used"
 
-      fields = queueinfo.split(/\s+/) #TODO: fix with above
-      [ fields[2], fields[1] ] #TODO: fix with above
+      fields = queueinfo.split(/\s+/)
+      [ fields[1], fields[2] ]
     rescue
       [ "exception", "exception" ]
     end


### PR DESCRIPTION
The added SCIR should enable CBRAIN to interface with Cobalt clusters. Cobalt is very similar to PBS, so that was used as a base and was adapted slightly for each command.

As I do not have access to a Cobalt cluster locally, this has yet to be thoroughly tested (i.e. I validated string parsing works as expected and matches the documentation, but I've not run the commands on a live cluster).

SCIR was written with reference to the following two guides:
- [Cobalt](http://trac.mcs.anl.gov/projects/cobalt/wiki/CommandReference)
- [PBS](http://docs.adaptivecomputing.com/torque/4-0-2/Content/topics/12-appendices/commandsOverview.htm)