### PR TITLE
Parallelizer recovery. Fixes #651

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -697,7 +697,8 @@ class ClusterTask < CbrainTask
       self.make_cluster_workdir
       self.apply_tool_config_environment do
         Dir.chdir(self.full_cluster_workdir) do
-          if ! self.setup  # as defined by subclass
+          setup_success = self.meta[:submit_without_setup] || self.setup
+          if ! setup_success  # as defined by subclass
             self.addlog("Failed to setup: 'false' returned by setup().")
             self.status_transition(self.status, "Failed To Setup")
           elsif ! self.submit_cluster_job
@@ -707,6 +708,7 @@ class ClusterTask < CbrainTask
             self.addlog("Setup and submit process successful.")
             # the status is moving forward at its own pace now
           end
+          self.meta[:submit_without_setup] = nil # reset special skip
         end
       end
       self.update_size_of_cluster_workdir

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/parallelizer/common/parallelizer.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/parallelizer/common/parallelizer.rb
@@ -43,6 +43,21 @@ class CbrainTask::Parallelizer #:nodoc:
     return CbrainTask.where(:id => task_ids)
   end
 
+  def disable_subtask(subtask) #:nodoc:
+    params           = self.params || {}
+    task_ids_enabled = (params[:task_ids_enabled] ||= {})
+    task_ids_enabled[subtask.id.to_s] = "0"
+    subtask.meta[:configure_only] = nil
+    self.remove_prerequisites_for_setup(subtask.id)
+  end
+
+  def enable_subtask(subtask) #:nodoc:
+    params           = self.params || {}
+    task_ids_enabled = (params[:task_ids_enabled] ||= {})
+    task_ids_enabled[subtask.id.to_s] = "1"
+    self.add_prerequisites_for_setup(subtask.id, 'Configured')
+  end
+
   # Creates and launch a set of Parallelizers for a set of other
   # CbrainTasks supplied in +tasklist+. All the tasks in +tasklist+
   # are assumed to already have been created with status 'Standby'.


### PR DESCRIPTION
Alright this is complex code change with several enhancements.

**Situation:** the Parallelizer normally runs sveral other subtask's bash scripts in parallel on their behalf, using a script more or less like this

```bash
# This is the parallelizer's script submitted to the cluster
cd subtask1_dir; bash subtask1.sh &
cd subtask2_dir; bash subtask2.sh &
wait
```

**The problem:** if the subtasks take too long, the cluster can terminate the entire parallelizer script and all its subprocess. Some of them might be finished, some of them might be incomplete. What we were left with was

* A parallelizer in state 'Failed On Cluster'
* Each subtask stuch in state 'Configured'

**The solution in this PR:** Clicking 'recover' on the Parallelizer now enables it to look at the state of its subtasks are reset things appropriately:

* Subtasks that had completed are simply marked as 'Data Ready' and the parallelizer is configured to no longer 'control' it
* Subtasks that were interrupted are marked as 'Recover Cluster' and they go through their normal cluster recovery code, if any
* The Parallelizer waits for them to recover and to return to 'Configured', and then resubmits its parallelizer script (with this time only the tasks a subset of tasks, nto recomputing tasks that were completed the prevoius time around)

The state monitoring of subtasks is performed by having each subtask create a touchfile in the parallelizer's work directory when they complete.