### PR TITLE
Switching Singularity 'run' to 'exec'

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2188,12 +2188,12 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
 # 3) All local symlinks to cached files have already been adjusted
 #    by the Ruby process that created this script.
 #{singularity_executable_name}                  \\
-    run                                         \\
+    exec                                        \\
     -B #{gridshare_dir.bash_escape}             \\
     -B #{cache_dir.bash_escape}                 \\
     -H #{task_workdir.bash_escape}              \\
     #{container_image_name.bash_escape}         \\
-    #{singularity_wrapper_basename.bash_escape}
+    ./#{singularity_wrapper_basename.bash_escape}
 
     SINGULARITY_COMMANDS
 


### PR DESCRIPTION
Currently, CBRAIN executes 'singularity run' for performing a pipeline on a singularity image, which invokes the containers 'runscript'.  We really want 'exec' which allows us to execute commands directly in the container.  This change fixes.  It also becomes necessary from the singularity commands perspective to specify what is to be executed with the path, so I placed './' before the sh script to ensure that the command can find it.

Changed singularity command to:
1) Use exec instead of run
2) Specify that the .singularity.sh script is specified as with './' in front of it so that singularity command can find and execute.