### PR TITLE
SSH DP collection_index() : fixes #483

### DIFF
--- a/BrainPortal/app/models/ssh_data_provider.rb
+++ b/BrainPortal/app/models/ssh_data_provider.rb
@@ -223,12 +223,7 @@ class SshDataProvider < DataProvider
         next if is_excluded?(entry.name) # in DataProvider
 
         fileinfo               = FileInfo.new
-        if entry.name =~ /\A#{Regexp.quote(userfile.name)}/ # this is actually BUGGY if a subdir has same name as userfile!
-          # (This entire method is such awful code)
-          fileinfo.name          = entry.name
-        else
-          fileinfo.name          = "#{userfile.name}#{base_dir}#{entry.name}"
-        end
+        fileinfo.name          = "#{userfile.name}#{base_dir}#{entry.name}"
 
         bad_attributes = []
         attlist.each do |meth|


### PR DESCRIPTION
Fix for #483 

I'm not even sure why the original code had a special 'if' check for a path that starts with the same prefix as the file collection's own name. It was unnecessary.

To test:

1) have a local Ssh DP (not smart)
2) put a file collection on it with a bunch of files and directories; make sure that some subdirectories at the top or inferior levels are named just like the file_collection itself
3) in the console try various forms of:

```ruby
f=Userfile.find(13780);x=f.provider_collection_index('subdir', [:directory, :regular]);x.map &:name
f=Userfile.find(13780);x=f.provider_collection_index(:top, [:directory, :regular]);x.map &:name
f=Userfile.find(13780);x=f.provider_collection_index('./subdir', [:directory, :regular]);x.map &:name
```
etc, where the first argument to `provider_collection_index` is misc tests subdirectory paths inside your collection.

Test this BEFORE my fix and AFTER my fix, see the difference.