### PR TITLE
Modified Boutiques hooks for 0.5

### DIFF
--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -167,7 +167,7 @@ class ToolConfigsController < ApplicationController
     form_tool_config.bourreau_id = @tool_config.bourreau_id
 
     # Update everything else
-    [ :version_name, :description, :script_prologue, :group_id, :ncpus, :container_engine, :containerhub_image_name, :container_image_userfile_id,
+    [ :version_name, :description, :script_prologue, :group_id, :ncpus, :container_engine, :container_index_location, :containerhub_image_name, :container_image_userfile_id,
       :extra_qsub_args, :cloud_disk_image, :cloud_vm_user, :cloud_ssh_key_pair, :cloud_instance_type,
       :cloud_job_slots, :cloud_vm_boot_timeout, :cloud_vm_ssh_tunnel_port ].each do |att|
        @tool_config[att] = form_tool_config[att]

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2367,8 +2367,7 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
   # Perform the singularity pull
   def load_singularity_image_from_repo #:nodoc:
     singularity_image_name = self.tool_config.containerhub_image_name
-    singularity_index_location = self.tool_config.container_index_location
-    singularity_index_location = singularity_index_location.presence || "shub://"
+    singularity_index_location = self.tool_config.container_index_location.presence || "shub://"
 
     self.addlog("Pulling singularity image '#{singularity_image_name}'")
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2050,7 +2050,7 @@ chmod 755 #{docker_wrapper_basename.bash_escape}
   def load_docker_image_cmd #:nodoc:
     dockerhub_image_name = self.tool_config.containerhub_image_name
     docker_container_index = self.tool_config.container_index_location
-    docker_container_index += '/' if (!docker_container_index.end_with? '/') && (docker_container_index.length > 0) # Add trailing / if not present and field not empty
+    docker_container_index += '/' if docker_container_index.present? && !docker_contianer_index.end_with?('/') # Add trailing / if not present and field not empty
     # Docker PULL
     if dockerhub_image_name.present?
       return <<-DOCKER_PULL
@@ -2368,7 +2368,7 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
   def load_singularity_image_from_repo #:nodoc:
     singularity_image_name = self.tool_config.containerhub_image_name
     singularity_index_location = self.tool_config.container_index_location
-    singularity_index_location = "shub://" if singularity_index_location.length < 1
+    singularity_index_location = "shub://" if singularity_index_location.blank?
 
     self.addlog("Pulling singularity image '#{singularity_image_name}'")
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2050,7 +2050,14 @@ chmod 755 #{docker_wrapper_basename.bash_escape}
   def load_docker_image_cmd #:nodoc:
     dockerhub_image_name = self.tool_config.containerhub_image_name
     docker_container_index = self.tool_config.container_index_location
-    docker_container_index += '/' if docker_container_index.present? && !docker_container_index.end_with?('/') # Add trailing / if not present and field not empty
+    if docker_container_index.present?
+      if !docker_container_index.end_with?('/')
+        docker_container_index += '/'
+      end
+    else
+      docker_container_index = ''
+    end
+    docker_container_index = docker_container_index + '/' if docker_container_index.present? && !docker_container_index.end_with?('/') # Add trailing / if not present and field not empty
     # Docker PULL
     if dockerhub_image_name.present?
       return <<-DOCKER_PULL

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2050,7 +2050,7 @@ chmod 755 #{docker_wrapper_basename.bash_escape}
   def load_docker_image_cmd #:nodoc:
     dockerhub_image_name = self.tool_config.containerhub_image_name
     docker_container_index = self.tool_config.container_index_location
-    docker_container_index += '/' if docker_container_index.present? && !docker_contianer_index.end_with?('/') # Add trailing / if not present and field not empty
+    docker_container_index += '/' if docker_container_index.present? && !docker_container_index.end_with?('/') # Add trailing / if not present and field not empty
     # Docker PULL
     if dockerhub_image_name.present?
       return <<-DOCKER_PULL

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2049,12 +2049,13 @@ chmod 755 #{docker_wrapper_basename.bash_escape}
   # Then name of the image will be set in a bash variable 'docker_image_name'
   def load_docker_image_cmd #:nodoc:
     dockerhub_image_name = self.tool_config.containerhub_image_name
-
+    docker_container_index = self.tool_config.container_index_location
+    docker_container_index += '/' if (!docker_container_index.end_with? '/') && (docker_container_index.length > 0) # Add trailing / if not present and field not empty
     # Docker PULL
     if dockerhub_image_name.present?
       return <<-DOCKER_PULL
 # Pull image from DockerHub
-#{docker_executable_name} pull #{dockerhub_image_name.bash_escape}
+#{docker_executable_name} pull #{docker_container_index.bash_escape}#{dockerhub_image_name.bash_escape}
 docker_image_name=#{dockerhub_image_name.bash_escape}
       DOCKER_PULL
     end
@@ -2366,11 +2367,14 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
   # Perform the singularity pull
   def load_singularity_image_from_repo #:nodoc:
     singularity_image_name = self.tool_config.containerhub_image_name
+    singularity_index_location = self.tool_config.container_index_location
+    singularity_index_location = "shub://" if singularity_index_location.length < 1
+
     self.addlog("Pulling singularity image '#{singularity_image_name}'")
 
     image_name = container_image_name
     errfile = "/tmp/.container_load_cmd.#{self.run_id}.err"
-    success = system("#{singularity_executable_name} pull --name #{image_name.bash_escape} #{singularity_image_name.bash_escape} </dev/null >/dev/null 2>#{errfile.bash_escape}")
+    success = system("#{singularity_executable_name} pull --name #{image_name.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape} </dev/null >/dev/null 2>#{errfile.bash_escape}")
     err     = File.read(errfile) rescue "No Error File?"
     # Singularity command can generate 'implausibly old time stamp' when pulling a docker image (due to tar), we ignore it.
     # Remove all lines (use ^ and $) that contains this message. 

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -340,11 +340,11 @@ class ToolConfig < ActiveRecord::Base
     end
 
     if self.container_engine.present? && self.container_engine == "Singularity" 
-      if self.container_index_location.present? && ! /^[a-z0-9]+\:\/\/$/.match(self.container_index_location)
+      if self.container_index_location.present? && self.container_index_location !~ /^[a-z0-9]+\:\/\/$/i
         errors[:container_index_location] = "is invalid for container engine Singularity. Should end in '://'."
       end
     elsif self.container_engine.present? && self.container_engine == "Docker"
-      if self.container_index_location.present? && ! /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/.match(self.container_index_location)
+      if self.container_index_location.present? && self.container_index_location !~ /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i
         errors[:container_index_location] = "is invalid for container engine Docker. Should be a valid hostname."
       end
     end

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -56,6 +56,10 @@ class ToolConfig < ActiveRecord::Base
                                    :message => "must be unique per pair [tool, server]" },
                   :if         => :applies_to_bourreau_and_tool?
 
