### PR TITLE
Show table helpers. Will fix #743

### DIFF
--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -791,7 +791,6 @@ pre {
 .field_with_errors {
   padding: 2px;
   background-color: red;
-  display: inline-table;
 }
 
 .errorExplanation {

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -522,9 +522,8 @@ class DataProvidersController < ApplicationController
       end
 
       # Notify user of registration successes and failures.
-      mangled_action = (post_action == :move ? 'mov' : 'copy')
       generic_notice_messages('register', succeeded, failed,
-        "Files will now be #{mangled_action}ed in background.")
+        "Files will now be #{post_action == :move ? 'moved' : 'copied'} in background.")
 
       # Prepare to copy/move the files to the new DP
       succeeded, failed = [], {}
@@ -568,6 +567,7 @@ class DataProvidersController < ApplicationController
         end
       end
 
+      mangled_action = (post_action == :move ? 'mov' : 'copy') # most work with 'ing' appended
       generic_notice_messages(mangled_action, succeeded, failed)
     end
 

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -72,7 +72,7 @@ module ShowTableHelper
       # Layout variables
       @template        = template
       @width           = options[:width] || 2
-      @edit_disabled   = false
+      @edit_disabled   = true
       @edit_disabled   = !options[:edit_condition] if options.has_key?(:edit_condition)
       @cells           = []
       @edit_cell_count = 0
@@ -82,7 +82,7 @@ module ShowTableHelper
 
       # Form information
       @url             = options[:url].presence
-      @method          = options[:method].presence || (object.new_record? ? :post : :put)
+      @method          = options[:method].presence || ((object.is_a?(ApplicationRecord) && object.new_record?) ? :post : :put)
       @form_helper     = nil
       @as              = options[:as].presence || @object.class.to_s.underscore
 
@@ -324,7 +324,7 @@ module ShowTableHelper
   def show_table(object, options = {}, &block)
 
     url = options[:url].presence
-    if url.blank?
+    if url.blank? && object.is_a?(ApplicationRecord)
       url = { :controller  => params[:controller] }
       if object.new_record?
         url[:action] = :create

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -75,15 +75,15 @@ module ShowTableHelper
       @edit_disabled   = true
       @edit_disabled   = !options[:edit_condition] if options.has_key?(:edit_condition)
       @cells           = []
-      @edit_cell_count = 0
 
       # Appearance
       @header          = options[:header].presence || "Info"
 
-      # Form information
+      # Form information; this will be provider to Rails' FormBuilder if the
+      # ShowTable helpers are used with blocks that receive an argument.
+      @form_helper     = nil
       @url             = options[:url].presence
       @method          = options[:method].presence || ((object.is_a?(ApplicationRecord) && object.new_record?) ? :post : :put)
-      @form_helper     = nil
       @as              = options[:as].presence || @object.class.to_s.underscore
 
       # Template code
@@ -98,7 +98,7 @@ module ShowTableHelper
     # Whether or not this table has editable content. An editable table will
     # have a toggle button to switch to edition mode.
     def editable?
-      !@edit_disabled # && @edit_cell_count > 0
+      !@edit_disabled
     end
 
     # Generate a single cell for the table, optionally along with a header cell
@@ -172,7 +172,6 @@ module ShowTableHelper
       header    = options.delete(:header) || field.to_s.humanize
       object    = @object
       options[:disabled] ||= @edit_disabled
-      @edit_cell_count += 1 unless options[:disabled]
       wrapper = -> { @form_helper ? block.call(@form_helper) : block.call }
       build_cell(ERB::Util.html_escape(header), @template.instance_eval { inline_edit_field(object, field, options, &wrapper) }, options)
     end

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -53,24 +53,52 @@ module ShowTableHelper
     # column/row-based.
     attr_accessor :width
 
+    attr_reader   :url
+    attr_reader   :method
+    attr_reader   :header
+    attr_reader   :as
+    attr_reader   :object
+    attr_writer   :form_helper
+
     # Create a new TableBuilder for +object+ using +template+ for rendering.
     # Available +options+ are the same as for the +show_table+ helper method.
     # Internal method; use +show_table+ (which uses this class) to create and
     # render show tables.
     def initialize(object, template, options = {}) #:nodoc:
+
+      # Main Object
       @object          = object
+
+      # Layout variables
       @template        = template
       @width           = options[:width] || 2
       @edit_disabled   = false
       @edit_disabled   = !options[:edit_condition] if options.has_key?(:edit_condition)
       @cells           = []
       @edit_cell_count = 0
+
+      # Appearance
+      @header          = options[:header].presence || "Info"
+
+      # Form information
+      @url             = options[:url].presence
+      @method          = options[:method].presence || (object.new_record? ? :post : :put)
+      @form_helper     = nil
+      @as              = options[:as].presence || @object.class.to_s.underscore
+
+      # Template code
+      @block           = options[:block]
+    end
+
+    def invoke_block #:nodoc:
+      @block.call(self)               if @block.arity == 1
+      @block.call(self, @form_helper) if @block.arity == 2 # in case we want the helper in the main block
     end
 
     # Whether or not this table has editable content. An editable table will
     # have a toggle button to switch to edition mode.
     def editable?
-      !@edit_disabled && @edit_cell_count > 0
+      !@edit_disabled # && @edit_cell_count > 0
     end
 
     # Generate a single cell for the table, optionally along with a header cell
@@ -101,7 +129,7 @@ module ShowTableHelper
     #  All other options are added as HTML attributes to both the generated
     #  header and content cells.
     def cell(header = "", options = {}, &block)
-      build_cell(ERB::Util.html_escape(header), @template.capture(&block), options)
+      build_cell(ERB::Util.html_escape(header), @template.capture(@form_helper,&block), options)
     end
 
     # Generate a new table row containing a single cell as wide as the table.
@@ -114,7 +142,7 @@ module ShowTableHelper
     # (see +pad_row_with_blank_cells+).
     def row(options = {}, &block)
       pad_row_with_blank_cells(options)
-      build_cell("", @template.capture(&block), options.dup.merge( { :no_header => true, :show_width => @width } ) )
+      build_cell("", @template.capture(@form_helper,&block), options.dup.merge( { :no_header => true, :show_width => @width } ) )
     end
 
     # Generate a cell for a field named +field+ inside the table's source
@@ -145,7 +173,8 @@ module ShowTableHelper
       object    = @object
       options[:disabled] ||= @edit_disabled
       @edit_cell_count += 1 unless options[:disabled]
-      build_cell(ERB::Util.html_escape(header), @template.instance_eval{ inline_edit_field(object, field, options, &block) }, options)
+      wrapper = -> { @form_helper ? block.call(@form_helper) : block.call }
+      build_cell(ERB::Util.html_escape(header), @template.instance_eval { inline_edit_field(object, field, options, &wrapper) }, options)
     end
 
     # Generates an editable checkbox cell for +field+, of which the current
@@ -249,17 +278,17 @@ module ShowTableHelper
     default_text = h(options.delete(:content) || object.send(attribute))
     return default_text if options.delete(:disabled)
     if object.errors.include?(attribute)
-      default_text = "<span class=\"show_table_error\">#{default_text}</span>"
+      default_text = "<div class=\"show_table_error\">#{default_text}</div>"
     end
 
     html = <<-HTML.html_safe
-      <span class="inline_edit_field_default_text">
+      <div class="inline_edit_field_default_text">
       #{default_text}
-      </span>
-      <span class="inline_edit_field_input" style="display:none">
+      </div>
+      <div class="inline_edit_field_input" style="display:none">
     HTML
     html += capture(&block) +
-            "</span>".html_safe
+            "</div>".html_safe
     return html
   end
 
@@ -292,76 +321,24 @@ module ShowTableHelper
   #  Whether or not to make the table's fields editable by the user. If the
   #  table is editable (+edit_condition+ is specified as true), an edit toggle
   #  will be added next to the header/title to switch into edition mode.
-  def show_table(object, options = {})
-    header = options.delete(:header) || "Info"
-    url    = options.delete :url
-    method = options.delete :method
+  def show_table(object, options = {}, &block)
 
-    tb = TableBuilder.new(object, self, options)
-    yield(tb)
-
-    if tb.editable? && object.is_a?(ApplicationRecord)
-      unless url
-        url = {:controller  => params[:controller]}
-        if object.new_record?
-          url[:action] = :create
-        else
-          url[:action] = :update
-          url[:id]     = object.id
-        end
-        url = url_for(url)
-      end
-
-      unless method
-        method = object.new_record? ? "post" : "put"
-      end
-    end
-
-
-    html = []
-    html << "<div class=\"inline_edit_field_group\">"
-    if tb.editable?
-      html << form_tag(url, :method => method)
-    end
-    html << "<fieldset>"
-    html << "<legend>#{header}"
-    if tb.editable?
-      html << "<span class=\"show_table_edit\">(#{link_to "Edit", "#", :class => "show_table_edit_link inline_edit_field_link"})</span>"
-    end
-    html << "</legend>"
-    html << "<table class=\"show_table\">"
-    col_count = 0
-    tb.cells.each do |cell|
-      if col_count == 0
-        html << "<tr>"
-      end
-      html      << cell[0] # content
-      col_count += cell[1] # show_width of cell (1, 2, 3 etc)
-      if col_count >= tb.width
-        html << "</tr>"
-        col_count = 0
-      end
-    end
-
-    html << "</table>"
-
-    if tb.editable?
-      html << "<div class=\"inline_edit_field_input\" style=\"display:none\">"
-      html << "<BR>"
+    url = options[:url].presence
+    if url.blank?
+      url = { :controller  => params[:controller] }
       if object.new_record?
-        html << submit_button("Create")
+        url[:action] = :create
       else
-        html << submit_button("Update")
+        url[:action] = :update
+        url[:id]     = object.id
       end
-      html << "</div>"
-      html << "</fieldset>"
-      html << "</form>"
-    else
-      html << "</fieldset>"
+      url = url_for(url)
     end
 
-    html << "</div>"
-    html.join("\n").html_safe
+    tb = TableBuilder.new(object, self, options.merge(:block => block, :url => url))
+
+    render :partial => 'shared/show_table', :locals => { :tb => tb }
   end
+
 end
 

--- a/BrainPortal/app/models/bourreau.rb
+++ b/BrainPortal/app/models/bourreau.rb
@@ -488,6 +488,7 @@ class Bourreau < RemoteResource
         if newstatus == 'Duplicated'
           new_bourreau_id = command.new_bourreau_id || task.bourreau_id || myself.id
           new_task = task.class.new(task.attributes) # a kind of DUP!
+          new_task.id                          = nil
           new_task.bourreau_id                 = new_bourreau_id
           new_task.cluster_jobid               = nil
           new_task.cluster_workdir             = nil

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -123,7 +123,7 @@
   <% end %>
 
   <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
-    <%= show_table(@provider, :header => "SSH parameters for remote Data Providers") do |t| %>
+    <%= show_table(@provider, :header => "SSH parameters for remote Data Providers", :edit_condition => true) do |t| %>
       <% t.edit_cell(:remote_host)  do %>
         <%= text_field_tag "data_provider[remote_host]", @provider.remote_host %>
       <% end %>
@@ -139,7 +139,7 @@
       <% end %>
     <% end %>
 
-    <%= show_table(@provider, :header => "Cloud Storage Configuration") do |t| %>
+    <%= show_table(@provider, :header => "Cloud Storage Configuration", :edit_condition => true) do |t| %>
       <% t.edit_cell(:cloud_storage_client_identifier, :header => 'Client Identifier', :show_width => 2)  do %>
         <%= text_field_tag "data_provider[cloud_storage_client_identifier]", @provider.cloud_storage_client_identifier %>
       <% end %>

--- a/BrainPortal/app/views/shared/_show_table.html.erb
+++ b/BrainPortal/app/views/shared/_show_table.html.erb
@@ -1,0 +1,26 @@
+
+<%
+# This partial receives a single local variable,
+# tb, a ShowTableHelper::TableBuilder object
+%>
+
+<div class="inline_edit_field_group">
+
+  <% if tb.editable? %>
+    <%= form_for(tb.object,
+          :url => tb.url,
+          :method => tb.method,
+          :as => tb.as,
+          :html => { :id => "edit_#{tb.as}_#{tb.header}".gsub(/\W+/,"_") },
+        ) do |f| %>
+      <% tb.form_helper = f %>
+      <% tb.invoke_block %>
+      <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => f } %>
+    <% end %>
+  <% else %>
+      <% tb.invoke_block %>
+      <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => nil } %>
+  <% end %>
+
+</div>
+

