### PR TITLE
First pass at making the API single token based.

### DIFF
--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -50,7 +50,7 @@ class ApplicationController < ActionController::Base
   after_action  :action_counter            # counts all action/controller/user agents
   after_action  :log_user_info             # add to log a single line with user info.
 
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :exception, unless: -> { request.format.json? || request.format.xml? }
 
 
 

--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -309,7 +309,7 @@ class ApplicationController < ActionController::Base
 
   # Home pages in hash form.
   def start_page_params #:nodoc:
-    if current_user.nil?
+    if current_user.blank?
       { :controller => :sessions, :action => :new }
     elsif current_user.has_role?(:normal_user)
       { :controller => :groups, :action => :index }

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -327,6 +327,8 @@ class UserfilesController < ApplicationController
     if request.format.to_sym == :json || request.format.to_sym == :xml
       rr_ids_accessible   = RemoteResource.find_all_accessible_by_user(current_user).map(&:id)
       @remote_sync_status = SyncStatus.where(:userfile_id => @userfile.id, :remote_resource_id => rr_ids_accessible)
+                            .select([:id, :remote_resource_id, :status, :accessed_at, :synced_at])
+                            .all.to_a
       @children_ids       = @userfile.children_ids  rescue []
 
       userfile_for_api = @userfile.for_api # transforms into a plain Hash

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -303,7 +303,11 @@ class UsersController < ApplicationController
     current_user.addlog("Switching to user '#{@user.login}'")
     @user.addlog("Switched from user '#{current_user.login}'")
     cbrain_session.clear
+
+    # This does most of the work...
     self.current_user = @user
+    # ... but we must adjust the CBRAIN session object too
+    cbrain_session.user_id = @user.id
 
     redirect_to start_page_path
   end

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -304,7 +304,6 @@ class UsersController < ApplicationController
     @user.addlog("Switched from user '#{current_user.login}'")
     cbrain_session.clear
     self.current_user = @user
-    cbrain_session[:user_id] = @user.id
 
     redirect_to start_page_path
   end

--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -93,6 +93,13 @@ class CbrainSession
     self.user
   end
 
+  # Change the user ID in underlying model; only used when switching users.
+  def user_id=(uid)
+    return unless @model
+    @model.user_id = uid
+    @modified      = true
+  end
+
   ###########################################
   # Hash-like interface to session attributes
   ###########################################
@@ -274,7 +281,8 @@ class CbrainSession
     @model.save!
   end
 
-  # Update timestamp of current session ONLY if it's older than
+  # Save model if modified in any way. If not,
+  # update timestamp of model ONLY if it's older
   # than 1 minute.
   def touch_unless_recent
     return             unless @model.present?

--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -39,8 +39,12 @@ class CbrainSession
   # Create a new CbrainSession object wrapping +session+ (a Rails session)
   # backed by +model+, an instance of CbrainSession.session_model (which is
   # expected to be an ActiveRecord record).
-  def initialize(session)
-    sid = session[:session_id].presence || self.class.random_session_id
+  def initialize(session_or_largeinfo)
+    if session_or_largeinfo.is_a?(self.class.session_model)
+      @model = session_or_largeinfo
+      return
+    end
+    sid = session_or_largeinfo[:session_id].presence || self.class.random_session_id
     @model   = self.class.session_model.where(:session_id => sid).first ||
                self.class.session_model.new(  :session_id => sid, :data => {})
   end
@@ -74,6 +78,19 @@ class CbrainSession
     @user = User.find_by_id(@model[:user_id]) unless
       @user && @user.id == @model[:user_id]
     @user
+  end
+
+  # Returns the token for API calls; right now we use the original Rails session ID obtained
+  # at logging in.
+  def cbrain_api_token
+    @model.try(:session_id)
+  end
+
+  # Returns the user if the model data indicates
+  # that it represents a valid, active session connected with +token+
+  def user_for_cbrain_api(token)
+    return nil unless @model && @model.active? && self.cbrain_api_token == token
+    self.user
   end
 
   ###########################################

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2274,7 +2274,10 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
     new_task.batch_id     = self.id
     self.level            = 0 if self.level.blank?
     new_task.level        = self.level + 1 # New task will be one level up its "parent" task in the task table.
-    new_task.share_workdir_with(new_share_wd_tid, "Queued") if new_share_wd_tid # can be nil
+    if new_share_wd_tid.present?
+      new_share_wd_tid      = self.id if new_share_wd_tid == 0 # a value of 0 means current task
+      new_task.share_workdir_with(new_share_wd_tid, "Queued")
+    end
 
     # Sets tool config among tool configs accessible by user of current task
     new_tool                = new_task.tool

