### PR TITLE
Save Work Directory as FileCollection

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -816,7 +816,7 @@ class TasksController < ApplicationController
           end
           if oktasks.size > 0
             bourreau.send_command_alter_tasks(oktasks, new_status, 
-                                               { :send_to_user_id          => current_user.id.to_s, 
+                                               { :requester_user_id        => current_user.id.to_s, 
                                                  :new_bourreau_id          => new_bourreau_id, 
                                                  :archive_data_provider_id => archive_dp_id
                                                }

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -815,7 +815,12 @@ class TasksController < ApplicationController
             new_status && allowed_new.include?(new_status)
           end
           if oktasks.size > 0
-            bourreau.send_command_alter_tasks(oktasks, new_status, new_bourreau_id, archive_dp_id) # TODO parse returned command object?
+            bourreau.send_command_alter_tasks(oktasks, new_status, 
+                                               { :notify_user_id           => current_user.id.to_s, 
+                                                 :new_bourreau_id          => new_bourreau_id, 
+                                                 :archive_data_provider_id => archive_dp_id
+                                               }
+                                              ) # TODO parse returned command object?
             success_list += oktasks
           end
           skippedtasks = btasklist - oktasks

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -816,7 +816,7 @@ class TasksController < ApplicationController
           end
           if oktasks.size > 0
             bourreau.send_command_alter_tasks(oktasks, new_status, 
-                                               { :requester_user_id        => current_user.id.to_s, 
+                                               { :requester_user_id        => current_user.id, 
                                                  :new_bourreau_id          => new_bourreau_id, 
                                                  :archive_data_provider_id => archive_dp_id
                                                }

--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -816,7 +816,7 @@ class TasksController < ApplicationController
           end
           if oktasks.size > 0
             bourreau.send_command_alter_tasks(oktasks, new_status, 
-                                               { :notify_user_id           => current_user.id.to_s, 
+                                               { :send_to_user_id          => current_user.id.to_s, 
                                                  :new_bourreau_id          => new_bourreau_id, 
                                                  :archive_data_provider_id => archive_dp_id
                                                }

--- a/BrainPortal/app/models/bourreau.rb
+++ b/BrainPortal/app/models/bourreau.rb
@@ -517,6 +517,9 @@ class Bourreau < RemoteResource
         elsif newstatus == 'RemoveWorkdir'
           task.send(:remove_cluster_workdir) # it's a protected method
           next
+        elsif newstatus == 'SaveWorkdir'
+          task.send(:save_cluster_workdir) # it's a protected method
+          next
         end
 
         # No other operations are allowed for archived tasks,

--- a/BrainPortal/app/models/bourreau.rb
+++ b/BrainPortal/app/models/bourreau.rb
@@ -458,7 +458,7 @@ class Bourreau < RemoteResource
     # description of an action to perform here (e.g. RemoveWorkDir)
     taskids   = command.task_ids.split(/,/)
     newstatus = command.new_task_status
-    userid    = command.notify_user_id
+    userid    = command.send_to_user_id
 
     tasks_affected = 0
 

--- a/BrainPortal/app/models/bourreau.rb
+++ b/BrainPortal/app/models/bourreau.rb
@@ -458,7 +458,7 @@ class Bourreau < RemoteResource
     # description of an action to perform here (e.g. RemoveWorkDir)
     taskids   = command.task_ids.split(/,/)
     newstatus = command.new_task_status
-    userid    = command.send_to_user_id
+    userid    = command.requester_user_id
 
     tasks_affected = 0
 

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -371,14 +371,14 @@ class CbrainTask < ApplicationRecord
 
   # Returns an ID string containing both the bourreau_id +bid+
   # and the task ID +tid+ in format "bid/tid". Example:
-  #     "3/4"   # Bourreau #3, task #4
+  #     "3/4"   # Bourreau ID 3, task ID 4
   def bid_tid
     @bid_tid ||= "#{self.bourreau_id || '?'}/#{self.id || '?'}"
   end
 
   # Returns an ID string containing both the bourreau_name +bname+
   # and the task ID +tid+ in format "bname/tid". Example:
-  #     "Mammouth/4"   # Bourreau 'Mammouth', task #4
+  #     "Mammouth/4"   # Bourreau 'Mammouth', task ID 4
   def bname_tid
     @bname_tid ||= "#{self.bourreau.name || '?'}/#{self.id || '?'}"
   end
@@ -386,19 +386,24 @@ class CbrainTask < ApplicationRecord
   # Returns an ID string containing both the bourreau_name +bname+
   # and the task ID +tid+ in format "bname-tid" ; this is suitable to
   # be used as part of a filename. Example:
-  #     "Mammouth-4"   # Bourreau 'Mammouth', task #4
+  #     "Mammouth-4"   # Bourreau 'Mammouth', task ID 4
   def bname_tid_dashed
     @bname_tid_dashed ||= "#{self.bourreau.name || 'Unk'}-#{self.id || 'Unk'}"
   end
 
   # Returns an ID string containing both the task +tname+
-  # and the task ID +tid+ in format "tname/tid". Example:
-  #     "Civet-1234"   # Task 'Civet' #1234
+  # and the task ID +tid+ in format "tname-tid". Example:
+  #     "Civet-1234"   # Task 'Civet' with ID 1234
   def tname_tid
     @tname_tid ||= "#{self.name || '?'}-#{self.id || '?'}"
   end
 
-
+  # Returns an ID string containing the task +tname+
+  # and the run_id in format "tname-rid". Example:
+  #     "Civet-1234-1"   # Task 'Civet' with ID 1234 and run number 1
+  def tname_rid
+    @tname_rid ||= "#{self.name || '?'}-#{self.run_id || '?'}"
+  end
 
   ##################################################################
   # Run Number ID Methods

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -401,8 +401,8 @@ class CbrainTask < ApplicationRecord
   # Returns an ID string containing the task +tname+
   # and the run_id in format "tname-rid". Example:
   #     "Civet-1234-1"   # Task 'Civet' with ID 1234 and run number 1
-  def tname_rid
-    @tname_rid ||= "#{self.name || '?'}-#{self.run_id || '?'}"
+  def tname_run_id
+    @tname_run_id ||= "#{self.name || '?'}-#{self.run_id || '?'}"
   end
 
   ##################################################################

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1938,9 +1938,9 @@ exit $status
   # Save the directory created to run the job.
   # The directory will be saved as a FileCollection
   # only if the task have a results Data Provider.
-  def save_cluster_workdir(user_id=nil)
+  def save_cluster_workdir(user_id)
     full_cluster_workdir = self.full_cluster_workdir
-    user                 = User.find(user_id) rescue nil
+    user                 = User.find(user_id)
 
     # Some verification before saving the work directory
     cb_error "Tried to save a task's work directory while in the wrong Rails app." unless
@@ -1972,7 +1972,8 @@ exit $status
     file_collection = safe_userfile_find_or_new(TaskRawWorkdir,
         :name             => userfile_name,
         :data_provider_id => data_provider_id
-        :user_id          => user_id
+        :user_id          => user.id,
+        :group_id         => user.own_group.id,
       )
 
     file_collection.cache_copy_from_local_file(full_cluster_workdir)

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1951,12 +1951,6 @@ exit $status
       return
     end
 
-    data_provider_id = self.results_data_provider_id || (user && user.meta[:pref_data_provider_id])
-    if data_provider_id.blank?
-      self.addlog("Cannot save work directory: the task should have a result Data Provider or user should have a default Data Provider")
-      return
-    end
-
     if self.workdir_archived
       self.addlog "Cannot save work directory: this task is archived"
       return
@@ -1966,6 +1960,13 @@ exit $status
       self.addlog "Cannot save work directory: this task doesn't have its own work directory"
       return
     end
+
+    data_provider_id = self.results_data_provider_id || (user && user.meta[:pref_data_provider_id])
+    if data_provider_id.blank?
+      self.addlog("Cannot save work directory: the task should have a result Data Provider or user should have a default Data Provider")
+      return
+    end
+
 
     # Save under a new TaskRawWorkdir
     userfile_name   = "TaskRawWorkdir-#{self.tname_run_id}"
@@ -1990,7 +1991,7 @@ exit $status
       Message.send_message(user,
         :header        => "Could not save work directory",
         :description   => "Unable to save work directory for [[#{self.pretty_type}][/tasks/#{self.id}]]",
-        :variable_text => "#{self.errors.full_messages}",
+        :variable_text => "#{self.errors.full_messages.join("\n")}",
         :type          => :error,
       ) if user
       self.addlog("Could not save work directory.")

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1971,7 +1971,8 @@ exit $status
     userfile_name   = "TaskRawWorkdir-#{self.tname_run_id}"
     file_collection = safe_userfile_find_or_new(TaskRawWorkdir,
         :name             => userfile_name,
-        :data_provider_id => data_provider_id.to_i
+        :data_provider_id => data_provider_id
+        :user_id          => user_id
       )
 
     file_collection.cache_copy_from_local_file(full_cluster_workdir)

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1971,7 +1971,7 @@ exit $status
     userfile_name   = "TaskRawWorkdir-#{self.tname_run_id}"
     file_collection = safe_userfile_find_or_new(TaskRawWorkdir,
         :name             => userfile_name,
-        :data_provider_id => data_provider_id
+        :data_provider_id => data_provider_id,
         :user_id          => user.id,
         :group_id         => user.own_group.id,
       )

--- a/BrainPortal/app/models/portal_task.rb
+++ b/BrainPortal/app/models/portal_task.rb
@@ -52,6 +52,7 @@ class PortalTask < CbrainTask
     "archive_file"        => "ArchiveWorkdirAsFile",
     "unarchive"           => "UnarchiveWorkdir",
     "zap_wd"              => "RemoveWorkdir",
+    "save_wd"             => "SaveWorkdir",
   }
 
   # In order to optimize the set of state transitions
@@ -82,13 +83,13 @@ class PortalTask < CbrainTask
 
     # Current                          => List of states we can change to
     #--------------------------------  ---------------------------------------------
-    "Failed To Setup"                  => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Failed On Cluster"                => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Failed To PostProcess"            => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Failed Setup Prerequisites"       => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Failed PostProcess Prerequisites" => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Terminated"                       => [ "Duplicated", "Restart Setup", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
-    "Completed"                        => [ "Duplicated", "Restart Setup", "Restart Cluster", "Restart PostProcess", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir" ],
+    "Failed To Setup"                  => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Failed On Cluster"                => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Failed To PostProcess"            => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Failed Setup Prerequisites"       => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Failed PostProcess Prerequisites" => [ "Duplicated", "Recover", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Terminated"                       => [ "Duplicated", "Restart Setup", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
+    "Completed"                        => [ "Duplicated", "Restart Setup", "Restart Cluster", "Restart PostProcess", "ArchiveWorkdir", "ArchiveWorkdirAsFile", "UnarchiveWorkdir", "RemoveWorkdir", "SaveWorkdir" ],
     "Duplicated"                       => [ "Restart Setup" ],
 
     #===============================================================================

--- a/BrainPortal/app/models/remote_command.rb
+++ b/BrainPortal/app/models/remote_command.rb
@@ -104,7 +104,7 @@ class RemoteCommand < RestrictedHash
 
     # -------- KEEP USER IDS --------
 
-    :requester_user_id,    # an input for the command generally the current_user
+    :requester_user_id,    # an input for the command, generally the current_user
 
   ]
 

--- a/BrainPortal/app/models/remote_command.rb
+++ b/BrainPortal/app/models/remote_command.rb
@@ -100,7 +100,11 @@ class RemoteCommand < RestrictedHash
 
     # -------- CHECK DATA PROVIDERS PARAMETERS --------
 
-    :data_provider_ids,    # in input for the command, an array of DP ids
+    :data_provider_ids,    # an input for the command, a list of DP ids as string. "1,2,3"
+
+    # -------- KEEP USER IDS --------
+
+    :notify_user_id,       # an input for the command generaly the current_user
 
   ]
 

--- a/BrainPortal/app/models/remote_command.rb
+++ b/BrainPortal/app/models/remote_command.rb
@@ -104,7 +104,7 @@ class RemoteCommand < RestrictedHash
 
     # -------- KEEP USER IDS --------
 
-    :send_to_user_id,         # an input for the command generally the current_user
+    :requester_user_id,    # an input for the command generally the current_user
 
   ]
 

--- a/BrainPortal/app/models/remote_command.rb
+++ b/BrainPortal/app/models/remote_command.rb
@@ -104,7 +104,7 @@ class RemoteCommand < RestrictedHash
 
     # -------- KEEP USER IDS --------
 
-    :notify_user_id,       # an input for the command generaly the current_user
+    :send_to_user_id,         # an input for the command generally the current_user
 
   ]
 

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -97,14 +97,12 @@
     <% if CbrainTask::FAILED_STATUS.include?(@task.status) or CbrainTask::COMPLETED_STATUS.include?(@task.status) %>
       <%= link_to "Remove Work Directory", url_for(:action  => :operation, :operation => 'zap_wd', 'tasklist[]' => @task.id),
                                                   :method   => :post,
-                                                  :datatype => :script,
                                                   :class    => "button",
                                                   :confirm  =>
                   "Are you sure you want to remove the task's work directory?"
       %>
       <%= link_to "Save Work Directory", url_for(:action    => :operation, :operation => 'save_wd', 'tasklist[]' => @task.id),
                                                   :method   => :post,
-                                                  :datatype => :script,
                                                   :class    => "button"
       %>
     <% end %>

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -96,11 +96,16 @@
 
     <% if CbrainTask::FAILED_STATUS.include?(@task.status) or CbrainTask::COMPLETED_STATUS.include?(@task.status) %>
       <%= link_to "Remove Work Directory", url_for(:action  => :operation, :operation => 'zap_wd', 'tasklist[]' => @task.id),
-                                                  :method  => :post,
+                                                  :method   => :post,
                                                   :datatype => :script,
-                                                  :class => "button",
-                                                  :confirm =>
+                                                  :class    => "button",
+                                                  :confirm  =>
                   "Are you sure you want to remove the task's work directory?"
+      %>
+      <%= link_to "Save Work Directory", url_for(:action    => :operation, :operation => 'save_wd', 'tasklist[]' => @task.id),
+                                                  :method   => :post,
+                                                  :datatype => :script,
+                                                  :class    => "button"
       %>
     <% end %>
   </div>

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/singularity_image/singularity_image.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/singularity_image/singularity_image.rb
@@ -28,7 +28,7 @@ class SingularityImage < FilesystemImage
   # There really is no specific code for that model, yet.
 
   def self.file_name_pattern #:nodoc:
-    /\.img\z/i
+    /\.s?img\z/i
   end
 
 end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_raw_workdir/task_raw_workdir.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_raw_workdir/task_raw_workdir.rb
@@ -20,14 +20,12 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-#This model is meant to represent an arbitrary collection files (which
-#may or may not contain subdirectories) registered as a single entry in
-#the userfiles table.
+# A specific FileCollection used for the work directories of tasks.
 class TaskRawWorkdir < FileCollection
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  self.pretty_type #:nodoc:
+  def self.pretty_type #:nodoc:
     "Task raw workdir"
   end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_raw_workdir/task_raw_workdir.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_raw_workdir/task_raw_workdir.rb
@@ -1,0 +1,36 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+#This model is meant to represent an arbitrary collection files (which
+#may or may not contain subdirectories) registered as a single entry in
+#the userfiles table.
+class TaskRawWorkdir < FileCollection
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  self.pretty_type #:nodoc:
+    "Task raw workdir"
+  end
+
+end
+
+

--- a/BrainPortal/spec/models/bourreau_spec.rb
+++ b/BrainPortal/spec/models/bourreau_spec.rb
@@ -154,7 +154,7 @@ describe Bourreau do
       allow(bourreau).to receive(:send_command)
     end
     it "should create a 'get task outputs' command" do
-      expect(RemoteCommand).to receive(:new).with(hash_including(:command => 'alter_tasks'))
+      expect(RemoteCommand).to receive(:new).with(hash_including(:command => 'alter_tasks')).and_return({})
       bourreau.send_command_alter_tasks("task_id", "New")
     end
     it "should send the command" do


### PR DESCRIPTION
My solution to the issue #673. 

On task show page the user will see a button `Save Work Directory`. 
It will allow the user to save the task Work directory as a FileCollection. 

*Note*: As a convention in CBRAIN the file viewer never shows files than begin by `.` or `..` so every single file present in the task work directory will not appear in the show page of the FileCollection even if they are present. 

@prioux I normally fixed what we discuss on Friday except for the `Message`. I do not see how I can send a message to the user. If I well understand I should use the `Message.send_message` method but I do not have access to the current_user in the `save_cluster_workdir` method. Any suggestion? 