### PR TITLE
Container image caching

### DIFF
--- a/Bourreau/app/models/scratch_data_provider.rb
+++ b/Bourreau/app/models/scratch_data_provider.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/scratch_data_provider.rb

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2345,6 +2345,8 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
   private
 
   # Give a unique name for container image
+  # This is used as an entry in the task's work directory, usually
+  # as a symbolic link to the real content of the image.
   def container_image_name #:nodoc:
     ".container-#{self.id}.img"
   end
@@ -2365,32 +2367,53 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
     singularity_image = self.tool_config.container_image
     self.addlog("Syncing the singularity image '#{singularity_image.name}'")
 
-    image_name = container_image_name
+    # Sync the userfile content
     singularity_image.sync_to_cache
+
+    # Create the symlink to the cached image.
     cachename = singularity_image.cache_full_path
+    image_name = container_image_name
     safe_symlink(cachename,image_name)
   end
 
-  # Perform the singularity pull
+  # Perform the singularity pull; the image will be cached
+  # as a special, hidden userfile on the ScratchDataProvider.
   def load_singularity_image_from_repo #:nodoc:
-    singularity_image_name = self.tool_config.containerhub_image_name
+    singularity_image_name     = self.tool_config.containerhub_image_name
     singularity_index_location = self.tool_config.container_index_location.presence || "shub://"
 
     self.addlog("Pulling singularity image '#{singularity_image_name}'")
 
+    # Find or create the userfile holding the image content.
+    scratch_name     = "Singularity-pull-" + singularity_image_name.gsub(/[^a-z0-9_\.\-]+/i,"_") # must respect userfile convention.
+    scratch_name.sub!(/(\.img)?$/i, ".img") # singularity pull is peculiar about extensions... :-(
+    scratch_userfile = SingularityImage.find_or_create_as_scratch(:name => scratch_name) do |cache_path|
+      # Optimization: if another find_or_create_as_scratch has already beaten us to the punch
+      # and dowloaded the file, just skip this block altogether. The way SyncStatus works, several
+      # of these blocks can be scheduled to run, but only one will execute at at any given time.
+      next if File.exists?(cache_path.to_s) && File.size(cache_path.to_s) > 0
+      # Run singularity pull command
+      errfile = "/tmp/.container_load_cmd.#{self.run_id}.err"
+      success = Dir.chdir(cache_path.parent.to_s) do # singularity pull won't work with full pathnames for --name :-(
+        system("#{singularity_executable_name} pull --name #{scratch_name.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape} </dev/null >/dev/null 2>#{errfile.bash_escape}")
+      end
+      err     = File.read(errfile) rescue "No Error File?"
+      File.unlink(errfile) rescue true
+      # Singularity command can generate 'implausibly old time stamp' when pulling a docker image (due to tar), we ignore it.
+      # Remove all lines (use ^ and $) that contains this message.
+      err.gsub!(/^.*implausibly old time stamp.*$\n?/,"")
+      cb_error "Cannot pull singularity image" if
+        err.present? ||
+        ! success    ||
+        ! File.exists?(cache_path.to_s)
+    end
+
+    self.addlog("Image stored as scratch userfile '#{scratch_userfile.name}' (ID #{scratch_userfile.id})")
+
+    # Create the symlink to the cached image.
+    cachename  = scratch_userfile.cache_full_path
     image_name = container_image_name
-    errfile = "/tmp/.container_load_cmd.#{self.run_id}.err"
-    success = system("#{singularity_executable_name} pull --name #{image_name.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape} </dev/null >/dev/null 2>#{errfile.bash_escape}")
-    err     = File.read(errfile) rescue "No Error File?"
-    # Singularity command can generate 'implausibly old time stamp' when pulling a docker image (due to tar), we ignore it.
-    # Remove all lines (use ^ and $) that contains this message. 
-    err.gsub!(/^.*implausibly old time stamp.*$\n?/,"")
-    cb_error "Cannot pull singularity image" if
-      err.present? ||
-      ! success    ||
-      ! File.exists?(image_name)
-  ensure
-    File.unlink(errfile) rescue true
+    safe_symlink(cachename,image_name)
   end
 
   ##################################################################

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -1231,7 +1231,7 @@ class DataProvider < ActiveRecord::Base
       # Check to see if the cache dir match the path of any known Data Provider
       conflict_dp = self.all
         .select do |dp|
-          Pathname.new(dp.remote_dir).cleanpath == cache_root_path
+          Pathname.new(dp.remote_dir || '').cleanpath == cache_root_path
         end
         .find do |dp|
           hosts  = (dp.alternate_host || "").split(',')