--- a/BrainPortal/app/views/shared/_show_table_content.html.erb
+++ b/BrainPortal/app/views/shared/_show_table_content.html.erb
@@ -1,0 +1,50 @@
+
+<fieldset>
+
+  <legend><%= tb.header %>
+    <% if tb.editable? %>
+      <span class="show_table_edit">(<%= link_to "Edit", "#", :class => "show_table_edit_link inline_edit_field_link" %>)</span>
+    <% end %>
+  </legend>
+
+  <table class="show_table">
+
+  <% col_count = 0 %>
+  <% tb.cells.each do |cell| %>
+
+    <% if col_count == 0 %>
+      <tr>
+    <% end %>
+
+    <%
+       # The content
+    %>
+    <%= cell[0] %>
+
+    <%
+      # show_width of cell (1, 2, 3 etc)
+      col_count += cell[1]
+    %>
+
+    <% if col_count >= tb.width %>
+      </tr>
+      <% col_count = 0 %>
+    <% end %>
+
+  <% end %>
+
+  </table>
+
+  <% if tb.editable? %>
+    <br>
+    <div class="inline_edit_field_input" style="display:none">
+      <% if tb.object.new_record? %>
+        <%= submit_button("Create") %>
+      <% else %>
+        <%= submit_button("Update") %>
+      <% end %>
+    </div>
+  <% end %>
+
+</fieldset>
+

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -46,7 +46,7 @@
 <br>
 <%= error_messages_for @userfile, :header_message => "#{@userfile.name} could not be updated." %>
 <div class="display_inline_block" style="min-width: 50%">