--- a/BrainPortal/app/models/large_session_info.rb
+++ b/BrainPortal/app/models/large_session_info.rb
@@ -29,5 +29,7 @@ class LargeSessionInfo < ActiveRecord::Base
 
   serialize :data
 
+  belongs_to :user
+
 end
 

--- a/BrainPortal/app/views/portal/credits.html.erb
+++ b/BrainPortal/app/views/portal/credits.html.erb
@@ -55,15 +55,15 @@
     <h3>Software Development Credits</h3>
 
       <ul type="none">
-        <li><strong>Principal Investigator: </strong>Alan C. Evans, Montreal Neurological Institute, McGill University</li>
+        <li><strong>Principal Investigator:</strong> Alan C. Evans, Montreal Neurological Institute, McGill University</li>
         <li><strong>Program Manager:</strong> Reza Adalat</li>
-        <li><strong>Technology Manager: </strong>Marc Rousseau </li>
+        <li><strong>Technology Managers:</strong> Shawn T. Brown, Marc Rousseau</li>
         <li><strong>System Architecture:</strong> Pierre Rioux, Tarek Sherif, Tristan Glatard</li>
         <li><strong>Lead Developers:</strong> Pierre Rioux, Tarek Sherif, Nicolas Kassis, Natacha Beck, Tristan Glatard, Andrew Doyle</li>
-        <li><strong>Additional Developers:</strong> Angela McCloskey, R&eacute;mi Bernard, Tristan Aumentado-Armstrong, Anton Zoubarev, Mathieu Desrosiers, Ehsan Afkhami</li>
+        <li><strong>Additional Developers:</strong> Angela McCloskey, R&eacute;mi Bernard, Tristan Aumentado-Armstrong, Anton Zoubarev, Mathieu Desrosiers, Ehsan Afkhami, Armin Taheri</li>
         <li><strong>Additional UX Design, Testing, Documentation:</strong> Najmeh Khalili-Mahani</li>
         <li><strong>IT Team:</strong> Alden Woodward, Chris Steele, Pamela Patterson, Pierre Rioux</li>
-        <li><strong>Consultants: </strong>Samir Das, Penelope Kostopoulos, Pierre Bellec, Robert Vincent, Christine Rogers, Claude Lepage, Linsday Lewis, Carolina Makowski</li>
+        <li><strong>Consultants:</strong> Samir Das, Penelope Kostopoulos, Pierre Bellec, Robert Vincent, Christine Rogers, Claude Lepage, Linsday Lewis, Carolina Makowski</li>
         <li><strong>Platform and licensing information:</strong> <a class="action_link" href="/about_us">(Available here)</a></li>
       </ul>
 

--- a/BrainPortal/app/views/sessions/new.txt.erb
+++ b/BrainPortal/app/views/sessions/new.txt.erb
@@ -1,1 +1,0 @@
-<%= h(form_authenticity_token) -%>

--- a/BrainPortal/app/views/sessions/new.xml.erb
+++ b/BrainPortal/app/views/sessions/new.xml.erb
@@ -1,5 +1,0 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE cbrain_login_form>
-<cbrain_login_form>
-  <authenticity_token><%= h(form_authenticity_token) %></authenticity_token>
-</cbrain_login_form>

--- a/BrainPortal/lib/authenticated_system.rb
+++ b/BrainPortal/lib/authenticated_system.rb
@@ -3,11 +3,17 @@ module AuthenticatedSystem #:nodoc:
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  include ActionController::HttpAuthentication::Token
+
   protected
 
     # Extract the API token from the params, leaves it in @cbrain_api_token
     def extract_api_token
-      @cbrain_api_token = params.delete(:cbrain_api_token).presence
+      http_token, options = token_and_options(request) # provided by Rails; we ignore options
+      params_token        = params.delete(:cbrain_api_token).presence
+      # The next two lines can be permuted to change the priority
+      @cbrain_api_token ||= http_token.presence
+      @cbrain_api_token ||= params_token.presence
       true
     end
 