--- a/BrainPortal/app/models/scratch_data_provider.rb
+++ b/BrainPortal/app/models/scratch_data_provider.rb
@@ -1,0 +1,128 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This data provider class is special in that it doesn't
+# store the Userfile data anywhere but in the local cache
+# of the CBRAIN Rails app. So all content is meant to be
+# just temporary (even if the entry in the userfiles
+# tables stays around) and the content itself might differ
+# from one rails app to the others. All other operations are
+# conceptually similar to a standard data provider, except:
+#
+# * The sync_to_cache() operation always succeed immediately
+#   if the file is InSync, and raises an exception otherwise
+#
+# * The sync_to_provider() operation always succeed immediately,
+#   therefore registering that whatever is in the local cache
+#   is the content of the file (that includes having no content!)
+#
+# There is only need for ONE such data provider in the entire
+# CBRAIN system and it is usually created by the sanity check
+# at boot time. The same DP will be used by all Rails app
+# to store locally the content of the scratch files.
+#
+# Programmers are encouraged to keep the scratch userfiles hidden to
+# normal users by creating them with a user_id set to the admin user's ID,
+# and the group_id set to the admin user's ID.
+#
+# See also the Userfile helper method find_or_create_as_scratch().
+class ScratchDataProvider < LocalDataProvider
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Utility: returns the single instance of this object
+  # that the system needs. Cached.
+  def self.main
+    @_main_ ||= self.first
+  end
+
+  # Returns true if the local Rails app has a properly configured
+  # cache directory.
+  def impl_is_alive? #:nodoc:
+    self.this_is_a_proper_cache_dir!(self.class.cache_rootdir.to_s)
+    true
+  rescue
+    false
+  end
+
+  # Returns true if content for userfile has been previous stored in the cache.
+  # raises an exception otherwise.
+  def impl_sync_to_cache(userfile)
+    return true if userfile.local_sync_status.try(:status) == 'InSync'
+    cb_error "No scratch content available for userfile #{userfile.id} on resource #{RemoteResource.current_resource.name}"
+  end
+
+  # This just marks whatever data is currently in the cache
+  # as being the true content of the userfile, as seen locally.
+  def impl_sync_to_provider(userfile)
+    true # will just mark it as 'InSync'
+  end
+
+  # Not supported; cache management and integrity is already handled by the caching subsystem
+  def impl_provider_report #:nodoc:
+    return []
+  end
+
+  #==============================================================
+  # Caching Subsytem Behavior Restoration
+  #==============================================================
+  # Because we inherit from LocalDataProvider which overrides
+  # cache_full_path to return the provider side path, we need
+  # to return to the correct caching subsystem methods just like
+  # the base class DataProvider did. The following three methods
+  # re-implement them.
+
+  # Restores DataProvider code, which was overrided in LocalDataProvider.
+  # See the code in DataProvider for more explanations.
+  def cache_full_path(userfile) #:nodoc:
+    cache_full_pathname(userfile) # this is the internal private version with a REAL path to the REAL cache
+  end
+
+  # Restores DataProvider code, which was overrided in LocalDataProvider.
+  # See the code in DataProvider for more explanations.
+  def cache_prepare(userfile) #:nodoc:
+    SyncStatus.ready_to_modify_cache(userfile) do
+      mkdir_cache_subdirs(userfile)
+    end
+    true
+  end
+
+  # Restores DataProvider code, which was overrided in LocalDataProvider.
+  # See the code in DataProvider for more explanations.
+  def cache_erase(userfile) #:nodoc:
+    SyncStatus.ready_to_modify_cache(userfile,:destroy) do
+      begin
+        fullpath = cache_full_pathname(userfile)
+        level2 = fullpath.parent
+        FileUtils.remove_entry(level2,true) rescue true
+        level1 = level2.parent
+        Dir.rmdir(level1)
+        level0 = level1.parent
+        Dir.rmdir(level0)
+      rescue Errno::ENOENT, Errno::ENOTEMPTY
+      end
+    end
+    true
+  end
+
+end
+

--- a/BrainPortal/app/models/scratch_data_provider.rb
+++ b/BrainPortal/app/models/scratch_data_provider.rb
@@ -58,7 +58,8 @@ class ScratchDataProvider < LocalDataProvider
   # Returns true if the local Rails app has a properly configured
   # cache directory.
   def impl_is_alive? #:nodoc:
-    self.this_is_a_proper_cache_dir!(self.class.cache_rootdir.to_s)
+    self.class.this_is_a_proper_cache_dir!(self.class.cache_rootdir.to_s,
+      :for_remote_resource_id => RemoteResource.current_resource.id)
     true
   rescue
     false

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/filesystem_image/filesystem_image.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/filesystem_image/filesystem_image.rb
@@ -1,0 +1,33 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Generic model for files containing a file system
+class FilesystemImage < SingleFile
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def self.file_name_pattern #:nodoc:
+    /\.img\z/i
+  end
+
+end
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/singularity_image/singularity_image.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/singularity_image/singularity_image.rb
@@ -1,0 +1,35 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This model represents a single file containing a Singularity container image.
+class SingularityImage < FilesystemImage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # There really is no specific code for that model, yet.
+
+  def self.file_name_pattern #:nodoc:
+    /\.img\z/i
+  end
+
+end
+