-  <%= show_table(@userfile) do |t| %>
+  <%= show_table(@userfile, :edit_condition => true) do |t| %>
 
     <% t.edit_cell(:name, :disabled => !@userfile.has_owner_access?(current_user)) do %>
       <%= text_field_tag "userfile[name]", @userfile.name %>

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -117,14 +117,14 @@
   <% end %>
 
   <% if @user.signed_license_agreements.present? %>
-    <%= show_table(@user, :as => :user, :header => "License Agreements", :width => 3, :edit_condition => false) do |t| %>
+    <%= show_table(@user, :as => :user, :header => "License Agreements", :width => 3) do |t| %>
       <% @user.signed_license_agreements.each  do |la| %>
         <% t.cell("", :no_header => true) { link_to la, "/show_license/#{la}" } %>
       <% end  %>
     <% end %>
   <% end %>
 
-  <%= show_table(@user, :as => :user, :header => 'Resources', :edit_condition => false) do |t| %>
+  <%= show_table(@user, :as => :user, :header => 'Resources') do |t| %>
 
     <% t.cell("Files") do
          size = Userfile.where(:user_id => @user.id).sum(:size)
@@ -162,7 +162,7 @@
        user_access_profiles = "(None)" if user_access_profiles.blank?
     %>
 
-    <%= show_table(@user, :as => :user, :header => 'Access Profiles') do |t| %>
+    <%= show_table(@user, :as => :user, :header => 'Access Profiles', :edit_condition => true) do |t| %>
       <% t.edit_cell(:access_profile_ids, :show_width => 2, :no_header => true, :content => user_access_profiles ) do %>
 
         <%= render :partial => 'shared/access_profile_checkbox_table',

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -42,17 +42,17 @@
 <%= error_messages_for @user, :header_message => "User could not be updated." %>
 
 <div class="display_inline_block" style="min-width: 50%">