--- a/BrainPortal/lib/authenticated_system.rb
+++ b/BrainPortal/lib/authenticated_system.rb
@@ -4,22 +4,36 @@ module AuthenticatedSystem #:nodoc:
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   protected
+
+    # Extract the API token from the params, leaves it in @cbrain_api_token
+    def extract_api_token
+      @cbrain_api_token = params.delete(:cbrain_api_token).presence
+      true
+    end
+
     # Returns true or false if the user is logged in.
     # Preloads @current_user with the user model if they're logged in.
     def logged_in?
       !!current_user
     end
 
-    # Accesses the current user from the session.
-    # Future calls avoid the database because nil is not equal to false.
+    # Returns the currently logged-in user, if any.
     def current_user
-      @current_user ||= login_from_session unless @current_user == false
+      return @current_user if @current_user.present?
+      return nil if @current_user == false # false means we previously explicitely set current_user=(nil)
+      user ||= user_from_api_token
+      user ||= user_from_session
+      self.current_user=user # user can be nil, in that case @current_user is set to false
+      @current_user.presence # transforms false into nil
     end
 
-    # Store the given user id in the session.
+    # Store the given user id in the cookie session. This makes the +new_user+
+    # permanently logged-in. If +new_user+ is nil then
+    # we record that the current user is unset, therefore marking the
+    # session as not logged in.
     def current_user=(new_user)
-      session[:user_id] = new_user ? new_user.id : nil
-      @current_user = new_user || false
+      session[:user_id] = new_user.try(:id) unless @cbrain_api_token
+      @current_user = new_user || false # the false value is important: it means we know we have no user.
     end
 
     # Check if the user is authorized
@@ -101,7 +115,7 @@ module AuthenticatedSystem #:nodoc:
           redirect_to new_session_path
         end
         format.any do
-          request_http_basic_authentication 'Web Password'
+          head :unauthorized
         end
       end
     end
@@ -126,11 +140,25 @@ module AuthenticatedSystem #:nodoc:
     # available as ActionView helper methods.
     def self.included(base)
       base.send :helper_method, :current_user, :logged_in?
+      base.class_eval do
+        before_action :extract_api_token
+      end
     end
 
     # Called from #current_user.  First attempt to login by the user id stored in the session.
-    def login_from_session
-      self.current_user = User.find_by_id(session[:user_id]) if session[:user_id]
+    def user_from_session
+      User.find_by_id(session[:user_id]) if session[:user_id]
+    end
+
+    # For API calls. A +cbrain_api_token+ is expected in the params.
+    # If the token is valid, the cbrain_session object will contain
+    # a proper LargeSessionInfo object from which the token's user
+    # can be found.
+    def user_from_api_token
+      return nil unless @cbrain_api_token
+      user = cbrain_session.user_for_cbrain_api(@cbrain_api_token)
+      #@cbrain_api_token = nil unless user # invalid, just reset it
+      user
     end
 
 end

--- a/BrainPortal/spec/controllers/users_controller_spec.rb
+++ b/BrainPortal/spec/controllers/users_controller_spec.rb
@@ -606,6 +606,7 @@ RSpec.describe UsersController, :type => :controller do
     end
 
     describe "switch" do
+      # NOTE: the mock model below is not right.... :-( cbrain_sesssion() returns a CbrainSession object!
       let(:cbrain_session) { mock_model(LargeSessionInfo, "_csrf_token" => 'dummy csrf', "session_id" => 'session_id', "user_id" => admin.id).as_null_object }
 
       before(:each) do
@@ -620,7 +621,7 @@ RSpec.describe UsersController, :type => :controller do
 
         it "should switch the current user" do
           expect(cbrain_session).to receive(:clear)
-          expect(cbrain_session).to receive(:[]=).with(:user_id, user.id)
+          expect(cbrain_session).to receive(:user_id=).with(user.id)
           post :switch, params: {:id => user.id}
         end
 
@@ -639,7 +640,7 @@ RSpec.describe UsersController, :type => :controller do
 
         it "should allow switching to a user from the site" do
           expect(cbrain_session).to receive(:clear)
-          expect(cbrain_session).to receive(:[]=).with(:user_id, site_user.id)
+          expect(cbrain_session).to receive(:user_id=).with(site_user.id)
           post :switch, params: {:id => site_user.id}
         end
 


### PR DESCRIPTION
* No longer need to GET /session/new
* a cbrain_api_token is returned by POST /session
* this token need to be sent as a param for all other requests
* no cookie jar needs to be maintained by the client!
* that means no persistent filters or session prefs either

Swagger spec will be updated shortly.

Some unrelated changes:

* If a subtask asks to share the workdir with task #0, it means it wants to share with the current task
* Credits updated