### PR TITLE
API limits

### DIFF
--- a/Bourreau/app/models/application_record.rb
+++ b/Bourreau/app/models/application_record.rb
@@ -1,3 +1,1 @@
-class ApplicationRecord < ActiveRecord::Base
-  self.abstract_class = true
-end
+../../../BrainPortal/app/models/application_record.rb

--- a/Bourreau/app/models/bourreau_worker.rb
+++ b/Bourreau/app/models/bourreau_worker.rb
@@ -68,7 +68,7 @@ class BourreauWorker < Worker
     end
 
     # Flush AR caches and trigger Ruby garbage collect
-    ActiveRecord::Base.connection.clear_query_cache
+    ApplicationRecord.connection.clear_query_cache
     GC.enable; GC.start
 
     # Check for tasks stuck in Ruby, at most once per 20 minutes

--- a/BrainPortal/app/controllers/access_profiles_controller.rb
+++ b/BrainPortal/app/controllers/access_profiles_controller.rb
@@ -31,7 +31,7 @@ class AccessProfilesController < ApplicationController
 
   def index #:nodoc:
 
-    @scope = scope_from_session('access_profiles')
+    @scope = scope_from_session
     scope_default_order(@scope, 'name')
 
     @base_scope       = AccessProfile.where({})

--- a/BrainPortal/app/controllers/bourreaux_controller.rb
+++ b/BrainPortal/app/controllers/bourreaux_controller.rb
@@ -48,10 +48,10 @@ class BourreauxController < ApplicationController
       format.html
       format.js
       format.xml  do
-        render :xml => @bourreaux.to_a.for_api
+        render :xml => @bourreaux.for_api
       end
       format.json do
-        render :json => @bourreaux.to_a.for_api
+        render :json => @bourreaux.for_api
       end
     end
   end

--- a/BrainPortal/app/controllers/bourreaux_controller.rb
+++ b/BrainPortal/app/controllers/bourreaux_controller.rb
@@ -36,7 +36,7 @@ class BourreauxController < ApplicationController
   before_action :manager_role_required, :except  => [:index, :show, :row_data, :load_info, :rr_disk_usage, :cleanup_caches, :rr_access, :rr_access_dp, :update, :start, :stop]
 
   def index #:nodoc:
-    @scope = scope_from_session('bourreaux')
+    @scope = scope_from_session
     scope_default_order(@scope, 'type')
 
     @base_scope = RemoteResource

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -46,10 +46,10 @@ class DataProvidersController < ApplicationController
     respond_to do |format|
       format.html
       format.xml  do
-        render :xml  => @data_providers.to_a.for_api
+        render :xml  => @data_providers.for_api
       end
       format.json do
-        render :json => @data_providers.to_a.for_api
+        render :json => @data_providers.for_api
       end
       format.js
     end

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -35,7 +35,7 @@ class DataProvidersController < ApplicationController
   before_action :admin_role_required,   :only => [:report, :repair]
 
   def index #:nodoc:
-    @scope = scope_from_session('data_providers')
+    @scope = scope_from_session
     scope_default_order(@scope, 'name')
 
     @base_scope = DataProvider
@@ -285,7 +285,7 @@ class DataProvidersController < ApplicationController
     end
 
     # Load up the default scope for DP browsing and handle 'name_like'.