--- a/BrainPortal/lib/portal_sanity_checks.rb
+++ b/BrainPortal/lib/portal_sanity_checks.rb
@@ -333,5 +333,33 @@ class PortalSanityChecks < CbrainChecker #:nodoc:
     end
   end
 
+  # There must be a single ScatchDataProvider object for the whole
+  # CBRAIN system.
+  def self.ensure_scratch_data_provider_exists #:nodoc:
+
+    #-----------------------------------------------------------------------------
+    puts "C> Ensuring a single ScratchDataProvider exists..."
+    #-----------------------------------------------------------------------------
+
+    admin_user  = User.find_by_login("admin")
+    all_scratch = ScratchDataProvider.all.to_a
+    if (all_scratch.size > 1)
+      puts "C> \t -There is more than one ScratchDataProvider in the system!"
+      all_scratch[1..(all_scratch.size-1)].each { |dp| dp.delete }
+    end
+    if (all_scratch.size == 0)
+      scratch = ScratchDataProvider.new
+      scratch.user_id      = admin_user.id
+      scratch.group_id     = admin_user.own_group.id
+      scratch.name         = "SystemScratchSpace"
+      scratch.online       = true
+      scratch.read_only    = false
+      scratch.not_syncable = false
+      scratch.description  = "Automatically created by the system.\n\n" +
+                             "Used to cache scratch userfile content on each server.\n"
+      scratch.save!
+    end
+  end
+
 end
 

--- a/BrainPortal/spec/controllers/data_providers_controller_spec.rb
+++ b/BrainPortal/spec/controllers/data_providers_controller_spec.rb
@@ -25,6 +25,7 @@ require 'rails_helper'
 RSpec.describe DataProvidersController, :type => :controller do
   let(:data_provider) { mock_model(DataProvider).as_null_object }
   let(:admin_user)    { create(:admin_user) }
+  let(:scratch_dp)    { ScratchDataProvider.main }
 
   context "with an admin user" do
     before(:each) do
@@ -40,7 +41,7 @@ RSpec.describe DataProvidersController, :type => :controller do
         let!(:local_dp) { create(:flat_dir_local_data_provider) }
         it "should assign @data_providers" do
           get :index
-          expect(assigns[:data_providers].to_a).to eq([local_dp])
+          expect(assigns[:data_providers].to_a).to match_array([scratch_dp,local_dp])
         end
         it "should render the index page" do
          get :index

--- a/BrainPortal/spec/modules/resource_access_spec.rb
+++ b/BrainPortal/spec/modules/resource_access_spec.rb
@@ -26,6 +26,7 @@ describe ResourceAccess do
   let(:normal_user)    { create(:normal_user) }
   let(:site_manager)   { create(:site_manager) }
   let(:admin)          { create(:admin_user) }
+  let(:scratch_dp)     { ScratchDataProvider.main }
   let(:free_resource)  { create(:data_provider) }
   let(:group_resource) { create(:data_provider, :group => user.groups.last) }
   let(:site_resource)  { create(:data_provider, :user => create(:normal_user, :site => user.site)) }
@@ -145,7 +146,7 @@ describe ResourceAccess do
         group_resource
         site_resource
         owned_resource
-        expect(DataProvider.find_all_accessible_by_user(admin).map(&:id)).to match_array([free_resource.id, group_resource.id, site_resource.id, owned_resource.id])
+        expect(DataProvider.find_all_accessible_by_user(admin).map(&:id)).to match_array([scratch_dp.id, free_resource.id, group_resource.id, site_resource.id, owned_resource.id])
       end
     end
 


### PR DESCRIPTION
The PR fixes the problem with having multiple copies of container images in each task's work directory (issue #645).

Because it depends on the previous PR ( #679 ) it also includes all its changes (it is based on top of it). Please review #679 first, then review this pull request. Once #679 has been merged, I will rebase this PR and make it more clean. The true commit for this PR is adb728e .

The idea here is that the cluster task code will now use the ScratchDataProvider mechanism introduced in the previous PR to store a single copy of the image for the system. This is done by embedding the original `singularity pull` command inside the content-creation block given to the new helper method `Userfile.find_or_create_as_scratch()` . This makes the code much more elegant and allows the management of the scratch userfiles to happen in exactly the same was as any other userfile's cached content.