### PR TITLE
Load tool_configs before singularity build.

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2403,7 +2403,7 @@ chmod o+x . .. ../.. ../../..
       # of these blocks can be scheduled to run, but only one will execute at at any given time.
       next if File.exists?(cache_path.to_s) && File.size(cache_path.to_s) > 0
       # Run singularity build command
-      out,err = tool_config_system("umask 002; #{singularity_executable_name} build #{cache_path.parent.to_s}/#{scratch_name.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape}")
+      out,err = tool_config_system("umask 002; #{singularity_executable_name} build #{cache_path.to_s.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape}")
       # Singularity command can generate 'implausibly old time stamp' when pulling a docker image (due to tar), we ignore it.
       # Not sure if it is still true for `build` command, leave it just in case.
       # Remove all lines (use ^ and $) that contains this message.


### PR DESCRIPTION
In order to be able to use singularity-2.4.1 on some clusters, we need to be able to call the tool_config bash prologue before running the `singularity build` command. 

I fixed some comments in the meantime since we did not use anymore the pull command.  

I also add the fix for the permission in order to be able to mount directory by singularity. 

I made the PR on master after discussion with @prioux since both issues are essential for singularity usage. 