-    @scope = scope_from_session(default_scope_name)
+    @scope = scope_from_session
     scope_filter_from_params(@scope, :name_like, {
       :attribute => 'name',
       :operator  => 'match'
@@ -370,8 +370,7 @@ class DataProvidersController < ApplicationController
     @fileinfolist = @scope.apply(@fileinfolist)
 
     @scope.pagination ||= Scope::Pagination.from_hash({ :per_page => 25 })
-    @files = @scope.pagination.apply(@fileinfolist) unless
-      [:xml, :json].include?(request.format.to_sym)
+    @files = @scope.pagination.apply(@fileinfolist)
 
     scope_to_session(@scope)
 
@@ -737,7 +736,7 @@ class DataProvidersController < ApplicationController
 
   # Report inconsistencies in the data provider.
   def report
-    @scope    = scope_from_session(default_scope_name)
+    @scope    = scope_from_session
     @provider = DataProvider.find(params[:id])
     @issues   = @provider.provider_report(params[:reload])
 

--- a/BrainPortal/app/controllers/exception_logs_controller.rb
+++ b/BrainPortal/app/controllers/exception_logs_controller.rb
@@ -29,7 +29,7 @@ class ExceptionLogsController < ApplicationController
   before_action :admin_role_required
 
   def index #:nodoc:
-    @scope = scope_from_session('exception_logs')
+    @scope = scope_from_session
     scope_default_order(@scope, 'created_at', :desc)
 
     @base_scope = ExceptionLog.where(nil)

--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -32,7 +32,7 @@ class GroupsController < ApplicationController
   # GET /groups
   # GET /groups.xml
   def index  #:nodoc:
-    @scope = scope_from_session('groups')
+    @scope = scope_from_session
     scope_default_order(@scope, 'groups.name')
 
     params[:name_like].strip! if params[:name_like]
@@ -238,10 +238,10 @@ class GroupsController < ApplicationController
     redirect_action     = params[:redirect_action]     || :index
     redirect_id         = params[:redirect_id]
 
-    ['userfiles', 'tasks'].each do |name|
+    ['userfiles#index', 'tasks#index'].each do |name|
       scope = scope_from_session(name)
       scope.filters.reject! { |f| f.attribute.to_s == 'group_id' }
-      scope_to_session(scope)
+      scope_to_session(scope, name)
     end
 
     redirect_path = { :controller => redirect_controller, :action => redirect_action }

--- a/BrainPortal/app/controllers/messages_controller.rb
+++ b/BrainPortal/app/controllers/messages_controller.rb
@@ -31,7 +31,7 @@ class MessagesController < ApplicationController
   # GET /messages
   # GET /messages.xml
   def index #:nodoc:
-    @scope = scope_from_session('messages')
+    @scope = scope_from_session
     scope_default_order(@scope, 'last_sent', :desc)
 
     @base_scope = Message.where(nil)

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -162,7 +162,7 @@ class SignupsController < ApplicationController
   ################################################################
 
   def index #:nodoc:
-    @scope = scope_from_session('signups')
+    @scope = scope_from_session
 
     scope_default_order(@scope, 'created_at', :desc)
 
@@ -181,7 +181,7 @@ class SignupsController < ApplicationController
 
     @signups                    = @scope.pagination.apply(@view_scope)
 
-    scope_to_session(@scope, 'signups')
+    scope_to_session(@scope)
 
     respond_to do |format|
       format.js

--- a/BrainPortal/app/controllers/sites_controller.rb
+++ b/BrainPortal/app/controllers/sites_controller.rb
@@ -32,7 +32,7 @@ class SitesController < ApplicationController
   # GET /sites
   # GET /sites.xml
   def index #:nodoc:
-    @scope = scope_from_session('sites')
+    @scope = scope_from_session
     scope_default_order(@scope, 'name')
 
     @sites = @scope.apply(Site.includes(:users, :groups))

--- a/BrainPortal/app/controllers/tags_controller.rb
+++ b/BrainPortal/app/controllers/tags_controller.rb
@@ -34,8 +34,8 @@ class TagsController < ApplicationController
   def index #:nodoc:
     @tags = current_user.tags.all
     respond_to do |format|
-      format.xml  { render :xml  => @tags.to_a.for_api }
-      format.json { render :json => @tags.to_a.for_api }
+      format.xml  { render :xml  => @tags.for_api }
+      format.json { render :json => @tags.for_api }
     end
   end
 

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
   before_action :login_required
 
   def index #:nodoc:
-    @scope      = scope_from_session('tasks')
+    @scope      = scope_from_session
     api_request = [:xml, :json].include?(request.format.to_sym)
 
     # Default sorting order and batch mode
@@ -83,7 +83,7 @@ class TasksController < ApplicationController
       .to_h
 
     # Save the modified scope object
-    scope_to_session(@scope, 'tasks')
+    scope_to_session(@scope)
 
     respond_to do |format|
       format.html
@@ -109,7 +109,7 @@ class TasksController < ApplicationController
 
   # Renders a set of tasks associated with a batch.
   def batch_list
-    @scope = scope_from_session('tasks')
+    @scope = scope_from_session('tasks#index')
     @scope.order.clear
 
     @base_scope = custom_scope(user_scope(
@@ -573,7 +573,7 @@ class TasksController < ApplicationController
 
   # Allows user to update attributes of multiple tasks.
   def update_multiple
-    @scope = scope_from_session('tasks')
+    @scope = scope_from_session('tasks#index')
 
     # Construct task_ids and batch_ids
     task_ids   = Array(params[:tasklist]  || [])
@@ -734,7 +734,7 @@ class TasksController < ApplicationController
   # [*Terminate*] Kill the task, while maintaining its temporary files and its entry in the database.
   # [*Delete*] Kill the task, delete the temporary files and remove its entry in the database.
   def operation
-    @scope = scope_from_session('tasks')
+    @scope = scope_from_session('tasks#index')
 
     operation  = params[:operation]
     tasklist   = params[:tasklist]  || []

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -1093,7 +1093,7 @@ class TasksController < ApplicationController
       statuses = StatusClasses[@value.to_s.downcase]
 
       # With a CbrainTask model (or scope)
-      if (collection <= ActiveRecord::Base rescue nil)
+      if (collection <= ApplicationRecord rescue nil)
         collection.where(:status => statuses)
 
       # With a Ruby Enumerable

--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -31,7 +31,7 @@ class ToolConfigsController < ApplicationController
   before_action :admin_role_required, :except => [ :index ]
 
   def index #:nodoc:
-    @scope              = scope_from_session('tool_configs')
+    @scope = scope_from_session
     scope_default_order(@scope, 'name')
 
     @base_scope   = base_scope.includes([:tool, :bourreau, :group])

--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -42,8 +42,8 @@ class ToolConfigsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render :json => @tool_configs.to_a.for_api }
-      format.xml  { render :xml  => @tool_configs.to_a.for_api }
+      format.json { render :json => @tool_configs.for_api }
+      format.xml  { render :xml  => @tool_configs.for_api }
       format.js
     end
   end

--- a/BrainPortal/app/controllers/tools_controller.rb
+++ b/BrainPortal/app/controllers/tools_controller.rb
@@ -33,7 +33,7 @@ class ToolsController < ApplicationController
   # GET /tools
   # GET /tools.xml
   def index #:nodoc:
-    @scope = scope_from_session('tools')
+    @scope = scope_from_session
     scope_default_order(@scope, 'name')
 
     @base_scope = current_user.available_tools.includes(:user, :group)

--- a/BrainPortal/app/controllers/tools_controller.rb
+++ b/BrainPortal/app/controllers/tools_controller.rb
@@ -42,8 +42,8 @@ class ToolsController < ApplicationController
     respond_to do |format|
       format.js
       format.html # index.html.erb
-      format.xml  { render :xml  => @tools.to_a.for_api }
-      format.json { render :json => @tools.to_a.for_api }
+      format.xml  { render :xml  => @tools.for_api }
+      format.json { render :json => @tools.for_api }
     end
   end
 

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -1696,7 +1696,7 @@ class UserfilesController < ApplicationController
     @scope.custom[:view_all] = !current_user.has_role?(:admin_user) if
       @scope.custom[:view_all].nil?
 
-    if (! api_request? && (@scope.custom[:view_all] == "false" || !@scope.custom[:view_all]))
+    if ((! api_request?) && (@scope.custom[:view_all] == "false" || !@scope.custom[:view_all]))
       base = base.where(:user_id => current_user.id)
     else # api request, or view_all is true
       base = Userfile.restrict_access_on_query(current_user, base, :access_requested => :read)

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -43,7 +43,7 @@ class UserfilesController < ApplicationController
   # GET /userfiles.xml
   # GET /userfiles.json
   def index #:nodoc:
-    @scope = scope_from_session('userfiles')
+    @scope = scope_from_session
 
     # Manually handle the 'name_like' input, as it cant be pre-computed
     # server-side (and going the JS route would be overkill).
@@ -128,11 +128,11 @@ class UserfilesController < ApplicationController
     # General case
     else
       @userfiles = @view_scope
-      @userfiles = @scope.pagination.apply(@userfiles) unless api_request
+      @userfiles = @scope.pagination.apply(@userfiles)
     end
 
     # Save the modified scope object
-    scope_to_session(@scope, 'userfiles')
+    scope_to_session(@scope)
 
     # This is for the tool selection dialog box....
     # we need the tools the user has access to and tags associated with the tools
@@ -340,7 +340,7 @@ class UserfilesController < ApplicationController
       @sort_index  = [ 0, params[:sort_index].to_i, 999_999_999 ].sort[1]
 
       # Rebuild the sorted Userfile scope
-      @scope       = scope_from_session('userfiles')
+      @scope       = scope_from_session('userfiles#index')
       sorted_scope = filtered_scope
 
       # Fetch the neighbors of the shown userfile in the ordered scope's order

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -152,8 +152,8 @@ class UserfilesController < ApplicationController
     respond_to do |format|
       format.html
       format.js
-      format.xml  { render :xml  => (params[:ids_only].present? && api_request) ? @userfiles.to_a : @userfiles.to_a.for_api }
-      format.json { render :json => (params[:ids_only].present? && api_request) ? @userfiles.to_a : @userfiles.to_a.for_api }
+      format.xml  { render :xml  => (params[:ids_only].present? && api_request) ? @userfiles.to_a : @userfiles.for_api }
+      format.json { render :json => (params[:ids_only].present? && api_request) ? @userfiles.to_a : @userfiles.for_api }
       format.csv
     end
   end
@@ -1761,7 +1761,7 @@ class UserfilesController < ApplicationController
       tags = Set.new(@value)
 
       # With an Userfile model (or scope)
-      if (collection <= ActiveRecord::Base rescue nil)
+      if (collection <= ApplicationRecord rescue nil)
         placeholders = tags.map { '?' }.join(',')
         collection.where(<<-"SQL".strip_heredoc, *tags)
           ((
@@ -1870,7 +1870,7 @@ class UserfilesController < ApplicationController
       raise "nothing to filter with" unless valid?
 
       # With an Userfile model (or scope)
-      if (collection <= ActiveRecord::Base rescue nil)
+      if (collection <= ApplicationRecord rescue nil)
         case @operator.to_s.downcase
         when 'no_child'
           collection.where(<<-"SQL".strip_heredoc)

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -33,7 +33,7 @@ class UsersController < ApplicationController
   before_action :manager_role_required, :except => [:show, :edit, :update, :request_password, :send_password, :change_password]
 
   def index #:nodoc:
-    @scope = scope_from_session('users')
+    @scope = scope_from_session
     scope_default_order(@scope, 'full_name')
 
     params[:name_like].strip! if params[:name_like]
@@ -46,8 +46,7 @@ class UsersController < ApplicationController
     @users = @view_scope = @scope.apply(@base_scope)
 
     @scope.pagination ||= Scope::Pagination.from_hash({ :per_page => 50 })
-    @users = @scope.pagination.apply(@view_scope) if
-      [:html, :js].include?(request.format.to_sym)
+    @users = @scope.pagination.apply(@view_scope)
 
     # Precompute file, task and locked/unlocked counts.
     @users_file_counts    = Userfile.where(:user_id => @view_scope).group(:user_id).count

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -61,10 +61,10 @@ class UsersController < ApplicationController
       format.html # index.html.erb
       format.js
       format.xml  do
-        render :xml  => @users.to_a.for_api
+        render :xml  => @users.for_api
       end
       format.json do
-        render :json => @users.to_a.for_api
+        render :json => @users.for_api
       end
     end
   end

--- a/BrainPortal/app/helpers/scope_helper.rb
+++ b/BrainPortal/app/helpers/scope_helper.rb
@@ -233,7 +233,7 @@ module ScopeHelper
     # and values.
     if model
       model = model.to_s.classify.constantize unless
-        (model <= ActiveRecord::Base rescue nil)
+        (model <= ApplicationRecord rescue nil)
       association = model.reflect_on_all_associations(:belongs_to)
         .find { |a| a.foreign_key == attribute }
 
@@ -552,7 +552,7 @@ module ScopeHelper
     view       = args.first
 
     # Pre-set some defaults
-    is_assoc = attribute <= ActiveRecord::Base rescue nil
+    is_assoc = attribute <= ApplicationRecord rescue nil
     label  = 'login' if is_assoc && attribute <= User
     format = formatter.((
       proc { |l| l.constantize.pretty_type } if

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -300,7 +300,7 @@ module ShowTableHelper
     tb = TableBuilder.new(object, self, options)
     yield(tb)
 
-    if tb.editable? && object.is_a?(ActiveRecord::Base)
+    if tb.editable? && object.is_a?(ApplicationRecord)
       unless url
         url = {:controller  => params[:controller]}
         if object.new_record?

--- a/BrainPortal/app/models/access_profile.rb
+++ b/BrainPortal/app/models/access_profile.rb
@@ -32,7 +32,7 @@
 # Later on, access restrictions will be
 # recorded here too. For instance, restrictions and
 # limits of launching tasks, number of files, etc etc.
-class AccessProfile < ActiveRecord::Base
+class AccessProfile < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/active_record_log.rb
+++ b/BrainPortal/app/models/active_record_log.rb
@@ -23,14 +23,14 @@
 # This model stores the logs for any other
 # ActiveRecord model objects. See the ActRecLog module
 # for more information about the API.
-class ActiveRecordLog < ActiveRecord::Base
+class ActiveRecordLog < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   def active_record_object #:nodoc:
     ar_id = self.ar_id
     klass = self.ar_table_name.classify.constantize rescue nil
-    return nil unless klass && ar_id && klass < ActiveRecord::Base
+    return nil unless klass && ar_id && klass < ApplicationRecord
     klass.find_by_id(ar_id)
   end
 

--- a/BrainPortal/app/models/application_record.rb
+++ b/BrainPortal/app/models/application_record.rb
@@ -1,3 +1,86 @@
-class ApplicationRecord < ActiveRecord::Base
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2018
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+class ApplicationRecord < ActiveRecord::Base #:nodoc:
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
   self.abstract_class = true
+
+  ###################################################################
+  # ActiveRecord Added Behavior For MetaData
+  ###################################################################
+
+  include ActRecMetaData # module in lib/act_rec_meta_data.rb
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Logging
+  ###################################################################
+
+  include ActRecLog # module in lib/act_rec_log.rb
+
+  ############################################################################
+  # Pretty Type methods
+  ############################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::PrettyType
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Single Table Inheritance
+  ###################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::SingleTableInheritance
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Single Table Inheritance
+  ###################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::AbstractModelMethods
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Serialization
+  ###################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::Serialization
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Core Models
+  ###################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::CoreModels
+
+  ###################################################################
+  # ActiveRecord Added Behavior For Hiding Attributes
+  ###################################################################
+
+  include CBRAINExtensions::ActiveRecordExtensions::HiddenAttributes
+  include CBRAINExtensions::ActiveRecordExtensions::ApiAttrVisible
+
+  # This method is used when .for_api() is invoked on
+  # a relation, to limit the number of records returned
+  # if not limit was specified.
+  def self.default_api_limit #:nodoc:
+    1000
+  end
+
 end
+

--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -286,10 +286,16 @@ class CbrainSession
   # than 1 minute.
   def touch_unless_recent
     return             unless @model.present?
-    return @model.save     if @modified
+    clean_model_for_api    if @model.data[:api]
+    return @model.save     if @modified && @model.changed? # I hate having two parallel systems to track this
     return                 if @model.updated_at.blank? || @model.updated_at > 1.minute.ago
     return                 if @model.new_record? && @model.data.try(:size) == 0
     @model.touch
+  end
+
+  # When using the CBRAIN API, we don't save any state information for scopes
+  def clean_model_for_api #:nodoc:
+    @model.data.delete "scopes"
   end
 
   def mark_as_modified #:nodoc:

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -30,7 +30,7 @@
 # Most of the methods here are useful both on the BrainPortal side and on
 # the Bourreau side; for methods that should only be used on a particular
 # side, see the classes PortalTask and ClusterTask respectively.
-class CbrainTask < ActiveRecord::Base
+class CbrainTask < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/custom_filter.rb
+++ b/BrainPortal/app/models/custom_filter.rb
@@ -47,7 +47,7 @@
 #= Associations:
 #*Belongs* *to*:
 #* User
-class CustomFilter < ActiveRecord::Base
+class CustomFilter < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -202,7 +202,7 @@ require 'digest/md5'
 # *Belongs* *to*:
 # * User
 # * Group
-class DataProvider < ActiveRecord::Base
+class DataProvider < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/exception_log.rb
+++ b/BrainPortal/app/models/exception_log.rb
@@ -21,7 +21,7 @@
 #
 
 # Exception logging class
-class ExceptionLog < ActiveRecord::Base
+class ExceptionLog < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/group.rb
+++ b/BrainPortal/app/models/group.rb
@@ -36,7 +36,7 @@
 #[<b>On Destroy</b>] All Userfile, RemoteResource and DataProvider
 #                    associated with the group being destroyed will
 #                    have their group set to their owner's SystemGroup.
-class Group < ActiveRecord::Base
+class Group < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/help_document.rb
+++ b/BrainPortal/app/models/help_document.rb
@@ -34,7 +34,7 @@ require 'fileutils'
 #          documentation is kept.
 #
 # TODO auto-generate an HelpDocument if theres a file in PATH matching the key
-class HelpDocument < ActiveRecord::Base
+class HelpDocument < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/large_session_info.rb
+++ b/BrainPortal/app/models/large_session_info.rb
@@ -23,7 +23,7 @@
 # This model is used to store CBRAIN large session information.
 # The table name will be adjusted in a future release; right now this
 # model is a piece of transition code between Rails 3 and Rails 5.
-class LargeSessionInfo < ActiveRecord::Base
+class LargeSessionInfo < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/message.rb
+++ b/BrainPortal/app/models/message.rb
@@ -27,7 +27,7 @@ require 'socket'
 
 # Model representing messages that can be sent by the system to
 # other users, or from users to each other.
-class Message < ActiveRecord::Base
+class Message < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/meta_data_store.rb
+++ b/BrainPortal/app/models/meta_data_store.rb
@@ -32,7 +32,7 @@
 # See ActRecMetaData::MetaDataHandler , which provides a nice
 # API to access the metadata store.
 #
-class MetaDataStore < ActiveRecord::Base
+class MetaDataStore < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
@@ -46,7 +46,7 @@ class MetaDataStore < ActiveRecord::Base
   def active_record_object #:nodoc:
     ar_id = self.ar_id
     klass = self.ar_table_name.classify.constantize rescue nil
-    return nil unless klass && ar_id && klass < ActiveRecord::Base
+    return nil unless klass && ar_id && klass < ApplicationRecord
     klass.find_by_id(ar_id)
   end
 

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -52,7 +52,7 @@ require 'socket'
 #*Belongs* *to*:
 #* User
 #* Group
-class RemoteResource < ActiveRecord::Base
+class RemoteResource < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
@@ -136,7 +136,7 @@ class RemoteResource < ActiveRecord::Base
   # database.yml.
   def self.current_resource_db_config(railsenv = nil)
     railsenv ||= (Rails.env || 'production')
-    myconfigs  = ActiveRecord::Base.configurations
+    myconfigs  = ApplicationRecord.configurations
     myconfig   = myconfigs[railsenv].dup
     myconfig
   end

--- a/BrainPortal/app/models/sanity_check.rb
+++ b/BrainPortal/app/models/sanity_check.rb
@@ -23,7 +23,7 @@
 # A simple model to track the revision info
 # of the DB sanity check class,
 # and track whether or not it was applied.
-class SanityCheck < ActiveRecord::Base
+class SanityCheck < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-class Signup < ActiveRecord::Base
+class Signup < ApplicationRecord
 
   validate              :strip_blanks
 

--- a/BrainPortal/app/models/site.rb
+++ b/BrainPortal/app/models/site.rb
@@ -25,7 +25,7 @@
 # system administrator. A Site is generally associated
 # with one or more Site Managers who can act as admistrators
 # for resources within the site.
-class Site < ActiveRecord::Base
+class Site < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/ssh_agent_unlocking_event.rb
+++ b/BrainPortal/app/models/ssh_agent_unlocking_event.rb
@@ -21,7 +21,7 @@
 #
 
 # This model represents events of unlocking the system's SshAgent
-class SshAgentUnlockingEvent < ActiveRecord::Base
+class SshAgentUnlockingEvent < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/sync_status.rb
+++ b/BrainPortal/app/models/sync_status.rb
@@ -60,7 +60,7 @@
 #                the content was already synchronized and
 #                younger than the RemoteResource's threshold
 #                (specified by its cache_trust_expire).
-class SyncStatus < ActiveRecord::Base
+class SyncStatus < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/tag.rb
+++ b/BrainPortal/app/models/tag.rb
@@ -29,7 +29,7 @@
 #* User
 #*Has* *and* *belongs* *to* *many*:
 #* Userfile
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/task_vm_allocation.rb
+++ b/BrainPortal/app/models/task_vm_allocation.rb
@@ -35,7 +35,7 @@
 # transitions, but that would be complex and error-prone. Instead,
 # creating a simple table to store these allocations sounds simple and
 # efficient.
-class TaskVmAllocation < ActiveRecord::Base
+class TaskVmAllocation < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/tool.rb
+++ b/BrainPortal/app/models/tool.rb
@@ -35,7 +35,7 @@
 #* Group
 #*Has* *and* *belongs* *to* *many*
 #* Bourreau
-class Tool < ActiveRecord::Base
+class Tool < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -33,7 +33,7 @@
 # * A set of 'versioning' tool config objects have both
 #   a tool_id and a bourreau_id; they represent all
 #   available versions of a tool on a particular bourreau.
-class ToolConfig < ActiveRecord::Base
+class ToolConfig < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -44,7 +44,7 @@ require 'pbkdf2'
 #                     Userfile, RemoteResource or DataProvider resources.
 #                     Destroying a user will destroy the associated
 #                     Tag and CustomFilter resources.
-class User < ActiveRecord::Base
+class User < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -39,7 +39,7 @@ require 'set'
 #*Has* *and* *belongs* *to* *many*:
 #* Tag
 #
-class Userfile < ActiveRecord::Base
+class Userfile < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 

--- a/BrainPortal/app/views/portal/report.html.erb
+++ b/BrainPortal/app/views/portal/report.html.erb
@@ -179,7 +179,7 @@ in a tabular layout. Proceed as follow:
                  <%= pretty_size(size) %></br>
                  <%=
                    scope_filter_link("#{pluralize(num_entries,"entry")} / #{pluralize(sum_files,"file")}",
-                     'userfiles', :replace,
+                     'userfiles#index', :replace,
                      @filter_fixed.merge(td_filters).map do |attr, value|
                        { :a => attr, :v => value }
                      end,

--- a/BrainPortal/app/views/portal/welcome.html.erb
+++ b/BrainPortal/app/views/portal/welcome.html.erb
@@ -176,7 +176,7 @@
       <h1>
         <%=
           scope_link('Latest Updated Tasks',
-            'tasks', { :order => [{ :a => 'updated_at', :d => 'desc' }], },
+            'tasks#index', { :order => [{ :a => 'updated_at', :d => 'desc' }], },
             url: { :controller => :tasks, :action => :index }
           )
         %>
@@ -184,8 +184,8 @@
         <% if active_count > 0 %>
           <%=
             scope_filter_link("(#{active_count} active)",
-              'tasks', :replace, { :t => 't.sts', :v => 'active' },
-              url: { :controller => :tasks }
+              'tasks#index', :replace, { :t => 't.sts', :v => 'active' },
+              url: { :controller => :tasks, :action => :index }
             )
           %>
         <% else %>
@@ -209,7 +209,7 @@
       <h1>
         <%=
           scope_link('Latest Updated Files',
-            'userfiles', { :order => [{ :a => 'updated_at', :d => 'desc' }], },
+            'userfiles#index', { :order => [{ :a => 'updated_at', :d => 'desc' }], },
             url: { :controller => :userfiles, :action => :index }
           )
         %>

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -43,7 +43,7 @@
       <%= link_to "Show All Records",    signups_path(:view_hidden => true),  :class => "button" %>
     <% end %>
 
-    <%= scope_filter_link("Latest TODO", "signups", :replace,
+    <%= scope_filter_link("Latest TODO", "signups#index", :replace,
           [ { :a => :approved_by, :v => '' }, { :a => :confirmed, :v => 1 } ],
           :url => { :controller => :signups, :action => :index, :view_hidden => false },
           :link => { :class => "button" }

--- a/BrainPortal/app/views/sites/_sites_table.html.erb
+++ b/BrainPortal/app/views/sites/_sites_table.html.erb
@@ -59,8 +59,8 @@
       ) { |m,r,c| link_to_user_with_tooltip(m) }
     end
 
-    users_scope  = scope_from_session('users')
-    groups_scope = scope_from_session('groups')
+    users_scope  = scope_from_session('users#index')
+    groups_scope = scope_from_session('groups#index')
 
     t.column("Number of Users", :nusers) do |s|
       scope_filter_link(s.users.count.to_s,

--- a/BrainPortal/config/console_rc/lib/logger_rc.rb
+++ b/BrainPortal/config/console_rc/lib/logger_rc.rb
@@ -23,7 +23,7 @@
 # Create a new logger for ActiveRecord operations
 console_logger              = Logger.new(STDOUT)
 console_logger.formatter    = Proc.new { |s,d,p,m| "#{m}\n" }
-ActiveRecord::Base.logger   = console_logger
+ApplicationRecord.logger    = console_logger
 ActiveResource::Base.logger = console_logger
 
 # Disable AR logging (actually, just sets logging level to ERROR).
@@ -46,7 +46,7 @@ end
 
 # Toggle log level for the two loggers
 def set_log_level(level) #:nodoc:
-  console_logger       = ActiveRecord::Base.logger
+  console_logger       = ApplicationRecord.logger
   previous_level       = console_logger.level
   console_logger.level = level
   return unless block_given?

--- a/BrainPortal/config/initializers/added_core_extensions/active_record.rb
+++ b/BrainPortal/config/initializers/added_core_extensions/active_record.rb
@@ -25,65 +25,8 @@
 ###################################################################
 module ActiveRecord #:nodoc:
 
-  # CBRAIN ActiveRecord::Base extensions
-  class Base
-
-
-    ###################################################################
-    # ActiveRecord Added Behavior For MetaData
-    ###################################################################
-
-    include ActRecMetaData # module in lib/act_rec_meta_data.rb
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Logging
-    ###################################################################
-
-    include ActRecLog # module in lib/act_rec_log.rb
-
-    ############################################################################
-    # Pretty Type methods
-    ############################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::PrettyType
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Single Table Inheritance
-    ###################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::SingleTableInheritance
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Single Table Inheritance
-    ###################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::AbstractModelMethods
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Serialization
-    ###################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::Serialization
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Core Models
-    ###################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::CoreModels
-
-    ###################################################################
-    # ActiveRecord Added Behavior For Hiding Attributes
-    ###################################################################
-
-    include CBRAINExtensions::ActiveRecordExtensions::HiddenAttributes
-    include CBRAINExtensions::ActiveRecordExtensions::ApiAttrVisible
-
-  end # class Base of ActiveRecord
-
-
-
   # CBRAIN ActiveRecord::Relation extensions
-  class Relation
+  class Relation #:nodoc:
 
     #####################################################################
     # ActiveRecord::Relation safety net to avoid OOM conditions
@@ -96,6 +39,12 @@ module ActiveRecord #:nodoc:
     #####################################################################
 
     include CBRAINExtensions::ActiveRecordExtensions::RelationExtensions::RawData
+
+    #####################################################################
+    # ActiveRecord::Relation Added Behavior For API Requests
+    #####################################################################
+
+    include CBRAINExtensions::ActiveRecordExtensions::RelationExtensions::ForApiRequests
 
   end
 

--- a/BrainPortal/config/initializers/cbrain.rb
+++ b/BrainPortal/config/initializers/cbrain.rb
@@ -80,7 +80,7 @@ class CBRAIN
   def self.spawn_with_active_records(destination = nil, taskname = 'Internal Background Task')
 
     # Save the original DB connection and disconnect
-    dbconfig = ActiveRecord::Base.remove_connection
+    dbconfig = ApplicationRecord.remove_connection
 
     reader,writer = IO.pipe  # The stream that we use to send the subchild's pid to the parent
     childpid = Kernel.fork do
@@ -126,7 +126,7 @@ class CBRAIN
           end
 
           # Reconnect to DB
-          ActiveRecord::Base.establish_connection(dbconfig)
+          ApplicationRecord.establish_connection(dbconfig)
 
           # Execute the user code
           yield
@@ -138,7 +138,7 @@ class CBRAIN
           destination = User.find_by_login('admin') if destination.blank? || destination == :admin
           Message.send_internal_error_message(destination,taskname,itswrong) unless destination == :nobody
         ensure
-          ActiveRecord::Base.remove_connection
+          ApplicationRecord.remove_connection
           Kernel.exit! # End of subchild.
         end
         Kernel.exit! # End of subchild.
@@ -156,7 +156,7 @@ class CBRAIN
     writer.close # Not needed in parent!
     subchildpid = reader.read.to_i
     reader.close # Parent is done reading subchild's PID from child
-    ActiveRecord::Base.establish_connection(dbconfig)
+    ApplicationRecord.establish_connection(dbconfig)
     subchildpid
   end
 

--- a/BrainPortal/config/initializers/wrap_parameters.rb
+++ b/BrainPortal/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters format: [] # [:json]
 end
 
 # To enable root element in JSON for ActiveRecord objects.

--- a/BrainPortal/db/seeds.rb
+++ b/BrainPortal/db/seeds.rb
@@ -30,13 +30,13 @@ require 'socket'
 #
 # ActiveRecord extensions for seeding
 #
-class ActiveRecord::Base
+class ApplicationRecord
 
   def self.seed_record!(attlist, create_attlist = {}, options = {}) # some gems like "seed_fu" already define a "seed" method
     raise "Bad attribute list." if attlist.blank? || ! attlist.is_a?(Hash)
 
     top_superclass = self
-    while top_superclass.superclass < ActiveRecord::Base
+    while top_superclass.superclass < ApplicationRecord
       top_superclass = top_superclass.superclass
     end
 

--- a/BrainPortal/db/seeds_dev.rb
+++ b/BrainPortal/db/seeds_dev.rb
@@ -47,13 +47,13 @@ require 'etc'
 #
 # ActiveRecord extensions for seeding
 #
-class ActiveRecord::Base
+class ApplicationRecord
 
   def self.seed_record!(attlist, create_attlist = {}, options = { :info_name_method => :name })
     raise "Bad attribute list." if attlist.blank? || ! attlist.is_a?(Hash)
 
     top_superclass = self
-    while top_superclass.superclass < ActiveRecord::Base
+    while top_superclass.superclass < ApplicationRecord
       top_superclass = top_superclass.superclass
     end
 

--- a/BrainPortal/db/seeds_test_bourreau.rb
+++ b/BrainPortal/db/seeds_test_bourreau.rb
@@ -34,13 +34,13 @@ require 'etc'
 #
 # ActiveRecord extensions for seeding
 #
-class ActiveRecord::Base
+class ApplicationRecord
 
   def self.seed_record!(attlist, create_attlist = {}, options = { :info_name_method => :name })
     raise "Bad attribute list." if attlist.blank? || ! attlist.is_a?(Hash)
 
     top_superclass = self
-    while top_superclass.superclass < ActiveRecord::Base
+    while top_superclass.superclass < ApplicationRecord
       top_superclass = top_superclass.superclass
     end
 

--- a/BrainPortal/lib/act_rec_log.rb
+++ b/BrainPortal/lib/act_rec_log.rb
@@ -48,7 +48,7 @@
 # (those that are defined with 'belongs_to', 'has_many', 'has_one' etc).
 # This table and its records are NOT expected to be ever accessed by CBRAIN
 # programmers directly, instead a simple API has been added to the lowest
-# level of the ActiveRecord class hierarchy, ActiveRecord::Base.
+# level of the ActiveRecord class hierarchy, ApplicationRecord.
 #
 # === The new ActiveRecord methods
 #
@@ -193,7 +193,7 @@ module ActRecLog
 
   # Check that the the class this module is being included into is a valid one.
   def self.included(includer) #:nodoc:
-    unless includer <= ActiveRecord::Base
+    unless includer <= ApplicationRecord
       raise "#{includer} is not an ActiveRecord model. The ActRecLog module cannot be used with it."
     end
 
@@ -398,12 +398,12 @@ module ActRecLog
   #   Managers updated by adminuser: Removed: login1
   #   Managers uddated by adminuser: Added: login4, login5
   def addlog_object_list_updated(message, model, oldlist, newlist, by_user=nil, name_method=:name, caller_level = 0)
-    klass = model < ActiveRecord::Base ? model : model.constantize
+    klass = model < ApplicationRecord ? model : model.constantize
     oldlist = Array(oldlist)
     newlist = Array(newlist)
     # this method handles mixed arrays of IDs or objects
-    oldlist_part = oldlist.hashed_partition { |x| x.is_a?(ActiveRecord::Base) ? :obj : :id }
-    newlist_part = newlist.hashed_partition { |x| x.is_a?(ActiveRecord::Base) ? :obj : :id }
+    oldlist_part = oldlist.hashed_partition { |x| x.is_a?(ApplicationRecord) ? :obj : :id }
+    newlist_part = newlist.hashed_partition { |x| x.is_a?(ApplicationRecord) ? :obj : :id }
     oldlist = ((oldlist_part[:obj] || []) + (oldlist_part[:id] ? klass.where(:id => oldlist_part[:id]).all.to_a : [])).uniq
     newlist = ((newlist_part[:obj] || []) + (newlist_part[:id] ? klass.where(:id => newlist_part[:id]).all.to_a : [])).uniq
     added     = newlist - oldlist

--- a/BrainPortal/lib/act_rec_meta_data.rb
+++ b/BrainPortal/lib/act_rec_meta_data.rb
@@ -32,13 +32,13 @@
 #
 # = CBRAIN Metadata API
 #
-# This module is included in the base class ActiveRecord::Base
+# This module is included in the base class ApplicationRecord
 # and provides a simple interface to a metadata store. It
 # allows a program to store arbitrary (key,value) pairs with
 # any ActiveRecord object on the system.
 #
 # The basic access mechanism is through the meta() instance method
-# added to the ActiveRecord::Base class. This returns an instance
+# added to the ApplicationRecord class. This returns an instance
 # of a special handler object of type ActRecMetaData::MetaDataHandler that
 # provides the interface to set and get metadata values for the original
 # ActiveRecord object.
@@ -78,7 +78,7 @@ module ActRecMetaData
 
   # Check that the the class this module is being included into is a valid one.
   def self.included(includer) #:nodoc:
-    unless includer <= ActiveRecord::Base
+    unless includer <= ApplicationRecord
       raise "#{includer} is not an ActiveRecord model. The ActRecMetaData module cannot be used with it."
     end
 

--- a/BrainPortal/lib/cbrain_extensions/active_record_extensions/relation_extensions/for_api_requests.rb
+++ b/BrainPortal/lib/cbrain_extensions/active_record_extensions/relation_extensions/for_api_requests.rb
@@ -1,0 +1,47 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+module CBRAINExtensions #:nodoc:
+  module ActiveRecordExtensions #:nodoc:
+    module RelationExtensions #:nodoc:
+      # ActiveRecord::Relation Added Behavior For API Requests
+      module ForApiRequests
+
+        Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+        DEFAULT_API_LIMIT = 100 #:nodoc:
+
+        # When invoked on a relation, this method will first check to see
+        # if it is limited. If not, it will impose a limit (configurable by
+        # model using the default_api_limit() method) and then return the
+        # relation through .to_a().for_api() to generate an array of
+        # API-acceptable records.
+        def for_api
+          rel = self
+          rel = rel.limit(rel.model.default_api_limit || DEFAULT_API_LIMIT) unless rel.limit_value
+          rel.to_a.for_api
+        end
+
+      end
+    end
+  end
+end

--- a/BrainPortal/lib/cbrain_extensions/active_record_extensions/single_table_inheritance.rb
+++ b/BrainPortal/lib/cbrain_extensions/active_record_extensions/single_table_inheritance.rb
@@ -139,13 +139,13 @@ module CBRAINExtensions #:nodoc:
 
         # Find the root of this branch of the STI hierarchy.
         def sti_root_class
-          return nil unless self < ::ActiveRecord::Base
+          return nil unless self < ::ApplicationRecord
           return class_variable_get("@@__sti_root_class__") if class_variable_defined?("@@__sti_root_class__")
 
-          if self.superclass == ::ActiveRecord::Base
+          if self.superclass == ::ApplicationRecord
             root_class = self
           else
-            root_class = ancestors.find{ |c| c.is_a?(Class) && c.superclass == ::ActiveRecord::Base }
+            root_class = ancestors.find{ |c| c.is_a?(Class) && c.superclass == ::ApplicationRecord }
           end
           root_class.class_variable_set("@@__sti_root_class__", root_class)
 

--- a/BrainPortal/lib/license_agreements.rb
+++ b/BrainPortal/lib/license_agreements.rb
@@ -28,7 +28,7 @@ module LicenseAgreements
 
   # Check that the the class this module is being included into is a valid one.
   def self.included(includer) #:nodoc:
-    unless includer <= ActiveRecord::Base
+    unless includer <= ApplicationRecord
       raise "#{includer} is not an ActiveRecord model. The LicenseAgreements module cannot be used with it."
     end
 

--- a/BrainPortal/lib/resource_access.rb
+++ b/BrainPortal/lib/resource_access.rb
@@ -35,7 +35,7 @@ module ResourceAccess
   def self.included(includer) #:nodoc:
     return unless includer.table_exists?
 
-    unless includer < ActiveRecord::Base
+    unless includer < ApplicationRecord
       raise "#{includer} is not an ActiveRecord model. The ResourceAccess module cannot be used with it."
     end
 

--- a/BrainPortal/lib/view_scopes.rb
+++ b/BrainPortal/lib/view_scopes.rb
@@ -993,7 +993,7 @@ module ViewScopes
 
         # Validate @total and clamp @page and @per_page to a sane range
         total    = (@total || collection.size).to_i
-        per_page = [25, @per_page.to_i, 1000].sort[1]
+        per_page = [1, @per_page.to_i, 1000].sort[1]
         page     = [1, @page.to_i, (total + per_page - 1) / per_page].sort[1]
 
         # Is there a native paginate method available?
@@ -1305,9 +1305,11 @@ module ViewScopes
 
     # FIXME: the per_page parameter is often passed in many requests where it
     # doesn't belong, creating spurious Scopes in the session. A workaround is
-    # to require the target scope to already exist:
+    # to require the target scope to already exist.
+    #
+    # Added exception for pagination on the 'index' methods, we just always apply those.
     pagination.delete('p') unless
-      (cbrain_session['scopes'] || {}).has_key?(pag_scope)
+      (cbrain_session['scopes'] || {}).has_key?(pag_scope) || pag_scope =~ /#index$/
 
     cbrain_session.apply_changes(
       { 'scopes' => { pag_scope => { 'p' => pagination } } }

--- a/BrainPortal/lib/view_scopes.rb
+++ b/BrainPortal/lib/view_scopes.rb
@@ -1263,7 +1263,8 @@ module ViewScopes
 
       # Then convert other query parameters to Scope::Filter hashes
       model_name = controller_path.classify
-      model_name = 'CbrainTask' if model_name == 'Task' # tasks_controller for CbrainTask model
+      model_name = 'CbrainTask'     if model_name == 'Task' # tasks_controller for CbrainTask model
+      model_name = 'RemoteResource' if model_name == 'Bourreau' # bourreaux_controller for RemoteResource model
       model      = model_name.constantize rescue nil
       att_list   = model.try(:attribute_names) || []
       common     = params.to_unsafe_hash.slice(*att_list)

--- a/BrainPortal/lib/view_scopes.rb
+++ b/BrainPortal/lib/view_scopes.rb
@@ -466,7 +466,7 @@ module ViewScopes
 
         @value ||= [] if [ 'in', 'out', 'range' ].include?(@operator.to_s)
 
-        if (collection <= ActiveRecord::Base rescue nil)
+        if (collection <= ApplicationRecord rescue nil)
           apply_on_model(collection)
         else
           apply_on_collection(collection)
@@ -809,7 +809,7 @@ module ViewScopes
         raise "no direction to sort in" unless @direction
         raise "no attribute to sort on" unless @attribute
 
-        if (collection <= ActiveRecord::Base rescue nil)
+        if (collection <= ApplicationRecord rescue nil)
           apply_on_model(collection)
         else
           apply_on_collection(collection)
@@ -987,7 +987,7 @@ module ViewScopes
       # with *per_page* elements per page, and return the paginated collection
       # scoped to the page corresponding to *page*.
       def apply(collection)
-        collection = collection.where(nil) if collection.is_a?(ActiveRecord::Base)
+        collection = collection.where(nil) if collection.is_a?(ApplicationRecord)
         collection = collection.to_a unless
           (collection.is_a?(ActiveRecord::Relation))
 
@@ -1475,9 +1475,9 @@ module ViewScopes
     return nil if assoc.blank?
 
     # Convert a table name into an ActiveRecord model class
-    unless ((assoc <= ActiveRecord::Base) rescue nil)
+    unless ((assoc <= ApplicationRecord) rescue nil)
       table = assoc.to_s.tableize
-      assoc = ActiveRecord::Base.descendants.find do |m|
+      assoc = ApplicationRecord.descendants.find do |m|
         assoc == m.name || table == m.table_name
       end
     end
@@ -1494,7 +1494,7 @@ module ViewScopes
   # +parse_assoc+) but using a table name (as a string) instead of an
   # ActiveRecord model class.
   def self.assoc_with_table(assoc)
-    return assoc.table_name if ((assoc <= ActiveRecord::Base) rescue nil)
+    return assoc.table_name if ((assoc <= ApplicationRecord) rescue nil)
     return assoc unless assoc.is_a?(Enumerable)
 
     assoc, assoc_attr, model_attr = assoc

--- a/BrainPortal/spec/controllers/userfiles_controller_spec.rb
+++ b/BrainPortal/spec/controllers/userfiles_controller_spec.rb
@@ -63,32 +63,32 @@ RSpec.describe UserfilesController, :type => :controller do
         end
 
         it "should display all files if 'view all' is on" do
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}}}}
           expect(assigns[:userfiles].to_a).to match_array(Userfile.all.to_a)
         end
 
         it "should only display user's files if 'view all' is off" do
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>false}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>false}}}}
           expect(assigns[:userfiles].to_a).to match_array(Userfile.where(:user_id => admin.id))
         end
 
         it "should not tree sort if 'tree_sort' is set" do
           expect(controller).to receive(:tree_sort_by_pairs)
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"tree_sort"=>true}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"tree_sort"=>true}}}}
         end
 
         context "filtering and sorting" do
 
           it "should filter by type FileCollection" do
             file_collection = create(:file_collection)
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "f"=>[{"a"=>"type", "v"=>"FileCollection"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "f"=>[{"a"=>"type", "v"=>"FileCollection"}]}}}
             expect(assigns[:userfiles].to_a).to match_array([file_collection])
           end
 
           it "should filter by tag" do
             admin_userfile_2
             tag = create(:tag, :userfiles => [admin_userfile], :user => admin)
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.tags", "v"=>[tag.id]}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.tags", "v"=>[tag.id]}]}}}
             expect(assigns[:userfiles].to_a).to match_array([admin_userfile])
           end
 