-  <%= show_table(@user, :edit_condition => edit_permission?(@user)) do |t| %>
+  <%= show_table(@user, :as => :user, :edit_condition => edit_permission?(@user)) do |t| %>
 
     <% t.attribute_cell(:login) %>
 
     <%
-      t.edit_cell(:type, :content => @user.type.underscore.titleize, :disabled => !((current_user.has_role?(:site_manager) || current_user.has_role?(:admin_user)) && not_admin_user(@user))) do
-        select_tag "user[type]", options_for_select(roles_for_user(current_user), :selected => @user.type)
+      t.edit_cell(:type, :content => @user.type.underscore.titleize, :disabled => !((current_user.has_role?(:site_manager) || current_user.has_role?(:admin_user)) && not_admin_user(@user))) do |f|
+        f.select :type, options_for_select(roles_for_user(current_user))
       end
     %>
 
-    <% t.edit_cell(:full_name) { text_field_tag "user[full_name]", @user.full_name } %>
+    <% t.edit_cell(:full_name) { |f| f.text_field :full_name } %>
 
     <%
       t.edit_cell(:site_id, :content => link_to_site_if_accessible(@user.site), :disabled => !current_user.has_role?(:admin_user)) do
@@ -60,7 +60,7 @@
       end
     %>
 