+  validates                 :container_index_location,
+                            :format => { :with => /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i },
+                            :allow_blank => true
+
   validate        :container_rules
 
   cb_scope        :global_for_tools     , where( { :bourreau_id => nil } )
@@ -64,7 +68,7 @@ class ToolConfig < ActiveRecord::Base
 
   attr_accessible :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue,
                   :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_engine,
-                  :containerindex_location, :extra_qsub_args,
+                  :container_index_location, :extra_qsub_args,
                   # The configuration of a tool in a VM managed by a
                   # ScirCloud Bourreau is defined by the following
                   # parameters which specify the disk image where the

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -342,11 +342,11 @@ class ToolConfig < ActiveRecord::Base
 
     if self.container_engine.present? && self.container_engine == "Singularity" 
       if self.container_index_location.present? && ! /^[a-z0-9]+\:\/\/$/.match(self.container_index_location)
-        errors[:container_index_location] = "Invalid index location type for container engine Singularity. Should end in '://'."
+        errors[:container_index_location] = "is invalid for container engine Singularity. Should end in '://'."
       end
     elsif self.container_engine.present? && self.container_engine == "Docker"
       if self.container_index_location.present? && ! /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/.match(self.container_index_location)
-        errors[:container_index_location] = "Invalid index location type for container engine Docker. Should be a valid hostname."
+        errors[:container_index_location] = "is invalid for container engine Docker. Should be a valid hostname."
       end
     end
     return errors.empty?

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -63,7 +63,8 @@ class ToolConfig < ActiveRecord::Base
   cb_scope        :specific_versions    , where( "bourreau_id is not null and tool_id is not null" )
 
   attr_accessible :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue,
