### PR TITLE
Plugins can provide a 'lib' directory. Fix #714

### DIFF
--- a/BrainPortal/cbrain_plugins/installed-plugins/lib/.gitignore
+++ b/BrainPortal/cbrain_plugins/installed-plugins/lib/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/BrainPortal/config/application.rb
+++ b/BrainPortal/config/application.rb
@@ -20,6 +20,9 @@ module CbrainRailsPortal
     # CBRAIN Plugins load paths: add directories for each Userfile model
     config.eager_load_paths += Dir[ * Dir.glob("#{config.root}/cbrain_plugins/installed-plugins/userfiles/*") ]
 
+    # CBRAIN Plugins load paths: add lib directory for standalone Ruby files
+    config.eager_load_paths += Dir["#{config.root}/cbrain_plugins/installed-plugins/lib"]
+
     # CBRAIN Plugins load paths: add directory for the CbrainTask models
     # This directory contains symbolic links to a special loader code
     # which will properly fetch the code in portal/xyz.rb or bourreau/xyz.rb

--- a/BrainPortal/lib/tasks/cbrain_plugins.rake
+++ b/BrainPortal/lib/tasks/cbrain_plugins.rake
@@ -16,6 +16,7 @@ namespace :cbrain do
     userfiles_plugins_dir   = installed_plugins_dir + "userfiles"
     tasks_plugins_dir       = installed_plugins_dir + "cbrain_task"
     descriptors_plugins_dir = installed_plugins_dir + "cbrain_task_descriptors"
+    lib_plugins_dir         = installed_plugins_dir + "lib"
 
     # Paths to public assets exposed by the web server
     public_root      = Rails.root  + "public"
@@ -136,6 +137,11 @@ namespace :cbrain do
               after: lambda do |symlink_location|
                 File.symlink "cbrain_task_descriptor_loader.rb", "#{symlink_location.sub(/.json$/, '.rb')}"
               end
+            )
+
+            # Setup each ruby lib file
+            setup.('lib/*', 'lib', lib_plugins_dir,
+              condition: lambda { |f| File.extname(f) == '.rb' },
             )
 
           end # chdir package
@@ -271,6 +277,7 @@ namespace :cbrain do
       erase.('userfile',   userfiles_plugins_dir)
       erase.('task',       tasks_plugins_dir)
       erase.('descriptor', descriptors_plugins_dir)
+      erase.('lib',        lib_plugins_dir)
 
     end
 


### PR DESCRIPTION
Any CBRAIN plugins can now contain a 'lib' directory with
ruby files in them (*.rb), these will be symlinked by
the rake installation task and loaded by Rails.