@@ -97,68 +97,68 @@ RSpec.describe UserfilesController, :type => :controller do
             custom_filter.data = {"file_name_type"=>"match", "file_name_term" => admin_userfile.name}
             custom_filter.save
             allow(admin).to receive(:custom_filter_ids).and_return([custom_filter.id])
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true, "custom_filters"=>[custom_filter.id]}}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true, "custom_filters"=>[custom_filter.id]}}}}
             expect(assigns[:userfiles].to_a).to eq([admin_userfile])
           end
 
           it "should filter for no parent" do
             admin_userfile.parent_id = admin_userfile_2.id
             admin_userfile.save
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.hier", "o"=>"no_parent"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.hier", "o"=>"no_parent"}]}}}
             expect(assigns[:userfiles].to_a).to match_array(Userfile.where(:parent_id => nil))
           end
 
           it "should filter for no children" do
             admin_userfile
             child_userfile
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.hier", "o"=>"no_child"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "f"=>[{"t"=>"uf.hier", "o"=>"no_child"}]}}}
             parent_ids = Userfile.where('parent_id is NOT NULL').map{|f| f.parent_id}
             expect(assigns[:userfiles].to_a).to match_array(Userfile.where(['userfiles.id NOT IN (?)', parent_ids]).all.to_a)
           end
 
           it "should sort by name" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"name"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"name"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.order(:name).all.to_a)
           end
 
           it "should be able to reverse sort" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"name", "d"=>"desc"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"name", "d"=>"desc"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.order("name DESC").all.to_a)
           end
 
           it "should sort by type" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"type"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"type"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.order(:type).all.to_a)
           end
 
           it "should sort by owner name" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"users.login", "j"=>"users"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"users.login", "j"=>"users"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.joins(:user).merge(User.order(login: :ASC)).all.to_a)
           end
 
           it "should sort by creation date" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"created_at"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"created_at"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.order(:created_at).all.to_a)
           end
 
           it "should sort by size" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"size"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"size"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.order(:size).all.to_a)
           end
 
           it "should sort by project name" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"groups.name", "j"=>"groups"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"groups.name", "j"=>"groups"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.joins(:group).order("groups.name").all.to_a)
           end
 
           it "should sort by project access" do
             [{"a"=>"group_writable"}]
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"group_writable"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"group_writable"}]}}}
             expect(assigns[:userfiles].to_a.map(&:group_writable)).to eq(Userfile.order(:group_writable).all.to_a.map(&:group_writable))
           end
 
           it "should sort by provider" do