-                  :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_engine, :extra_qsub_args,
+                  :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_engine,
+                  :containerindex_location, :extra_qsub_args,
                   # The configuration of a tool in a VM managed by a
                   # ScirCloud Bourreau is defined by the following
                   # parameters which specify the disk image where the

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -56,7 +56,6 @@ class ToolConfig < ActiveRecord::Base
                                    :message => "must be unique per pair [tool, server]" },
                   :if         => :applies_to_bourreau_and_tool?
 
-
   validate        :container_rules
 
   cb_scope        :global_for_tools     , where( { :bourreau_id => nil } )
@@ -350,8 +349,6 @@ class ToolConfig < ActiveRecord::Base
       end
     end
     return errors.empty?
-
   end
-
 
 end

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -56,9 +56,6 @@ class ToolConfig < ActiveRecord::Base
                                    :message => "must be unique per pair [tool, server]" },
                   :if         => :applies_to_bourreau_and_tool?
 
-  validates                 :container_index_location,
-                            :format => { :with => /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$|^shub\:\/\/$/},
-                            :allow_blank => true
 
   validate        :container_rules
 
@@ -342,7 +339,18 @@ class ToolConfig < ActiveRecord::Base
     if self.container_engine.present? && ( self.containerhub_image_name.blank? && self.container_image_userfile_id.blank? )
       errors[:container_engine] = "a container hub image name or a container image userfile ID should be set when the container engine is set"
     end
+
+    if self.container_engine.present? && self.container_engine == "Singularity" 
+      if self.container_index_location.present? && ! /^[a-z0-9]+\:\/\/$/.match(self.container_index_location)
+        errors[:container_index_location] = "Invalid index location type for container engine Singularity. Should end in '://'."
+      end
+    elsif self.container_engine.present? && self.container_engine == "Docker"
+      if self.container_index_location.present? && ! /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/.match(self.container_index_location)
+        errors[:container_index_location] = "Invalid index location type for container engine Docker. Should be a valid hostname."
+      end
+    end
     return errors.empty?
+
   end
 
 

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -57,7 +57,7 @@ class ToolConfig < ActiveRecord::Base
                   :if         => :applies_to_bourreau_and_tool?
 
   validates                 :container_index_location,
-                            :format => { :with => /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$/i },
+                            :format => { :with => /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,6}$|^shub\:\/\/$/},
                             :allow_blank => true
 
   validate        :container_rules

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -100,18 +100,6 @@
     <%= f.select :container_engine, [["None", ''], ['Docker', 'Docker'], ['Singularity', 'Singularity']] %>
   </span>
 
-  <span title="Container image name">
-    <p><%= f.label :containerhub_image_name, "Container image name:" %><br/>
-      <%= f.text_field :containerhub_image_name %><br/>
-      <div class="field_explanation">
-        The name and tag of the container image in which the tool is installed,
-        for instance "centos:latest". This name refers to the Docker/Singulariry index
-        accessed by the Bourreau, which is configured manually in the Bourreau
-        for now.
-      </div>
-    </p>
-  </span>
-
   <span title="Index of the container image">
     <p><%= f.label :container_index_location, "Index of the container image:" %><br/>
       <%= f.text_field :container_index_location %><br>
@@ -120,6 +108,18 @@
         accessible through.
         Examples for Docker are: quay.io, index.docker.io (default).
         Examples for Singularity are: docker://, shub:// (default).
+      </div>
+    </p>
+  </span>
+
+  <span title="Container image name">
+    <p><%= f.label :containerhub_image_name, "Container image name:" %><br/>
+      <%= f.text_field :containerhub_image_name %><br/>
+      <div class="field_explanation">
+        The name and tag of the container image in which the tool is installed,
+        for instance "centos:latest". This name refers to the Docker/Singulariry index
+        accessed by the Bourreau, which is configured manually in the Bourreau
+        for now.
       </div>
     </p>
   </span>

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -112,6 +112,16 @@
     </p>
   </span>
 
