### PR TITLE
force entrypoint override to `/bin/sh`

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2038,6 +2038,7 @@ chmod 755 #{docker_wrapper_basename.bash_escape}
     run                                          \\
     -u #{Process.uid}:#{Process.gid}             \\
     --rm                                         \\
+    --entrypoint /bin/sh                         \\
     -v "${PWD}":#{esc_cont_work_dir}             \\
     -v #{cache_dir.bash_escape}:#{cache_dir.bash_escape}         \\
     -v #{gridshare_dir.bash_escape}:#{gridshare_dir.bash_escape} \\


### PR DESCRIPTION
This enables containers with entrypoints other than a shell to work within cbrain. Similar to #696 but for Docker.