-            get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"data_providers.name", "j"=>"data_providers"}]}}}
+            get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}, "o"=>[{"a"=>"data_providers.name", "j"=>"data_providers"}]}}}
             expect(assigns[:userfiles].to_a).to eq(Userfile.joins(:data_provider).order("data_providers.name").all.to_a)
           end
         end
@@ -176,12 +176,12 @@ RSpec.describe UserfilesController, :type => :controller do
         end
 
         it "should display site-associated files if 'view all' is on" do
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}}}}
           expect(assigns[:userfiles].to_a).to match_array(Userfile.find_all_accessible_by_user(site_manager, :access_requested => :read))
         end
 
         it "should only display user's files if 'view all' is off" do
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>false}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>false}}}}
           expect(assigns[:userfiles].to_a).to match_array([site_manager_userfile])
         end
       end
@@ -198,12 +198,12 @@ RSpec.describe UserfilesController, :type => :controller do
 
         it "should display group-associated files if 'view all' is on" do
           group_userfile
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>true}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>true}}}}
           expect(assigns[:userfiles].to_a).to match_array([group_userfile, user_userfile])
         end
 
         it "should only display user's files if 'view all' is off" do
-          get :index, params: {_scopes: {"userfiles" => {"c"=>{"view_all"=>false}}}}
+          get :index, params: {_scopes: {"userfiles#index" => {"c"=>{"view_all"=>false}}}}
           expect(assigns[:userfiles].to_a).to match_array([user_userfile])
         end
       end