+  <span title="Index of the container image">
+    <p><%= f.label :container_index_location, "Index of the container image:" %><br/>
+      <%= f.text_field :container_index_location %><br>
+      <div class="field_explanation">
+        The index/url of the Container image in which the docker/singularity container is
+        accessible through. Examples are: quay.io, index.docker.io (default).
+      </div>
+    </p>
+  </span>
+
   <span title="ID of the container image">
     <p><%= f.label :container_image_userfile_id, "ID of the container image:" %><br/>
       <%= f.text_field :container_image_userfile_id %> <%= link_to_userfile_if_accessible(@tool_config.container_image) %><br>

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -104,7 +104,7 @@
     <p><%= f.label :containerhub_image_name, "Container image name:" %><br/>
       <%= f.text_field :containerhub_image_name %><br/>
       <div class="field_explanation">
-        The name and tag of the Container image in which the tool is installed,
+        The name and tag of the container image in which the tool is installed,
         for instance "centos:latest". This name refers to the Docker/Singulariry index
         accessed by the Bourreau, which is configured manually in the Bourreau
         for now.
@@ -116,8 +116,10 @@
     <p><%= f.label :container_index_location, "Index of the container image:" %><br/>
       <%= f.text_field :container_index_location %><br>
       <div class="field_explanation">
-        The index/url of the Container image in which the docker/singularity container is
-        accessible through. Examples are: quay.io, index.docker.io (default).
+        The index/url of the container image in which the docker/singularity container is
+        accessible through.
+        Examples for Docker are: quay.io, index.docker.io (default).
+        Examples for Singularity are: docker://, shub:// (default).
       </div>
     </p>
   </span>
@@ -126,7 +128,7 @@
     <p><%= f.label :container_image_userfile_id, "ID of the container image:" %><br/>
       <%= f.text_field :container_image_userfile_id %> <%= link_to_userfile_if_accessible(@tool_config.container_image) %><br>
       <div class="field_explanation">
-        The ID number of the Container image in which the tool is installed.
+        The ID number of the container image in which the tool is installed.
         This ID refers to userfile registered in CBRAIN.
       </div>
     </p>

--- a/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
+++ b/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
@@ -95,6 +95,11 @@
       :filters  => default_filters_for(@base_scope, :container_engine)
     ) { |tc| tc.container_engine.to_s }
 
+    t.column("Container Index", :container_index_location,
+    ) { |tc|
+        tc.container_index_location
+      }
+
     t.column("Container Image", :container_name_image,
     ) { |tc|
         if tc.containerhub_image_name.present?
@@ -102,11 +107,6 @@
         elsif  tc.container_image.present?
           link_to_userfile_if_accessible(tc.container_image)
         end
-      }
-
-    t.column("Container Index", :container_index_location,
-    ) { |tc|
-        tc.container_index_location
       }
 
     t.column("Description", :description,

--- a/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
+++ b/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
@@ -104,6 +104,13 @@
         end
       }
 
+    t.column("Container Index", :container_index_location,
+    ) { |tc|
+        if tc.container_index_location.present?
+          tc.container_index_location
+        end
+      }
+
     t.column("Description", :description,
       :sortable => true,
     ) { |tc| overlay_description(tc.description) }

