### PR TITLE
Misc fixes.

### DIFF
--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -469,9 +469,10 @@ class DataProvidersController < ApplicationController
     CBRAIN.spawn_with_active_records_if(
       [:html, :js].include?(request.format.to_sym),
       current_user,
-      "Register files (data_provider: #{@provider.id})"
+      "Register files DP=#{@provider.id}"
     ) do
-      userfiles.keys.shuffle.each do |basename|
+      userfiles.keys.shuffle.each_with_index_and_size do |basename,idx,size|
+        $0 = "Register DP=#{@provider.id} NAME=#{basename} #{idx+1}/#{size}"
         begin
           # Is the file already registered?
           if userfiles[basename].present?
@@ -546,7 +547,7 @@ class DataProvidersController < ApplicationController
 
       # Copy/move each file
       userfiles.shuffle.each_with_index do |userfile, ix|
-        $0 = "#{post_action.to_s.humanize} registered files ID=#{userfile.id} #{ix + 1}/#{userfiles.size}\0\0\0\0"
+        $0 = "#{post_action.to_s.humanize} registered files ID=#{userfile.id} #{ix + 1}/#{userfiles.size}"
 
         begin
           case post_action
@@ -613,9 +614,11 @@ class DataProvidersController < ApplicationController
     CBRAIN.spawn_with_active_records_if(
       [:html, :js].include?(request.format.to_sym),
       current_user,
-      "Unregister files (data_provider: #{@provider.id})"
+      "Unregister files DP=#{@provider.id}"
     ) do
-      userfiles.reject { |b,u| u.blank? }.to_a.shuffle.each do |basename, userfile|
+      userfiles.reject { |b,u| u.blank? }.to_a.shuffle.each_with_index_and_size do |base_uf,idx,size|
+        basename, userfile = *base_uf  # pair of values
+        $0 = "Unregister DP=#{@provider.id} ID=#{userfile.id} #{idx+1}/#{size}"
         begin
           # Make sure the current user can unregister the file
           unless userfile.has_owner_access?(current_user)
@@ -681,9 +684,12 @@ class DataProvidersController < ApplicationController
     CBRAIN.spawn_with_active_records_if(
       [:html, :js].include?(request.format.to_sym),
       current_user,
-      "Delete files (data_provider: #{@provider.id})"
+      "Delete files DP=#{@provider.id}"
     ) do
-      userfiles.to_a.shuffle.each do |basename, userfile|
+      userfiles.to_a.shuffle.each_with_index_and_size do |base_uf,idx,size|
+        basename, userfile = *base_uf  # pair of values
+        label = userfile.present? ? "ID=#{userfile.id}" : "NAME=#{basename}"
+        $0 = "Delete DP=#{@provider.id} #{label} #{idx+1}/#{size}"
         begin
           # Is the userfile registered?
           if userfile.present?

--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -248,7 +248,7 @@ module DynamicFormHelper
   # Creates a disabled checkbox, which will be checked if
   # +checked+ is present.
   def disabled_checkbox(checked = nil)
-    check_box_tag(:dummy_disabled_checkbox, "", checked.present?, :disabled => true)
+    check_box_tag(:dummy_disabled_checkbox, "", checked.present?, :disabled => true, :id => "dummy_#{rand(999999)}")
   end
 
 end

--- a/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
+++ b/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
@@ -73,7 +73,7 @@ end
 ========================================================
 Feature: Hirb pretty model tables, and table helpers
 ========================================================
-  Models have pretty unicode tables: User.limt(4)
+  Models have pretty unicode tables: User.limit(4)
   Console commands 'table' and 'view'
   Toggle with: Hirb.enable ; Hirb.disable
   (See the doc for the gem Hirb for more info)

--- a/BrainPortal/lib/portal_sanity_checks.rb
+++ b/BrainPortal/lib/portal_sanity_checks.rb
@@ -356,9 +356,17 @@ class PortalSanityChecks < CbrainChecker #:nodoc:
       scratch.read_only    = false
       scratch.not_syncable = false
       scratch.description  = "Automatically created by the system.\n\n" +
-                             "Used to cache scratch userfile content on each server.\n"
+                             "Used to cache scratch userfile content on each server.\n" +
+                             "Sysadmins: do no make this provider available or visible\n" +
+                             "to normal users, and do not attempt to transfer/copy/upload\n" +
+                             "files here, it won't work."
       scratch.save!
     end
+
+    # Force some properties
+    scratch = ScratchDataProvider.first
+    scratch.meta['no_uploads'] = 'on'  # interface won't offer it as upload destination
+    scratch.meta['no_viewers'] = 'on'  # files can't be viewed in interface
   end
 
 end


### PR DESCRIPTION
* DataProvider controller provides better process messages
  when registering, unregistering, and deleting files.
* A helper to create disabled checkboxes was assigning them
  all the same ID; fixed.
* The sanity checks create a better message for the
  ScratchDataProvider, and makes it unavailable for
  upload or file viewing.

There are no issues associated with these changes.