--- a/BrainPortal/spec/controllers/users_controller_spec.rb
+++ b/BrainPortal/spec/controllers/users_controller_spec.rb
@@ -53,23 +53,23 @@ RSpec.describe UsersController, :type => :controller do
           expect(assigns[:users]).to eq(User.order(:full_name).all.to_a)
         end
         it "should sort by full name" do
-          get :index, params: {"_scopes"=>{"users" => {"o"=>[{"a"=>"full_name"}]}}}
+          get :index, params: {"_scopes"=>{"users#index" => {"o"=>[{"a"=>"full_name"}]}}}
           expect(assigns[:users]).to eq(User.order(:full_name).all.to_a)
         end
         it "should sort by last connection" do
-          get :index, params: {"_scopes"=>{"users" => {"o"=>[{"a"=>"last_connected_at"}]}}}
+          get :index, params: {"_scopes"=>{"users#index" => {"o"=>[{"a"=>"last_connected_at"}]}}}
           expect(assigns[:users]).to eq(User.order(:last_connected_at).all.to_a)
         end
         it "should sort by site" do
-          get :index, params: {"_scopes"=>{"users" => {"o" =>[{"a"=>"sites"}]}}}
+          get :index, params: {"_scopes"=>{"users#index" => {"o" =>[{"a"=>"sites"}]}}}
           expect(assigns[:users]).to eq(User.includes("site").order("sites.name").all.to_a)
         end
         it "should sort by city" do