--- a/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
+++ b/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
@@ -106,9 +106,7 @@
 
     t.column("Container Index", :container_index_location,
     ) { |tc|
-        if tc.container_index_location.present?
-          tc.container_index_location
-        end
+        tc.container_index_location
       }
 
     t.column("Description", :description,

--- a/BrainPortal/config/console_rc/lib/pretty_view.rb
+++ b/BrainPortal/config/console_rc/lib/pretty_view.rb
@@ -331,8 +331,7 @@ ToolConfig #%d "%s"
   Exec:            %d (%s)
   nCPUs:           %d
   ContainerEngine: %s
-  ContainerIndex:  %s
-  ContainerImage:  %s
+  ContainerImage:  %s%s
   ContainerID:     %d (%s)
   QsubExt:         "%s"
     VIEW

--- a/BrainPortal/config/console_rc/lib/pretty_view.rb
+++ b/BrainPortal/config/console_rc/lib/pretty_view.rb
@@ -342,6 +342,7 @@ ToolConfig #%d "%s"
       bourreau_id.presence || 0, bourreau.try(:name),
       ncpus.presence || 0,
       container_engine.presence || "(none)",
+      container_index_location || "",
       containerhub_image_name.presence || "",
       container_image_userfile_id.presence || 0,
       container_image || "none",

--- a/BrainPortal/config/console_rc/lib/pretty_view.rb
+++ b/BrainPortal/config/console_rc/lib/pretty_view.rb
@@ -331,6 +331,7 @@ ToolConfig #%d "%s"
   Exec:            %d (%s)
   nCPUs:           %d
   ContainerEngine: %s
+  ContainerIndex:  %s
   ContainerImage:  %s
   ContainerID:     %d (%s)
   QsubExt:         "%s"

--- a/BrainPortal/config/initializers/initialize_console.rb
+++ b/BrainPortal/config/initializers/initialize_console.rb
@@ -24,5 +24,8 @@
 #=================================================================
 
 if defined?(Rails::Console)
-  IRB.conf[:RC_NAME_GENERATOR] = lambda { |ext| (Rails.root + "config/console_rc/init_rc.rb").to_s }
+  IRB.conf[:RC_NAME_GENERATOR] = lambda do |ext|
+    ext.to_s == '_history' ? (ENV['HOME'] + '/.irb-history')
+                           : (Rails.root + "config/console_rc/init_rc.rb").to_s
+  end
 end

--- a/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
+++ b/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
@@ -1,5 +1,21 @@
 class AddContainerIndexToToolConfigs < ActiveRecord::Migration
-  def change
+  def self.up
     add_column :tool_configs, :container_index_location, :string
+    ToolConfig.find_each do |tool|
+      if tool.container_engine == "Singularity" && tool.containerhub_image_name.present?
+        tmp = tool.containerhub_image_name.split('://') # Splits container image name based on singularity expected syntax
+        tool.containerhub_image_name = tmp[-1] # The container will always be the last item in the list
+        tool.container_index_location = tmp[0] + "://" if tmp.length == 2 # The index location will be default if none found, else the first element
+      end
+    end
+  end
+
+  def self.down
+    ToolConfig.find_each do |tool|
+      if tool.container_engine == "Singularity" && tool.container_index_location.present?
+        tool.containerhub_image_name = tool.container_index_location + tool.containerhub_image_name
+      end
+    end
+    remove_column :tool_configs, :container_index_location
   end
 end

--- a/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
+++ b/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
@@ -1,0 +1,5 @@
+class AddContainerIndexToToolConfigs < ActiveRecord::Migration
+  def change
+    add_column :tool_configs, :container_index_location, :string
+  end
+end

--- a/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
+++ b/BrainPortal/db/migrate/20170913185428_add_container_index_to_tool_configs.rb
@@ -3,10 +3,11 @@ class AddContainerIndexToToolConfigs < ActiveRecord::Migration
     add_column :tool_configs, :container_index_location, :string
     ToolConfig.find_each do |tool|
       if tool.container_engine == "Singularity" && tool.containerhub_image_name.present?
-        tmp = tool.containerhub_image_name.split('://') # Splits container image name based on singularity expected syntax
+        tmp = tool.containerhub_image_name.split("://") # Splits container image name based on singularity expected syntax
         tool.containerhub_image_name = tmp[-1] # The container will always be the last item in the list
-        tool.container_index_location = tmp[0] + "://" if tmp.length == 2 # The index location will be default if none found, else the first element
+        tool.container_index_location = tmp[0] + "://" if tmp.length >= 2 # The index location will be default if none found, else the first element
       end
+      tool.save
     end
   end
 
@@ -15,6 +16,7 @@ class AddContainerIndexToToolConfigs < ActiveRecord::Migration
       if tool.container_engine == "Singularity" && tool.container_index_location.present?
         tool.containerhub_image_name = tool.container_index_location + tool.containerhub_image_name
       end
+      tool.save
     end
     remove_column :tool_configs, :container_index_location
   end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20170823174959) do
+ActiveRecord::Schema.define(:version => 20170913185428) do
 
   create_table "access_profiles", :force => true do |t|
     t.string   "name",        :null => false
