### PR TITLE
Two fixes: IP lookup and session cleanup

### DIFF
--- a/BrainPortal/app/controllers/application_controller.rb
+++ b/BrainPortal/app/controllers/application_controller.rb
@@ -160,6 +160,7 @@ class ApplicationController < ActionController::Base
 
     # Compute the host and IP from the request (when not logged in)
     from_ip   ||= reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR']
+    from_ip     = Regexp.last_match[1] if ((from_ip || "") =~ /(\d+\.\d+\.\d+\.\d+)/) # sometimes we get several IPs with commas
     from_host ||= hostname_from_ip(from_ip)
 
     # Pretty user agent string

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -203,6 +203,7 @@ class SessionsController < ApplicationController
     # Record the best guess for browser's remote host name
     reqenv      = request.env
     from_ip     = reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR']
+    from_ip     = Regexp.last_match[1] if ((from_ip || "") =~ /(\d+\.\d+\.\d+\.\d+)/) # sometimes we get several IPs with commas
     from_host   = hostname_from_ip(from_ip)
     from_ip   ||= '0.0.0.0'
     from_host ||= 'unknown'

--- a/BrainPortal/app/models/large_session_info.rb
+++ b/BrainPortal/app/models/large_session_info.rb
@@ -29,7 +29,7 @@ class LargeSessionInfo < ApplicationRecord
 
   serialize :data
 
-  belongs_to :user
+  belongs_to :user # we no longer allow them to be nil
 
 end
 

--- a/BrainPortal/app/views/portal/welcome.html.erb
+++ b/BrainPortal/app/views/portal/welcome.html.erb
@@ -98,7 +98,8 @@
              [ "One month ago",     1.month.seconds.to_i   ],
              [ "One week ago",      1.week.seconds.to_i    ],
              [ "One day ago",       1.day.seconds.to_i     ],
-             [ "One hour ago",      1.hour.seconds.to_i    ]
+             [ "One hour ago",      1.hour.seconds.to_i    ],
+             [ "Now! (Including yours!)", 1.seconds.to_i   ],
            ]) %>
         <%= submit_tag "Clear", :confirm => "Are you sure you want to clear the sessions?" %>
       <% end %>


### PR DESCRIPTION
IP lookup had a bug when several source IP addresses where provided in the HTTP headers.

Session objects can be cleaned even up to right now; the session code was adjusted to re-create a session object that has disappeared for properly logged-in users.