-          get :index, params: {"_scopes"=>{"users" => {"o" =>[{"a"=>"city"}]}}}
+          get :index, params: {"_scopes"=>{"users#index" => {"o" =>[{"a"=>"city"}]}}}
           expect(assigns[:users]).to eq(User.order(:city).all.to_a)
         end
         it "should sort by country" do
-          get :index, params: {"_scopes"=>{"users" => {"o" =>[{"a"=>"country"}]}}}
+          get :index, params: {"_scopes"=>{"users#index" => {"o" =>[{"a"=>"country"}]}}}
           expect(assigns[:users]).to eq(User.order(:country).all.to_a)
         end
       end

--- a/BrainPortal/spec/models/data_provider_spec.rb
+++ b/BrainPortal/spec/models/data_provider_spec.rb
@@ -145,9 +145,6 @@ describe DataProvider do
       provider.not_syncable = true
       expect{provider.sync_to_cache(userfile)}.to raise_error(CbrainError, "Error: provider #{provider.name} is not syncable.")
     end
-    it "should raise an exception if sync_to_cache is called" do
-      expect{provider.sync_to_cache(userfile)}.to raise_error("Error: method not yet implemented in subclass.")
-    end
   end
 
   describe "#sync_to_provider" do
@@ -165,9 +162,6 @@ describe DataProvider do
     it "should raise an exception if not syncable" do
       provider.not_syncable = true
       expect{provider.sync_to_provider(userfile)}.to raise_error(CbrainError, "Error: provider #{provider.name} is not syncable.")