@@ -373,6 +373,7 @@ ActiveRecord::Schema.define(:version => 20170823174959) do
     t.integer  "container_image_userfile_id"
     t.string   "containerhub_image_name"
     t.string   "container_engine"
+    t.string   "container_index_location"
   end
 
   add_index "tool_configs", ["bourreau_id"], :name => "index_tool_configs_on_bourreau_id"

--- a/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
+++ b/BrainPortal/lib/cbrain_task_generators/schema_task_generator.rb
@@ -220,8 +220,8 @@ module SchemaTaskGenerator
       version          = @descriptor['tool-version']     || '(unknown)'
       description      = @descriptor['description']      || ''
       container_engine = (@descriptor['container-image'] || {})['type']
-      container_image  = (@descriptor['container-image'] || {})['image'] ||
-                         (@descriptor['container-image'] || {})['url']
+      container_image  = (@descriptor['container-image'] || {})['image']
+      container_index  = (@descriptor['container-image'] || {})['index']
       resource         = RemoteResource.current_resource
 
       # Create and save a new Tool for the task, unless there's already one.
@@ -249,13 +249,14 @@ module SchemaTaskGenerator
       return if container_engine == "Docker"      && !resource.docker_present?
 
       ToolConfig.new(
-        :tool_id                 => task.tool.id,
-        :bourreau_id             => resource.id,
-        :group_id                => User.admin.own_group.id,
-        :version_name            => version,
-        :description             => "#{name} #{version} on #{resource.name}",
-        :container_engine        => container_engine,
-        :containerhub_image_name => container_image,
+        :tool_id                  => task.tool.id,
+        :bourreau_id              => resource.id,
+        :group_id                 => User.admin.own_group.id,
+        :version_name             => version,
+        :description              => "#{name} #{version} on #{resource.name}",
+        :container_engine         => container_engine,
+        :containerhub_image_name  => container_image,
+        :container_index_location => container_index,
       ).save! unless
         ToolConfig.exists?(
           :tool_id      => task.tool.id,

--- a/BrainPortal/lib/cbrain_task_generators/schemas/boutiques.schema.json
+++ b/BrainPortal/lib/cbrain_task_generators/schemas/boutiques.schema.json
@@ -49,29 +49,33 @@
             },{
                 "oneOf": [{
                     "properties": {
-                        "type": { "enum": ["docker"] },
+                        "type": { "enum": ["docker", "singularity"] },
                         "image": {
                             "id": "http://github.com/boutiques/boutiques-schema/container/image",
                             "minLength": 1,
-                            "description": "Name of an image where the tool is installed and configured. Example: docker.io/neurodebian.",
+                            "description": "Name of an image where the tool is installed and configured. Example: bids/mriqc.",
                             "type": "string"
+                        },
+                        "entrypoint": {
+                          "id": "http://github.com/boutiques/boutiques-schema/container/entrypoint",
+                          "description": "Flag indicating whether or not the container uses an entrypoint.",
+                          "type": "boolean"
                         },
                         "index": {
                             "id": "http://github.com/boutiques/boutiques-schema/container/index",
                             "minLength": 1,
-                            "description": "Index where the image is available.",
-                            "default": "http://index.docker.io",
+                            "description": "Optional index where the image is available, if not the standard location. Example: docker.io",
                             "type": "string"
-                        },           
+                        },
                         "working-directory": {},
                         "container-hash": {}
                     },
                     "required": ["type", "image"],
                     "additionalProperties": false,
-                    "description": "Object representing a docker container for the tool."
+                    "description": "Object representing a docker or singularity container for the tool."
                 }, {
                     "properties": {
-                        "type": { "enum": ["rootfs", "singularity"] },
+                        "type": { "enum": ["rootfs"] },
                         "url": {
                             "id": "http://github.com/boutiques/boutiques-schema/container/url",
                             "minLength": 1,
@@ -83,7 +87,7 @@
                     },
                     "required": ["type", "url"],
                     "additionalProperties": false,
-                    "description": "Object representing a rootfs or singularity container for the tool."
+                    "description": "Object representing a rootfs container for the tool."
                 }]
             }]
         },