-    <% t.edit_cell(:email, :content => mail_to(h(@user.email))) { text_field_tag "user[email]", @user.email } %>
+    <% t.edit_cell(:email, :content => mail_to(h(@user.email))) { |f| f.text_field :email } %>
 
     <%
       t.cell("Last Connected") do
@@ -68,7 +68,7 @@
       end
     %>
 
-    <% t.edit_cell(:city) { text_field_tag "user[city]", @user.city } %>
+    <% t.edit_cell(:city) { |f| f.text_field :city } %>
 
     <%
       t.edit_cell("meta[pref_data_provider_id]", :header => "Default Data Provider", :content => link_to_data_provider_if_accessible(DataProvider.find_by_id(@user.meta["pref_data_provider_id"])) ) do
@@ -78,7 +78,7 @@
       end
     %>
 
-    <% t.edit_cell(:country) { text_field_tag "user[country]", @user.country } %>
+    <% t.edit_cell(:country) { |f| f.text_field :country } %>
 
     <%
       t.edit_cell("meta[pref_bourreau_id]", :header => "Default Execution Server", :content => link_to_bourreau_if_accessible(Bourreau.find_by_id(@user.meta["pref_bourreau_id"])) ) do
@@ -90,8 +90,8 @@
     %>
 
     <%
-      t.edit_cell(:time_zone, :content => (@user.time_zone || "(Unset)") ) do
-        select_tag "user[time_zone]", time_zone_options_for_select(@user.time_zone, /canada/i), :include_blank => true
+      t.edit_cell(:time_zone, :content => (@user.time_zone || "(Unset)") ) do |f|
+        f.select :time_zone, time_zone_options_for_select(@user.time_zone, /canada/i), :include_blank => true
       end
     %>
 
@@ -117,14 +117,14 @@
   <% end %>
 
   <% if @user.signed_license_agreements.present? %>
-    <%= show_table(@user, :header => "License Agreements", :width => 3) do |t| %>
+    <%= show_table(@user, :as => :user, :header => "License Agreements", :width => 3, :edit_condition => false) do |t| %>
       <% @user.signed_license_agreements.each  do |la| %>
         <% t.cell("", :no_header => true) { link_to la, "/show_license/#{la}" } %>
       <% end  %>
     <% end %>
   <% end %>
 
-  <%= show_table(@user, :header => 'Resources') do |t| %>
+  <%= show_table(@user, :as => :user, :header => 'Resources', :edit_condition => false) do |t| %>
 
     <% t.cell("Files") do
          size = Userfile.where(:user_id => @user.id).sum(:size)
@@ -162,7 +162,7 @@
        user_access_profiles = "(None)" if user_access_profiles.blank?
     %>
 
-    <%= show_table(@user, :header => 'Access Profiles') do |t| %>
+    <%= show_table(@user, :as => :user, :header => 'Access Profiles') do |t| %>
       <% t.edit_cell(:access_profile_ids, :show_width => 2, :no_header => true, :content => user_access_profiles ) do %>
 
         <%= render :partial => 'shared/access_profile_checkbox_table',


### PR DESCRIPTION
This will fix #743 

The show_table() helper is backwards compatible, except by default the tables built are not editable; the view programmer must add `:edit_condition => true` when necessary. Which I did, everywhere needed.

The new feature is that when creating a table cell in an editable table, we can receive the FormBuilder handle in argument. This also allow us to use all those FormBuilder helpers too, including coloring for record errors. See issue #743 for an example, and also see the User's `show` page which I adapted and can be used for testing the code.