-    end
-    it "should raise an exception when sync_to_provider called but not implemented" do
-      expect{provider.sync_to_provider(userfile)}.to raise_error("Error: method not yet implemented in subclass.")
     end
     it "should raise an exception if userfile is immutable" do
       allow(userfile).to receive(:immutable?).and_return(true)

--- a/BrainPortal/spec/models/remote_resource_spec.rb
+++ b/BrainPortal/spec/models/remote_resource_spec.rb
@@ -23,6 +23,7 @@
 require 'rails_helper'
 
 describe RemoteResource do
+  let(:userfile)        {create(:single_file)}
   let(:remote_resource) {create(:remote_resource)}
 
   describe "#spaced_dp_ignore_patterns" do
@@ -53,7 +54,7 @@ describe RemoteResource do
   end
   describe "#after_destroy" do
     it "should destroy all associated sync statuses" do
-      syncstatus = SyncStatus.new(:remote_resource_id => remote_resource.id, :userfile_id => 1)
+      syncstatus = SyncStatus.new(:remote_resource_id => remote_resource.id, :userfile_id => userfile.id)
       syncstatus.save!
       remote_resource.reload
       remote_resource.save!

--- a/BrainPortal/spec/models/task_custom_filter_spec.rb
+++ b/BrainPortal/spec/models/task_custom_filter_spec.rb
@@ -26,14 +26,19 @@ describe TaskCustomFilter do
   let(:filter)  {create(:task_custom_filter)}
   let(:task_scope) { double("task_scope").as_null_object }
 