@@ -91,13 +95,7 @@
             "id": "http://github.com/boutiques/boutiques-schema/schema-version",
             "type": "string",
             "description": "Version of the schema used.",
-            "enum": ["0.4"]
-        },
-        "walltime-estimate": {
-            "id": "http://github.com/boutiques/boutiques-schema/walltime-estimate",
-            "type": "number",
-            "description": "Estimated wall time of a task in seconds.",
-            "minLength": 1
+            "enum": ["0.5"]
         },
         "environment-variables": {
             "id": "http://github.com/boutiques/boutiques-schema/environment-variables",
@@ -176,6 +174,11 @@
                     "one-is-required": {
                         "id": "http://github.com/boutiques/boutiques-schema/group/one-is-required",
                         "description": "True if at least one of the inputs in the group must be active at runtime.",
+                        "type": "boolean"
+                    },
+                    "all-or-none": {
+                        "id": "http://github.com/boutiques/boutiques-schema/group/all-or-none",
+                        "description": "True if members of the group need to be toggled together",
                         "type": "boolean"
                     }
                 },
@@ -481,6 +484,42 @@
         "invocation-schema": {
             "id": "http://github.com/boutiques/boutiques-schema/invocation-schema",
             "type": "object"
+        },
+        "suggested-resources": {
+            "id": "http://github.com/boutiques/boutiques-schema/suggested-resources",
+            "type": "object",
+            "properties": {
+                "cpu-cores": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/cpu-cores",
+                    "description": "The requested number of cpu cores to run the described application",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                "ram": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/ram",
+                    "description": "The requested number of GB RAM to run the described application",
+                    "type": "number",
+                    "minimum": 0
+                },
+                "disk-space": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/disk-space",
+                    "description": "The requested number of GB of storage to run the described application",
+                    "type": "number",
+                    "minimum": 0
+                },
+                "nodes": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/nodes",
+                    "description": "The requested number of nodes to spread the described application across",
+                    "type": "integer",
+                    "minimum": 1
+                },
+                 "walltime-estimate": {
+                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
+                     "type": "number",
+                     "description": "Estimated wall time of a task in seconds.",
+                     "minimum": 0
+                 }
+            }
         },
         "custom": {
             "id": "http://github.com/boutiques/boutiques-schema/custom",

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -501,14 +501,14 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 % end
   end
 
-% if descriptor['cbrain:walltime-estimate'] or descriptor['suggested-resources']['walltime-estimate']
+% if descriptor['cbrain:walltime-estimate'] or descriptor['suggested-resources'].try(:[],'walltime-estimate')
   # Conservative maximal run time estimate for <%= name %> when submitting a
   # job on a cluster. This value should be somewhat larger than the longest
   # expected run without being overly excessive; it will be submitted along
   # with the job to the cluster management system for scheduling purposes.
   def job_walltime_estimate
     (<%= (descriptor['cbrain:walltime-estimate']) ?
-          descriptor['cbrain:walltime-estimate'].to_s : descriptor['suggested-resources']['walltime-estimate'].to_s  %>).seconds
+          descriptor['cbrain:walltime-estimate'].to_s : descriptor['suggested-resources'].try(:[], 'walltime-estimate').to_s  %>).seconds
   end
 
 % end

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -501,14 +501,14 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 % end
   end
 
-% if descriptor['cbrain:walltime-estimate'] or descriptor['walltime-estimate']
+% if descriptor['cbrain:walltime-estimate'] or descriptor['suggested-resources']['walltime-estimate']
   # Conservative maximal run time estimate for <%= name %> when submitting a
   # job on a cluster. This value should be somewhat larger than the longest
   # expected run without being overly excessive; it will be submitted along
   # with the job to the cluster management system for scheduling purposes.
   def job_walltime_estimate
     (<%= (descriptor['cbrain:walltime-estimate']) ?
-          descriptor['cbrain:walltime-estimate'].to_s : descriptor['walltime-estimate'].to_s  %>).seconds
+          descriptor['cbrain:walltime-estimate'].to_s : descriptor['suggested-resources']['walltime-estimate'].to_s  %>).seconds
   end
 
 % end

