### PR TITLE
Fixed Boutiques bug in save_results() implementation.

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -181,7 +181,7 @@ module SchemaTaskGenerator
 
         # Redefine the CbrainTask or Object constant pointing to the task's
         # class to point to the switcher instead.
-        [ Object, CbrainTask ].select { |m| m.const_defined?(name) }.each do |m|
+        [ CbrainTask ].select { |m| m.const_defined?(name) }.each do |m|
           m.send(:remove_const, name)
           m.const_set(name, switcher)
         end
@@ -193,8 +193,20 @@ module SchemaTaskGenerator
 
       # For debugging templates, it helps to view the code generated.
       # You can simply create an empty directory some place and provide its
-      # path to the method below.
-      #to_directory("/home/myself/cbrain/tmp") # adjust here
+      # path to the method to_directory() below.
+      #
+      # Adjust path here, get the dumps of ALL Boutiques tasks in it.
+      #to_directory("/tmp/dump")
+      #
+      # Adjust path here, if you're interested in a single task's (CbrainTask::AbcdXyz) files.
+      #to_directory("/tmp/dump") if name == 'AbcdXyz'
+      #
+      # Alternatively, you can trigger the dumps using environment variables
+      # CBRAIN_BOUTIQUES_DUMPDIR="/path/to/dir"
+      # CBRAIN_BOUTIQUES_DUMPTASK="Abcd" # if not set, all tasks are dumped
+      if ((dumpdir = ENV['CBRAIN_BOUTIQUES_DUMPDIR']) && dumpdir.present? && File.directory?(dumpdir))
+        to_directory(dumpdir) if ENV['CBRAIN_BOUTIQUES_DUMPTASK'].blank? || name == ENV['CBRAIN_BOUTIQUES_DUMPTASK']
+      end
 
       task
     end

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -399,10 +399,8 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
     # No output files to save; nothing else to do
     true
 % else
-    # Extract out the output files parameters from params. They will be re-added
-    # once their existence is validated and their registration into CBRAIN is
-    # complete.
-    outputs = params.extract!(*[
+    # Identify the output files parameters from params.
+    outputs = params.slice(*[
 %   outputs.each do |output|
       :'<%= output['id'] %>',
 %   end
@@ -485,16 +483,16 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
         end
 
         output.cache_copy_from_local_file(path)
-        params[param] ||= []
-        params[param]  << output.id
+        params["_cbrain_output_#{param}"] ||= []
+        params["_cbrain_output_#{param}"]  << output.id
         self.addlog("Saved result file #{path}")
 %   if (single_file = files.first if files.count == 1 && ! files.first['list'])
 
         # As all output files were generated from a single input file,
         # the outputs can all be made children of the one parent input file.
-        parent = Userfile.find(params[:'<%= single_file['id'] %>'])
-        output.move_to_child_of(parent)
-        self.addlog_to_userfiles_these_created_these([parent], [output])
+        parent = Userfile.find_by_id(params[:'<%= single_file['id'] %>'])
+        output.move_to_child_of(parent) if parent
+        self.addlog_to_userfiles_these_created_these([parent], [output]) if parent
 %   end
       end
     end

--- a/BrainPortal/lib/cbrain_task_generators/templates/show_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/show_params.html.erb.erb
@@ -109,7 +109,7 @@
       <tr>
         <td class="tsk-sw-name"><%= output['name'] %></td>
         <td class="tsk-sw-val">
-          <%%= format_files.(params[:'<%= output['id'] %>']) %>
+          <%%= format_files.(params[:'<%= "_cbrain_output_" + output['id'].to_s %>']) %>
         </td>
       </tr>
     <%- end -%>


### PR DESCRIPTION
Will fix #647 . Also added feature that we can get the dump of the instanciated templates using environment variables. Example:

```
unix% mkdir /tmp/dump;CBRAIN_BOUTIQUES_DUMPDIR=/tmp/dump CBRAIN_BOUTIQUES_DUMPTASK=NiakFmriPreprocess rails console
```