### PR TITLE
Fix save preset bug by having belongs to optionnal

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -998,8 +998,7 @@ class TasksController < ApplicationController
 
       # Cleanup stuff that don't need to go into a preset
       preset.status               = params[:save_as_site_preset].blank? ? 'Preset' : 'SitePreset'
-      preset.bourreau             = nil # convention: presets have bourreau id set to 0
-      preset.bourreau_id          = 0 # convention: presets have bourreau id set to 0
+      preset.bourreau_id          = 0   # convention: presets have bourreau id set to 0
       preset.batch_id             = nil
       preset.cluster_jobid        = nil
       preset.cluster_workdir      = nil

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -46,7 +46,7 @@ class CbrainTask < ApplicationRecord
   validates_presence_of :status
   validates_presence_of :tool_config_id
 
-  belongs_to            :bourreau
+  belongs_to            :bourreau, optional: true
   belongs_to            :user
   belongs_to            :group
   belongs_to            :tool_config, :optional => true  # no TC means a task object containing 'presets'

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -46,6 +46,9 @@ class CbrainTask < ApplicationRecord
   validates_presence_of :status
   validates_presence_of :tool_config_id
 
+  # Rails5 make belongs_to association required by default
+  # Task presets have bourreau id set to 0, 
+  # that's why the :bourreau assocition should be optionnal
   belongs_to            :bourreau, optional: true
   belongs_to            :user
   belongs_to            :group


### PR DESCRIPTION
This is my fix to the `Save preset` we just had in CBRAIN.

This bug was due to: 

1. line 1001 in `app/controllers/tasks_controller.rb` [here](https://github.com/aces/cbrain/blob/dbc45baccfe6c62c9547aa320ae11337f3b15712/BrainPortal/app/controllers/tasks_controller.rb#L1001)
2. A new comportment of rails5 that make [belongs_to association required by default](https://blog.bigbinary.com/2016/02/15/rails-5-makes-belong-to-association-required-by-default.html)