+  let(:user1)     { create(:normal_user) }
+  let(:user2)     { create(:normal_user) }
+  let(:bourreau1) { create(:bourreau) }
+  let(:bourreau2) { create(:bourreau) }
+
   let(:cbrain_task1) {
-    create(:cbrain_task, :description => "desc1", :user_id => 1, :bourreau_id => 1,
+    create(:cbrain_task, :description => "desc1", :user_id => user1.id, :bourreau_id => bourreau1.id,
                     :created_at => "2011-04-04", :status => "New",
                     :updated_at => "2011-05-04")
   }
 
   let(:cbrain_task2) {
-    create(:cbrain_task, :description => "desc2", :user_id => 2, :bourreau_id => 2,
+    create(:cbrain_task, :description => "desc2", :user_id => user2.id, :bourreau_id => bourreau2.id,
                     :created_at => "2011-04-29", :status => "Completed",
                     :updated_at => "2011-05-29")
   }


### PR DESCRIPTION
API queries are now limited by default to 1000 results.

Each model can specify a limit with the class method `default_api_limit()` ; the method is defined in **ApplicationRecord**, which is a superclass of all **ActiveRecords**. Right now it's the one returning 1000.

The **ActiveRecord::Relation** class has been extended to gain its own `for_api()` which will check for a limit, fetch that value of not, apply it, and delegate to the `for_api()` method of **Array**.

While all this was being coded, it made sens to also tackle a refactoring issue: putting all the common code added by CBRAIN to **ActiveRecord::Base** into the new Rails5 **ApplicationRecord** instead. So this PR includes this too.

KNOWN LIMITATIONS:

None of the controllers right now implement the pagination conventions for API requests (these are normally supplied as the two parameters _per_page_ and _page_ ). This means basically that an API user cannot fetch let than the first 1000 records, and cannot get any records beyond these 1000. Oops. Will create an issue for that.