--- a/BrainPortal/spec/boutiques/descriptor_test.json
+++ b/BrainPortal/spec/boutiques/descriptor_test.json
@@ -3,7 +3,7 @@
 	"tool-version" : "9.7.13",
 	"description" : "Simple test task for Boutiques",
 	"command-line" : "./boutiquesTestApp.rb [A] [B] [C] [a] [b] [c] [d] [e] [f] [g] [i] [j] [k] [l] [m] [n] [p] [q] [u] [v] [w] [x] [o] [r] [y] [E] [I] [N] [L]",
-	"schema-version" : "0.4",
+	"schema-version" : "0.5",
   "environment-variables" : [{
     "name" : "ev1",
     "value" : "nice_value"

--- a/BrainPortal/spec/boutiques/test_helpers.rb
+++ b/BrainPortal/spec/boutiques/test_helpers.rb
@@ -364,7 +364,7 @@ module TestHelpers
       'tool-version'   => "9.7.13",
       'description'    => "Minimal test task for Boutiques",
       'command-line'   => '/minimalApp [A]',
-      'schema-version' => '0.4',
+      'schema-version' => '0.5',
       'inputs'         => [GenerateJsonInputDefault.('a','String','A String arg')],
       'output-files'   => [{'id' => 'u', 'name' => 'U', 'path-template' => '[A]'}],
     }

--- a/BrainPortal/spec/boutiques/test_helpers.rb
+++ b/BrainPortal/spec/boutiques/test_helpers.rb
@@ -80,7 +80,7 @@ module TestHelpers
     json_file  = File.join(__dir__, TestScriptDescriptor)
     descriptor = JSON.parse( File.read(json_file) )
     errors     = JSON::Validator.fully_validate(schema, descriptor)
-    return errors == []
+    return errors.empty?
   end
 
   # Create mock input files

--- a/BrainPortal/spec/boutiques/test_helpers.rb
+++ b/BrainPortal/spec/boutiques/test_helpers.rb
@@ -32,7 +32,6 @@ module TestHelpers
   # External helper constants
   TestScriptName           = 'boutiquesTestApp.rb'
   TestScriptDescriptor     = 'descriptor_test.json'
-  ValidationScriptLocation = 'validator.rb'
   TempStore                = File.join('spec','fixtures') # Site for temp file creation, as in other specs
 
   ### Helper script argument-specific constants ###
@@ -75,11 +74,13 @@ module TestHelpers
 
   # JSON validation
   def runAndCheckJsonValidator(boutiquesSchemaLocation)
-    validator  = File.join(__dir__, ValidationScriptLocation)
+    require 'json-schema'
+    require 'json'
     schema     = boutiquesSchemaLocation.to_s
-    descriptor = File.join(__dir__, TestScriptDescriptor)
-    stdout     = `ruby #{validator} #{schema} #{descriptor}`
-    return stdout.start_with?( '["OK"]' )
+    json_file  = File.join(__dir__, TestScriptDescriptor)
+    descriptor = JSON.parse( File.read(json_file) )
+    errors     = JSON::Validator.fully_validate(schema, descriptor)
+    return errors == []
   end
 
   # Create mock input files

--- a/BrainPortal/spec/boutiques/test_helpers.rb
+++ b/BrainPortal/spec/boutiques/test_helpers.rb
@@ -19,6 +19,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+require 'json-schema'
+require 'json'
+
 # This module provides helper methods and constants to avoid cluttering the
 # actual Rspec test files too much. It is shared by the Boutiques tests
 # on both the Bourreau and the Portal side. Note that it is specific to the
@@ -74,8 +77,6 @@ module TestHelpers
 
   # JSON validation
   def runAndCheckJsonValidator(boutiquesSchemaLocation)
-    require 'json-schema'
-    require 'json'
     schema     = boutiquesSchemaLocation.to_s
     json_file  = File.join(__dir__, TestScriptDescriptor)
     descriptor = JSON.parse( File.read(json_file) )


### PR DESCRIPTION
Fixed backward compatibility breaking changes when going from Boutiques 0.4 to 0.5. This includes:
  - replacing access of `["walltime-estimate"]` to `["suggested-resources"]["walltime-estimate"]`
  - now treating `singularity` like `docker` with image and index names
  - now checking the `index` field for docker and singularity pull locations, rather than assuming "docker.io" and "shub://", respectively