### PR TITLE
Table helpers "Use new show table helper's form builder in all show pages" #754

### DIFF
--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -42,19 +42,19 @@
 
   <%= show_table(@access_profile, :edit_condition => check_role(:admin_user)) do |t| %>
 
-    <% t.edit_cell(:name, :content => access_profile_label(@access_profile)) do %>
-      <%= text_field_tag "access_profile[name]", @access_profile.name, :class => "cb_colorpick_bg_target" %>
+    <% t.edit_cell(:name, :content => access_profile_label(@access_profile)) do |f| %>
+      <%= f.text_field :name, :class => "cb_colorpick_bg_target" %>
     <% end %>
 
-    <% t.edit_cell(:color) do %>
-      <%= text_field_tag "access_profile[color]", @access_profile.color, :class => "cb_colorpick_val_target" %><br>
+    <% t.edit_cell(:color) do |f| %>
+      <%= f.text_field :color, :class => "cb_colorpick_val_target" %><br>
       <span class="field_explanation">Use a CSS-compliant <strong>pale</strong> color:<br>
       e.g. <em>#ff0</em> or <em>yellow</em> etc.</span><br>
       <%= render :partial => 'shared/color_picker', :locals => { :step => 30, :greys => false, :dark => false } %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => full_description(@access_profile.description), :show_width => 2 ) do %>
-      <%= text_area_tag "access_profile[description]", @access_profile.description, :rows => 6, :cols => 60 %><br/>
+    <% t.edit_cell(:description, :content => full_description(@access_profile.description), :show_width => 2 ) do |f| %>
+      <%= f.text_area :description, :rows => 6, :cols => 60 %><br/>
       <span class="field_explanation">These are your private notes about this profile.</span>
     <% end %>
 

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -160,7 +160,7 @@
   <% end %>
 
   <% if is_portal %>
-    <%= show_table(@bourreau, :header => "Mail configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+    <%= show_table(@bourreau, :as => :bourreau, :header => "Mail configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
       <% t.edit_cell(:support_email, :header => "Support email address") do |f| %>
         <%= f.text_field :support_email, :size => 30 %><br/>
         <div class="field_explanation">If set, the portal will show a <em>mailto:</em> link for letting users contact support.</div>
@@ -180,7 +180,7 @@
 
     <% if is_bourreau %>
 
-      <%= show_table(@bourreau, :header => "Connection Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+      <%= show_table(@bourreau, :as => :bourreau, :header => "Connection Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
         <% t.edit_cell(:ssh_control_host, :header => "SSH Hostname") do |f| %>
           <%= f.text_field :ssh_control_host %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -67,16 +67,16 @@
 
     <% t.attribute_cell(:class) %>
 
-    <% t.edit_cell(:online, :header => "Status", :content => (@bourreau.online ? "Online" : "Offline")) do %>
-      <%= select_tag "bourreau[online]", options_for_select([["Online", true], ["Offline", false]], :selected => @bourreau.online) %>
+    <% t.edit_cell(:online, :header => "Status", :content => (@bourreau.online ? "Online" : "Offline")) do |f| %>
+      <%=  f.select  :online, [["Online", true], ["Offline", false]] %>
     <% end %>
 
     <% t.edit_cell(:user_id, :header => "Owner", :content => link_to_user_with_tooltip(@bourreau.user), :disabled => ! current_user.has_role?(:admin_user)) do %>
       <%= user_select("bourreau[user_id]", { :selector => @bourreau } ) %>
     <% end %>
 
-    <% t.edit_cell(:time_zone, :content => (@bourreau.time_zone || "(Unset)") ) do %>
-      <%= select_tag "bourreau[time_zone]", time_zone_options_for_select(@bourreau.time_zone, /canada/i), :include_blank => true %>
+    <% t.edit_cell(:time_zone, :content => (@bourreau.time_zone || "(Unset)") ) do |f| %>
+      <%=  f.select :time_zone, time_zone_options_for_select(@bourreau.time_zone, /canada/i), :include_blank => true %>
     <% end %>
 
     <% t.edit_cell(:group_id, :header => "Project", :content => link_to_group_if_accessible(@bourreau.group)) do %>
@@ -89,7 +89,7 @@
 
     <% licenses = @bourreau.license_agreements.count == 0 ? "(None)": @bourreau.license_agreements.join("\n") %>
     <% t.edit_cell(:license_agreements, :content => licenses) do |f| %>
-      <%= f.text_area :license_agreements, :value => licenses, :rows => 5, :cols => 40 %><br>
+      <%= f.text_area :license_agreements, :value => @bourreau.license_agreements.join("\n"), :rows => 5, :cols => 40 %><br>
       <div class="field_explanation">Enter one agreement name per line. Note that only alphanumeric characters, underscores (_) and dashes (-) are accepted.</div>
     <% end %>
 
@@ -227,8 +227,8 @@
         <%= f.text_field :spaced_dp_ignore_patterns, :size => 60 %><br/>
         <div class="field_explanation">Separate several patterns with spaces; each pattern can contain single '*'s, but no '/'s or special characters.</div>
       <% end %>
-      <% t.edit_cell(:cache_trust_expire, :header => "Cache Expiration Timeout (in seconds)", :content => (@bourreau.cache_trust_expire == 0 ? "Never" : @bourreau.cache_trust_expire)) do %>
-        <%= select_tag("bourreau[cache_trust_expire]", options_for_select([
+      <% t.edit_cell(:cache_trust_expire, :header => "Cache Expiration Timeout (in seconds)", :content => (@bourreau.cache_trust_expire == 0 ? "Never" : @bourreau.cache_trust_expire)) do |f| %>
+        <%= f.select :cache_trust_expire, [
                 [ "Never",        "0"                  ],
                 [ "Six hours",     6.hours.to_i.to_s   ],
                 [ "Twelve hours", 12.hours.to_i.to_s   ],
@@ -240,7 +240,7 @@
                 [ "Two months",    2.months.to_i.to_s  ],
                 [ "Three months",  3.months.to_i.to_s  ],
                 [ "Six months",    6.months.to_i.to_s  ]
-            ], :selected => @bourreau.cache_trust_expire ))
+            ]
         %></br>
         <div class="field_explanation">This means that in the execution server's cache, files that have been recorded
         as 'InSync' but were last accessed more than this amount of time will be considered untrustworthy
@@ -254,8 +254,8 @@
     <% if is_bourreau %>
       <%= show_table(@bourreau, :header => "Cluster Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
-        <% t.edit_cell(:cms_class, :header => "Type of cluster") do %>
-          <%= select_tag "bourreau[cms_class]", options_for_select([
+        <% t.edit_cell(:cms_class, :header => "Type of cluster") do |f| %>
+          <%= f.select :cms_class, [
                   [ "(Unconfigured)",  "" ],
                   [ "Sun GridEngine",  "ScirSge" ],
                   [ "PBS",             "ScirPbs" ],
@@ -265,7 +265,7 @@
                   [ "Amazon EC2",      "ScirAmazon" ],
                   [ "SLURM",           "ScirSlurm" ],
                   [ "UNIX processes",  "ScirUnix" ]
-              ], :selected => @bourreau.cms_class)
+              ]
           %>
         <% end %>
 
@@ -274,8 +274,8 @@
           <div class="field_explanation">Optional.</div>
         <% end %>
 
-        <% t.edit_cell 'meta[task_limit_total]', :header => "Maximum total number of active tasks", :content => (@bourreau.meta["task_limit_total"].blank? ? "Unlimited" : @bourreau.meta["task_limit_total"]) do %>
-          <%= select_tag 'meta[task_limit_total]',
+        <% t.edit_cell 'meta[task_limit_total]', :header => "Maximum total number of active tasks", :content => (@bourreau.meta["task_limit_total"].blank? ? "Unlimited" : @bourreau.meta["task_limit_total"]) do |f| %>
+          <%=  select_tag  'meta[task_limit_total]',
               options_for_select( [ [ "Unlimited", "" ] ] + %w( 1 2 3 4 5 8 10 15 20 25 30 35 40 45 50 60 75 100 200 500 1000 ) ,
                                   @bourreau.meta[:task_limit_total] )
           %>
@@ -369,8 +369,8 @@
         <% end %>
       <% end %>
       <%= show_table(@bourreau, :header => "Worker Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
-        <% t.edit_cell :workers_instances, :header => "Number of workers" do %>
-          <%= select_tag "bourreau[workers_instances]", options_for_select([
+        <% t.edit_cell :workers_instances, :header => "Number of workers" do |f| %>
+          <%=  f.select :workers_instances, [
                   [ "None (for debug)",  0 ],
                   [ "1",                 1 ],
                   [ "2",                 2 ],
@@ -379,11 +379,11 @@
                   [ "5",                 5 ],
                   [ "10",                10 ],
                   [ "20",                20 ]
-              ], :selected => @bourreau.workers_instances)
+              ]
           %>
         <% end %>
-        <% t.edit_cell :workers_chk_time, :header => "Check interval" do %>
-          <%= select_tag "bourreau[workers_chk_time]", options_for_select([
+        <% t.edit_cell :workers_chk_time, :header => "Check interval" do |f| %>
+          <%=  f.select :workers_chk_time, [
                   [ "5 seconds",               5 ],
                   [ "10 seconds",              10 ],
                   [ "30 seconds",              30 ],
@@ -392,11 +392,11 @@
                   [ "5 minutes",               300 ],
                   [ "15 minutes",              900 ],
                   [ "1 hour",                  3600 ]
-              ], :selected => @bourreau.workers_chk_time)
+              ]
           %>
         <% end %>
-        <% t.edit_cell :workers_log_to, :header => "Log destination" do %>
-          <%= select_tag "bourreau[workers_log_to]", options_for_select([
+        <% t.edit_cell :workers_log_to, :header => "Log destination" do |f| %>
+          <%= f.select :workers_log_to, [
                   [ "Combined file (recommended)", "combined" ],
                   [ "Separate files",              "separate" ],
                   [ "RAILS log",                   "bourreau" ],
@@ -404,14 +404,14 @@
                   [ "RAILS stderr",                "stderr" ],
                   [ "RAILS stdout and stderr",     "stdout|stderr" ],
                   [ "No logging",                  "none" ]
-              ], :selected => @bourreau.workers_log_to)
+              ]
           %>
         <% end %>
-        <% t.edit_cell :workers_verbose, :header => "Log verbosity", :content => ['(Not configured)', 'Normal', 'Debug info' ][@bourreau.workers_verbose || 0]  do %>
-          <%= select_tag "bourreau[workers_verbose]", options_for_select([
+        <% t.edit_cell :workers_verbose, :header => "Log verbosity", :content => ['(Not configured)', 'Normal', 'Debug info' ][@bourreau.workers_verbose || 0]  do |f| %>
+          <%=  f.select :workers_verbose, [
                   [ "Normal",      1 ],
                   [ "Debug info",  2 ]
-              ], :selected => @bourreau.workers_verbose)
+              ]
           %>
         <% end %>
       <% end %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -51,17 +51,17 @@
 <div class="display_inline_block" style="min-width: 50%">
   <%= show_table(@bourreau, :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
-    <% t.edit_cell(:name) do %>
-      <%= text_field_tag "bourreau[name]", @bourreau.name %><br>
-      <div class="field_explanation">
+    <% t.edit_cell(:name) do |f| %>
+      <%= f.text_field :name %><br>
+      <div class="field_explanation"  >
         Important note: this name must also be changed accordingly in the config file
         <em><%= is_bourreau ? "Bourreau/config/initializers/config_bourreau.rb" : "BrainPortal/config/initializers/config_portal.rb" %></em>
         for this server to restart properly later on.
       </div>
     <% end %>
 
-    <% t.edit_cell(:description, :content =>  full_description(@bourreau.description)) do %>
-      <%= text_area_tag "bourreau[description]", @bourreau.description, :rows => 10, :cols => 40 %><br>
+    <% t.edit_cell(:description, :content =>  full_description(@bourreau.description)) do |f| %>
+      <%= f.text_area :description, :rows => 10, :cols => 40 %><br>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>
 
@@ -88,16 +88,16 @@
     <% t.cell("Site") { link_to_site_if_accessible(@bourreau.site_affiliation) } %>
 
     <% licenses = @bourreau.license_agreements.count == 0 ? "(None)": @bourreau.license_agreements.join("\n") %>
-    <% t.edit_cell(:license_agreements, :content => licenses) do %>
-      <%= text_area_tag "bourreau[license_agreements]", @bourreau.license_agreements.join("\n"), :rows => 5, :cols => 40 %><br>
+    <% t.edit_cell(:license_agreements, :content => licenses) do |f| %>
+      <%= f.text_area :license_agreements, :value => licenses, :rows => 5, :cols => 40 %><br>
       <div class="field_explanation">Enter one agreement name per line. Note that only alphanumeric characters, underscores (_) and dashes (-) are accepted.</div>
     <% end %>
 
     <% if is_bourreau %>
       <% external_status_page_url = @bourreau.external_status_page_url.nil? ?
                                       "(None)" : link_to(@bourreau.external_status_page_url, @bourreau.external_status_page_url, :class => "action_link", :target => "_blank") %>
-      <% t.edit_cell(:external_status_page_url, :header => "External status page URL", :content => external_status_page_url ) do %>
-        <%= text_field_tag "bourreau[external_status_page_url]", @bourreau.external_status_page_url, :size => 60 %><br>
+      <% t.edit_cell(:external_status_page_url, :header => "External status page URL", :content => external_status_page_url ) do |f| %>
+        <%= f.text_field :external_status_page_url, :size => 60 %><br>
         <div class="field_explanation">Link to external status page for the server.</div>
       <% end %>
     <% end %>
@@ -107,30 +107,30 @@
       <% t.edit_cell :site_url_prefix,
                      :header => "Base Portal URL",
                      :content => (@bourreau.site_url_prefix.blank? ? "(None)" : @bourreau.site_url_prefix),
-                     :show_width => 1 do %>
-        <%= text_field_tag "bourreau[site_url_prefix]", @bourreau.site_url_prefix, :size => 40 %><br/>
+                     :show_width => 1 do |f| %>
+        <%= f.text_field :site_url_prefix, :size => 40 %><br/>
         <div class="field_explanation">
           Required to direct new users to the portal, this should be filled in with the <em>base</em> URL of the portal
         </div>
       <% end %>
 
-      <% t.edit_cell(:help_url, :header => "User Manual URL", :show_width => 1) do %>
-        <%= text_field_tag "bourreau[help_url]", @bourreau.help_url, :size => 40 %><br/>
+      <% t.edit_cell(:help_url, :header => "User Manual URL", :show_width => 1) do |f| %>
+        <%= f.text_field :help_url, :size => 40 %><br/>
         <div class="field_explanation">If set, the portal will show a link called 'User Manual' in the account bar at the top.</div>
       <% end %>
 
       <% t.edit_cell :small_logo,
                      :header => "Small logo",
                      :content => (@bourreau.small_logo.blank? ? "(None)" : @bourreau.small_logo),
-                     :show_width => 1 do %>
-        <%= text_field_tag "bourreau[small_logo]", @bourreau.small_logo, :size => 40 %><br/>
+                     :show_width => 1 do |f| %>
+        <%= f.text_field :small_logo, :size => 40 %><br/>
       <% end %>
 
       <% t.edit_cell :large_logo,
                      :header => "Large logo",
                      :content => (@bourreau.large_logo.blank? ? "(None)" : @bourreau.large_logo),
-                     :show_width => 1 do %>
-        <%= text_field_tag "bourreau[large_logo]", @bourreau.large_logo, :size => 40 %><br/>
+                     :show_width => 1 do |f| %>
+        <%= f.text_field :large_logo, :size => 40 %><br/>
       <% end %>
 
       <% t.edit_cell 'meta[large_upload_url]',
@@ -161,12 +161,12 @@
 
   <% if is_portal %>
     <%= show_table(@bourreau, :header => "Mail configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
-      <% t.edit_cell(:support_email, :header => "Support email address") do %>
-        <%= text_field_tag "bourreau[support_email]", @bourreau.support_email, :size => 30 %><br/>
+      <% t.edit_cell(:support_email, :header => "Support email address") do |f| %>
+        <%= f.text_field :support_email, :size => 30 %><br/>
         <div class="field_explanation">If set, the portal will show a <em>mailto:</em> link for letting users contact support.</div>
       <% end %>
-      <% t.edit_cell(:system_from_email, :header => "System 'From' reply address") do %>
-        <%= text_field_tag "bourreau[system_from_email]", @bourreau.system_from_email, :size => 30 %><br/>
+      <% t.edit_cell(:system_from_email, :header => "System 'From' reply address") do |f| %>
+        <%= f.text_field :system_from_email, :size => 30 %><br/>
         <div class="field_explanation">If set, messages sent automatically by this system will contain this return address.</div>
       <% end %>
       <% t.edit_cell("meta[error_message_mailing_list]", :header => "Error notifications sent to members of project", :content => link_to_group_if_accessible(@bourreau.meta[:error_message_mailing_list])) do %>
@@ -182,32 +182,32 @@
 
       <%= show_table(@bourreau, :header => "Connection Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
-        <% t.edit_cell(:ssh_control_host, :header => "SSH Hostname") do %>
-          <%= text_field_tag "bourreau[ssh_control_host]", @bourreau.ssh_control_host %>
+        <% t.edit_cell(:ssh_control_host, :header => "SSH Hostname") do |f| %>
+          <%= f.text_field :ssh_control_host %>
         <% end %>
 
-        <% t.edit_cell(:ssh_control_rails_dir, :header => "Rails Server Directory") do %>
-          <%= text_field_tag "bourreau[ssh_control_rails_dir]", @bourreau.ssh_control_rails_dir, :size => 60 %>
+        <% t.edit_cell(:ssh_control_rails_dir, :header => "Rails Server Directory") do |f| %>
+          <%= f.text_field :ssh_control_rails_dir, :size => 60 %>
         <% end %>
 
-        <% t.edit_cell(:ssh_control_user, :header => "SSH User") do %>
-          <%= text_field_tag "bourreau[ssh_control_user]", @bourreau.ssh_control_user %>
+        <% t.edit_cell(:ssh_control_user, :header => "SSH User") do |f| %>
+          <%= f.text_field :ssh_control_user %>
         <% end %>
 
-        <% t.edit_cell(:tunnel_mysql_port, :header => "Database Server Remote Tunnel Port") do %>
-          <%= text_field_tag "bourreau[tunnel_mysql_port]", @bourreau.tunnel_mysql_port, :size => 6 %>
+        <% t.edit_cell(:tunnel_mysql_port, :header => "Database Server Remote Tunnel Port") do |f| %>
+          <%= f.text_field :tunnel_mysql_port, :size => 6 %>
         <% end %>
 
-        <% t.edit_cell(:ssh_control_port, :header => "SSH Port") do %>
-          <%= text_field_tag "bourreau[ssh_control_port]", @bourreau.ssh_control_port, :size => 6 %>
+        <% t.edit_cell(:ssh_control_port, :header => "SSH Port") do |f| %>
+          <%= f.text_field :ssh_control_port, :size => 6 %>
         <% end %>
 
-        <% t.edit_cell(:tunnel_actres_port, :header => "ActiveResource Remote Tunnel Port") do %>
-          <%= text_field_tag "bourreau[tunnel_actres_port]", @bourreau.tunnel_actres_port, :size => 6 %>
+        <% t.edit_cell(:tunnel_actres_port, :header => "ActiveResource Remote Tunnel Port") do |f| %>
+          <%= f.text_field :tunnel_actres_port, :size => 6 %>
         <% end %>
 
-        <% t.edit_cell(:proxied_host, :header => "Second-level Hostname") do %>
-          <%= text_field_tag "bourreau[proxied_host]", @bourreau.proxied_host %>
+        <% t.edit_cell(:proxied_host, :header => "Second-level Hostname") do |f| %>
+          <%= f.text_field :proxied_host %>
         <% end %>
 
       <% end %>
@@ -217,14 +217,14 @@
 
 
     <%= show_table(@bourreau, :header => "Cache Management Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
-      <% t.edit_cell(:dp_cache_dir, :header => "Path to Data Provider caches") do %>
-        <%= text_field_tag "bourreau[dp_cache_dir]", @bourreau.dp_cache_dir, :size => 60 %><br/>
+      <% t.edit_cell(:dp_cache_dir, :header => "Path to Data Provider caches") do |f| %>
+        <%= f.text_field :dp_cache_dir, :size => 60 %><br/>
         <div class="field_explanation">Warning! Changing this field will result in resetting the synchronization
         status of all files from all Data Providers! Also, the Rails app will have to
         be restarted, and all files in that directory will be erased!</div>
       <% end %>
-      <% t.edit_cell(:spaced_dp_ignore_patterns, :header => "Patterns for filenames to ignore", :content => @bourreau.spaced_dp_ignore_patterns) do %>
-        <%= text_field_tag "bourreau[spaced_dp_ignore_patterns]", @bourreau.spaced_dp_ignore_patterns, :size => 60 %><br/>
+      <% t.edit_cell(:spaced_dp_ignore_patterns, :header => "Patterns for filenames to ignore", :content => @bourreau.spaced_dp_ignore_patterns) do |f| %>
+        <%= f.text_field :spaced_dp_ignore_patterns, :size => 60 %><br/>
         <div class="field_explanation">Separate several patterns with spaces; each pattern can contain single '*'s, but no '/'s or special characters.</div>
       <% end %>
       <% t.edit_cell(:cache_trust_expire, :header => "Cache Expiration Timeout (in seconds)", :content => (@bourreau.cache_trust_expire == 0 ? "Never" : @bourreau.cache_trust_expire)) do %>
@@ -269,8 +269,8 @@
           %>
         <% end %>
 
-        <% t.edit_cell(:cms_default_queue, :header => "Default queue name") do %>
-          <%= text_field_tag "bourreau[cms_default_queue]", @bourreau.cms_default_queue %><br/>
+        <% t.edit_cell(:cms_default_queue, :header => "Default queue name") do |f| %>
+          <%= f.text_field :cms_default_queue %><br/>
           <div class="field_explanation">Optional.</div>
         <% end %>
 
@@ -281,8 +281,8 @@
           %>
         <% end %>
 
-        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra 'qsub' options") do %>
-          <%= text_field_tag "bourreau[cms_extra_qsub_args]", @bourreau.cms_extra_qsub_args, :size => 60 %><br/>
+        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra 'qsub' options") do |f| %>
+          <%= f.text_field :cms_extra_qsub_args, :size => 60 %><br/>
           <div class="field_explanation">Optional. Careful, this is inserted as-is in the command-line for submitting jobs.</div>
         <% end %>
 
@@ -339,8 +339,8 @@
           <%= tool_config_edit_link || tool_config_create_link %>
         <% end %>
 
-        <% t.edit_cell(:cms_shared_dir, :header => "Path to shared work directory", :show_width => 2) do %>
-          <%= text_field_tag "bourreau[cms_shared_dir]", @bourreau.cms_shared_dir, :size => 60 %><br/>
+        <% t.edit_cell(:cms_shared_dir, :header => "Path to shared work directory", :show_width => 2) do |f| %>
+          <%= f.text_field :cms_shared_dir, :size => 60 %><br/>
           <div class="field_explanation">Mandatory. This directory must be visible and writable from all nodes.
                  This is were the work subdirectories for all tasks will be created.</div>
         <% end %>
@@ -418,13 +418,13 @@
       <!-- Container -->
       <%= show_table(@bourreau, :header => "Container Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
         <!-- Docker -->
-        <% t.edit_cell :docker_executable_name, :header => "Docker executable" do %>
-          <%= text_field_tag "bourreau[docker_executable_name]", @bourreau.docker_executable_name, :size => 60 %><br/>
+        <% t.edit_cell :docker_executable_name, :header => "Docker executable" do |f| %>
+          <%= f.text_field :docker_executable_name, :size => 60 %><br/>
            <div class="field_explanation">Name of the Docker executable available on the machines where tasks will run. It should always be set if Docker is present.</div>
         <% end %>
         <!-- Singularity -->
-        <% t.edit_cell :singularity_executable_name, :header => "Singularity executable" do %>
-          <%= text_field_tag "bourreau[singularity_executable_name]", @bourreau.singularity_executable_name, :size => 60 %><br/>
+        <% t.edit_cell :singularity_executable_name, :header => "Singularity executable" do |f| %>
+          <%= f.text_field :singularity_executable_name, :size => 60 %><br/>
            <div class="field_explanation">Name of the Singularity executable available on the machines where tasks will run. It should always be set if Singularity is present.</div>
         <% end %>
       <% end %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -49,7 +49,7 @@
 <%= error_messages_for @bourreau, :header_message => "Server could not be updated." %>
 
 <div class="display_inline_block" style="min-width: 50%">
-  <%= show_table(@bourreau, :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+  <%= show_table(@bourreau, :as => :bourreau, :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
     <% t.edit_cell(:name) do |f| %>
       <%= f.text_field :name %><br>
@@ -216,7 +216,7 @@
 
 
 
-    <%= show_table(@bourreau, :header => "Cache Management Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+    <%= show_table(@bourreau, :as => :bourreau, :header => "Cache Management Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
       <% t.edit_cell(:dp_cache_dir, :header => "Path to Data Provider caches") do |f| %>
         <%= f.text_field :dp_cache_dir, :size => 60 %><br/>
         <div class="field_explanation">Warning! Changing this field will result in resetting the synchronization
@@ -252,7 +252,7 @@
 
 
     <% if is_bourreau %>
-      <%= show_table(@bourreau, :header => "Cluster Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+      <%= show_table(@bourreau, :as => :bourreau, :header => "Cluster Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
 
         <% t.edit_cell(:cms_class, :header => "Type of cluster") do |f| %>
           <%= f.select :cms_class, [
@@ -368,7 +368,7 @@
           <% end %>
         <% end %>
       <% end %>
-      <%= show_table(@bourreau, :header => "Worker Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+      <%= show_table(@bourreau, :as => :bourreau, :header => "Worker Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
         <% t.edit_cell :workers_instances, :header => "Number of workers" do |f| %>
           <%=  f.select :workers_instances, [
                   [ "None (for debug)",  0 ],
@@ -416,7 +416,7 @@
         <% end %>
       <% end %>
       <!-- Container -->
-      <%= show_table(@bourreau, :header => "Container Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+      <%= show_table(@bourreau, :as => :bourreau, :header => "Container Configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
         <!-- Docker -->
         <% t.edit_cell :docker_executable_name, :header => "Docker executable" do |f| %>
           <%= f.text_field :docker_executable_name, :size => 60 %><br/>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -139,7 +139,7 @@
       <% end %>
     <% end %>
 
-    <%= show_table(@provider, :header => "Cloud Storage Configuration", :edit_condition => true) do |t| %>
+    <%= show_table(@provider, :as => :data_provider, :header => "Cloud Storage Configuration", :edit_condition => true) do |t| %>
       <% t.edit_cell(:cloud_storage_client_identifier, :header => 'Client Identifier', :show_width => 2)  do |f| %>
         <%= f.text_field :cloud_storage_client_identifier %>
       <% end %>
@@ -151,7 +151,7 @@
   <% end %>
 
 
-  <%= show_table(@provider, :header => "Other Properties", :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
+  <%= show_table(@provider, :as => :data_provider, :header => "Other Properties", :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
 
     <% t.boolean_edit_cell("meta[no_uploads]", @provider.meta["no_uploads"],  "on", "", :header => "Cannot be used for uploading files in the file manager") %>
 
@@ -180,7 +180,7 @@
 
   <% if other_dps.size > 0 %>
 
-    <%= show_table(@provider, :width => 5, :header => 'Files can be copied or moved to these other Data Providers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
+    <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'Files can be copied or moved to these other Data Providers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
       <% if dps_by_category[:official] %>
         <% t.row(:class => 'subheader') { "<strong>Official Storage</strong>".html_safe } %>
         <% dps_by_category[:official].sort_by(&:name).each do |dp| %>
@@ -206,7 +206,7 @@
 
   <% if other_rrs.size > 0 %>
 
-    <%= show_table(@provider, :width => 5, :header => 'File contents can be accessed by these Servers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
+    <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'File contents can be accessed by these Servers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
       <% if rrs_by_category[:portal] %>
         <% t.row(:class => 'subheader') { "<strong>Portals<strong>".html_safe } %>
         <% rrs_by_category[:portal].sort_by(&:name).each do |rr| %>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -78,7 +78,7 @@
       <%= user_select("data_provider[user_id]", { :selector => @provider } ) %>
     <% end %>
 
-    <% t.edit_cell(:online, :content => (@provider.read_only ? "Read Only" : "Read/Write"), :header => "Mode") do |f| %>
+    <% t.edit_cell(:read_only, :content => (@provider.read_only ? "Read Only" : "Read/Write"), :header => "Mode") do |f| %>
       <%= f.select :read_only, [["Read/Write", false], ["Read Only", true]] %>
     <% end %>
 
@@ -86,7 +86,7 @@
       <%= group_select("data_provider[group_id]", { :selector => @provider }) %>
     <% end %>
 
-    <% t.edit_cell(:online, :content => (@provider.not_syncable ? "NOT syncable" : "Fully syncable"), :header => "Syncability") do |f| %>
+    <% t.edit_cell(:not_syncable, :content => (@provider.not_syncable ? "NOT syncable" : "Fully syncable"), :header => "Syncability") do |f| %>
       <%= f.select :not_syncable, [["Fully syncable", false], ["NOT syncable", true]] %>
     <% end %>
 
@@ -144,7 +144,7 @@
         <%= f.text_field :cloud_storage_client_identifier %>
       <% end %>
       <% t.edit_cell(:cloud_storage_client_token, :content => '****************', :header => 'Client Token', :show_width => 2) do |f| %>
-        <%= password_field :cloud_storage_client_token, :size => 80 %>
+        <%= f.password_field :cloud_storage_client_token, :size => 80 %>
       <% end %>
     <% end %>
 

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -57,7 +57,7 @@
   <%= show_table(@provider, :as => :data_provider, :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
 
     <% t.edit_cell(:name) do |f| %>
-      <%= f.text_field :name, @provider.name %>
+      <%= f.text_field :name %>
     <% end %>
 
     <% t.edit_cell(:description, :content => full_description(@provider.description)) do  |f| %>
@@ -87,7 +87,7 @@
     <% end %>
 
     <% t.edit_cell(:online, :content => (@provider.not_syncable ? "NOT syncable" : "Fully syncable"), :header => "Syncability") do |f| %>
-      <%= f.select_tag :not_syncable, [["Fully syncable", false], ["NOT syncable", true]] %>
+      <%= f.select :not_syncable, [["Fully syncable", false], ["NOT syncable", true]] %>
     <% end %>
 
     <% t.cell("Site") { link_to_site_if_accessible(@provider.site) } %>
@@ -105,7 +105,7 @@
     <% end %>
 
     <% t.edit_cell(:time_zone, :content => (@provider.time_zone || "(Unset)") ) do |f| %>
-      <%= f.select "data_provider[time_zone]", time_zone_options_for_select(@provider.time_zone, /canada/i), :include_blank => true %>
+      <%= f.select :time_zone, time_zone_options_for_select(@provider.time_zone, /canada/i), :include_blank => true %>
     <% end %>
 
     <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
@@ -116,7 +116,7 @@
 
     <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
       <% t.edit_cell(:remote_dir, :header => "Physical Data Location", :show_width => 2) do |f| %>
-        <%= f.text_fielt :remote_dir, :size => 60 %>
+        <%= f.text_field :remote_dir, :size => 60 %>
       <% end %>
     <% end %>
 
@@ -125,7 +125,7 @@
   <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
     <%= show_table(@provider, :as => :data_provider, :header => "SSH parameters for remote Data Providers", :edit_condition => true) do |t| %>
       <% t.edit_cell(:remote_host)  do |f| %>
-        <%= f.text_field remote_host %>
+        <%= f.text_field :remote_host %>
       <% end %>
       <% t.edit_cell(:alternate_host, :header => "Alternate hostname(s)")  do |f| %>
         <%= f.text_field :alternate_host, :size => 60 %><br />

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -54,14 +54,14 @@
 
 <div class="display_inline_block" style="min-width: 50%">
 
-  <%= show_table(@provider, :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
+  <%= show_table(@provider, :as => :data_provider, :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
 
-    <% t.edit_cell(:name) do %>
-      <%= text_field_tag "data_provider[name]", @provider.name %>
+    <% t.edit_cell(:name) do |f| %>
+      <%= f.text_field :name, @provider.name %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => full_description(@provider.description)) do %>
-      <%= text_area_tag "data_provider[description]", @provider.description, :rows => 10, :cols => 40 %><br>
+    <% t.edit_cell(:description, :content => full_description(@provider.description)) do  |f| %>
+      <%= f.text_area :description, :rows => 10, :cols => 40 %><br>
     <% end %>
 
     <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
@@ -70,24 +70,24 @@
       <% t.empty_cell %>
     <% end %>
 
-    <% t.edit_cell(:online, :content => (@provider.online ? "Online" : "Offline")) do %>
-      <%= select_tag "data_provider[online]", options_for_select([["Online", true], ["Offline", false]], :selected => @provider.online) %>
+    <% t.edit_cell(:online, :content => (@provider.online ? "Online" : "Offline")) do |f| %>
+      <%= f.select :online, [["Online", true], ["Offline", false]] %>
     <% end %>
 
     <% t.edit_cell(:user_id, :header => "Owner", :content => link_to_user_with_tooltip(@provider.user), :disabled => ! current_user.has_role?(:admin_user) ) do %>
       <%= user_select("data_provider[user_id]", { :selector => @provider } ) %>
     <% end %>
 
-    <% t.edit_cell(:online, :content => (@provider.read_only ? "Read Only" : "Read/Write"), :header => "Mode") do %>
-      <%= select_tag "data_provider[read_only]", options_for_select([["Read/Write", false], ["Read Only", true]], :selected => @provider.read_only) %>
+    <% t.edit_cell(:online, :content => (@provider.read_only ? "Read Only" : "Read/Write"), :header => "Mode") do |f| %>
+      <%= f.select :read_only, [["Read/Write", false], ["Read Only", true]] %>
     <% end %>
 
     <% t.edit_cell(:group_id, :header => "Project", :content => link_to_group_if_accessible(@provider.group) ) do %>
       <%= group_select("data_provider[group_id]", { :selector => @provider }) %>
     <% end %>
 
-    <% t.edit_cell(:online, :content => (@provider.not_syncable ? "NOT syncable" : "Fully syncable"), :header => "Syncability") do %>
-      <%= select_tag "data_provider[not_syncable]", options_for_select([["Fully syncable", false], ["NOT syncable", true]], :selected => @provider.not_syncable) %>
+    <% t.edit_cell(:online, :content => (@provider.not_syncable ? "NOT syncable" : "Fully syncable"), :header => "Syncability") do |f| %>
+      <%= f.select_tag :not_syncable, [["Fully syncable", false], ["NOT syncable", true]] %>
     <% end %>
 
     <% t.cell("Site") { link_to_site_if_accessible(@provider.site) } %>
@@ -97,15 +97,15 @@
     <% else %>
       <% t.empty_cell %>
     <% end %>
-
+    <% joint_licenses = @provider.license_agreements.join("\n") %>
     <% licenses = @provider.license_agreements.count == 0 ? "(None)": @provider.license_agreements.join("\n") %>
-    <% t.edit_cell(:license_agreements, :content => licenses) do %>
-      <%= text_area_tag "data_provider[license_agreements]", @provider.license_agreements.join("\n"), :rows => 5, :cols => 40 %><br>
+    <% t.edit_cell(:license_agreements, :content => licenses) do |f| %>
+      <%= f.text_area :license_agreements, :value => joint_licenses, :content => joint_licenses, :rows => 5, :cols => 40 %><br>
       <div class="field_explanation">Enter one agreement name per line. Note that only alphanumeric characters, underscores (_) and dashes (-) are accepted.</div>
     <% end %>
 
-    <% t.edit_cell(:time_zone, :content => (@provider.time_zone || "(Unset)") ) do %>
-      <%= select_tag "data_provider[time_zone]", time_zone_options_for_select(@provider.time_zone, /canada/i), :include_blank => true %>
+    <% t.edit_cell(:time_zone, :content => (@provider.time_zone || "(Unset)") ) do |f| %>
+      <%= f.select "data_provider[time_zone]", time_zone_options_for_select(@provider.time_zone, /canada/i), :include_blank => true %>
     <% end %>
 
     <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
@@ -115,36 +115,36 @@
     <% end %>
 
     <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
-      <% t.edit_cell(:remote_dir, :header => "Physical Data Location", :show_width => 2) do %>
-        <%= text_field_tag "data_provider[remote_dir]", @provider.remote_dir, :size => 60 %>
+      <% t.edit_cell(:remote_dir, :header => "Physical Data Location", :show_width => 2) do |f| %>
+        <%= f.text_fielt :remote_dir, :size => 60 %>
       <% end %>
     <% end %>
 
   <% end %>
 
   <% if check_role(:admin_user) || @provider.user_id == current_user.id %>
-    <%= show_table(@provider, :header => "SSH parameters for remote Data Providers", :edit_condition => true) do |t| %>
-      <% t.edit_cell(:remote_host)  do %>
-        <%= text_field_tag "data_provider[remote_host]", @provider.remote_host %>
+    <%= show_table(@provider, :as => :data_provider, :header => "SSH parameters for remote Data Providers", :edit_condition => true) do |t| %>
+      <% t.edit_cell(:remote_host)  do |f| %>
+        <%= f.text_field remote_host %>
       <% end %>
-      <% t.edit_cell(:alternate_host, :header => "Alternate hostname(s)")  do %>
-        <%= text_field_tag "data_provider[alternate_host]", @provider.alternate_host, :size => 60 %><br />
+      <% t.edit_cell(:alternate_host, :header => "Alternate hostname(s)")  do |f| %>
+        <%= f.text_field :alternate_host, :size => 60 %><br />
         <div class="field_explanation">Comma-separated list of alternate hostnames; hostname1,hostname2,hostname3,...</div>
       <% end %>
-      <% t.edit_cell(:remote_port) do %>
-        <%= text_field_tag "data_provider[remote_port]", @provider.remote_port, :size => 6 %>
+      <% t.edit_cell(:remote_port) do |f| %>
+        <%= f.text_field :remote_port, :size => 6 %>
       <% end %>
-      <% t.edit_cell(:remote_user) do %>
-        <%= text_field_tag "data_provider[remote_user]", @provider.remote_user %>
+      <% t.edit_cell(:remote_user) do |f| %>
+        <%= f.text_field :remote_user %>
       <% end %>
     <% end %>
 
     <%= show_table(@provider, :header => "Cloud Storage Configuration", :edit_condition => true) do |t| %>
-      <% t.edit_cell(:cloud_storage_client_identifier, :header => 'Client Identifier', :show_width => 2)  do %>
-        <%= text_field_tag "data_provider[cloud_storage_client_identifier]", @provider.cloud_storage_client_identifier %>
+      <% t.edit_cell(:cloud_storage_client_identifier, :header => 'Client Identifier', :show_width => 2)  do |f| %>
+        <%= f.text_field :cloud_storage_client_identifier %>
       <% end %>
-      <% t.edit_cell(:cloud_storage_client_token, :content => '****************', :header => 'Client Token', :show_width => 2) do %>
-        <%= password_field_tag "data_provider[cloud_storage_client_token]", @provider.cloud_storage_client_token, :size => 80 %>
+      <% t.edit_cell(:cloud_storage_client_token, :content => '****************', :header => 'Client Token', :show_width => 2) do |f| %>
+        <%= password_field :cloud_storage_client_token, :size => 80 %>
       <% end %>
     <% end %>
 

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -46,7 +46,7 @@
 
 <div class="display_inline_block" style="min-width: 50%">
 
-  <%= show_table(@group, :edit_condition => @group.can_be_edited_by?(current_user)) do |t| %>
+  <%= show_table(@group, :as => :group, :edit_condition => @group.can_be_edited_by?(current_user)) do |t| %>
 
     <% t.edit_cell(:name) do |f| %>
       <%= f.text_field :name %>
@@ -69,9 +69,8 @@
     <% end %>
 
     <% if current_user.has_role?(:admin_user) && @group.is_a?(WorkGroup) %>
-      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do %>
-        <%= hidden_field_tag "group[invisible]", "0" %>
-        <%= check_box_tag("group[invisible]", "1", @group.invisible?) %>
+      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do |f|%>
+        <%= f.check_box :invisible %>
       <% end %>
     <% end %>
 
@@ -114,7 +113,7 @@
     open_invites   = Invitation.where(sender_id: current_user.id, group_id: @group.id, active: true).to_a
   %>
 
-  <%= show_table(@group, :header => 'Members', :edit_condition => @group.can_be_edited_by?(current_user) && (!current_user.has_role?(:normal_user) || group_members.count > 1 || open_invites.count > 0 )) do |t| %>
+  <%= show_table(@group, :as => :group, :header => 'Members', :edit_condition => @group.can_be_edited_by?(current_user) && (!current_user.has_role?(:normal_user) || group_members.count > 1 || open_invites.count > 0 )) do |t| %>
 
     <% default_text = array_to_table(group_members.sort{ |a,b| a.login.casecmp(b.login)}, :table_class => 'simple bordered float_left', :cols => 20, :min_data => 20, :fill_by_columns => true ) { |u,r,c| link_to_user_with_tooltip(u) } %>
 

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -48,8 +48,8 @@
 
   <%= show_table(@group, :edit_condition => @group.can_be_edited_by?(current_user)) do |t| %>
 
-    <% t.edit_cell(:name) do %>
-      <%= text_field_tag "group[name]", @group.name %>
+    <% t.edit_cell(:name) do |f| %>
+      <%= f.text_field :name %>
     <% end %>
 
     <% t.edit_cell(:creator_id, :content => link_to_user_with_tooltip(@group.creator), :header => "Creator") do %>
@@ -63,8 +63,8 @@
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
 
-    <% t.edit_cell(:description, :content =>  full_description(@group.description)) do %>
-        <%= text_area_tag "group[description]", @group.description, :rows => 4, :cols => 40 %><br>
+    <% t.edit_cell(:description, :content =>  full_description(@group.description)) do |f| %>
+        <%= f.text_area :description, :rows => 4, :cols => 40 %><br>
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
     <% end %>
 

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -69,7 +69,7 @@
     <% end %>
 
     <% if current_user.has_role?(:admin_user) && @group.is_a?(WorkGroup) %>
-      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do |f|%>
+      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do |f| %>
         <%= f.check_box :invisible %>
       <% end %>
     <% end %>

--- a/BrainPortal/app/views/sites/show.html.erb
+++ b/BrainPortal/app/views/sites/show.html.erb
@@ -36,7 +36,7 @@
 
   <%= show_table(@site, :edit_condition => check_role(:admin_user)) do |t| %>
     <% t.edit_cell(:name) { |f| f.text_field :name } %>
-    <% t.edit_cell(:description, content: full_description(@site.description)) do |f|%>
+    <% t.edit_cell(:description, content: full_description(@site.description)) do |f| %>
       <%= f.text_area :description, cols:40, rows: 10 %><br/>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>

--- a/BrainPortal/app/views/sites/show.html.erb
+++ b/BrainPortal/app/views/sites/show.html.erb
@@ -35,9 +35,9 @@
 <div class="display_inline_block" style="min-width: 50%">
 
   <%= show_table(@site, :edit_condition => check_role(:admin_user)) do |t| %>
-    <% t.edit_cell(:name) { text_field_tag "site[name]", @site.name } %>
-    <% t.edit_cell(:description, :content => full_description(@site.description)) do %>
-      <%= text_area_tag "site[description]", @site.description, :rows => 10, :cols => 40 %><br/>
+    <% t.edit_cell(:name) { |f| f.text_field :name } %>
+    <% t.edit_cell(:description, content: full_description(@site.description)) do |f|%>
+      <%= f.text_area :description, cols:40, rows: 10 %><br/>
       <div class="field_explanation">The first line should be a short summary, and the rest are for any special notes for the users.</div><br>
     <% end %>
   <% end %>

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -46,7 +46,7 @@
 <br>
 <%= error_messages_for @userfile, :header_message => "#{@userfile.name} could not be updated." %>
 <div class="display_inline_block" style="min-width: 50%">
-  <%= show_table(@userfile, :edit_condition => true) do |t| %>
+  <%= show_table(@userfile, :as => :userfile, :edit_condition => true) do |t| %>
 
     <% t.edit_cell(:name, :disabled => !@userfile.has_owner_access?(current_user)) do |f| %>
       <%= f.text_field :name %>
@@ -130,15 +130,14 @@
       <%= f.select :group_writable, [['Read Only', false],['Read/Write', true]] %>
     <% end %>
 
-    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
-      <%= hidden_field_tag "userfile[hidden]", "0" %>
-      <%= check_box_tag("userfile[hidden]",    "1", @userfile.hidden?) %>
+    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f|%>
+      <%= f.check_box(:hidden) %>
       <%= hidden_icon %>
     <% end %>
 
-    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
-      <%= hidden_field_tag "userfile[immutable]", "0" %>
-      <%= check_box_tag("userfile[immutable]",    "1", @userfile.immutable?) %>
+    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f|%>
+
+      <%= f.check_box :immutable %>
       <%= immutable_icon %>
     <% end %>
 

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -130,13 +130,12 @@
       <%= f.select :group_writable, [['Read Only', false],['Read/Write', true]] %>
     <% end %>
 
-    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f|%>
-      <%= f.check_box(:hidden) %>
+    <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f| %>
+      <%= f.check_box :hidden %>
       <%= hidden_icon %>
     <% end %>
 
-    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f|%>
-
+    <% t.edit_cell("Immutable file", :content => check_box_tag(nil ,nil, @userfile.immutable?, :disabled => true) + "&nbsp;".html_safe + immutable_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do |f| %>
       <%= f.check_box :immutable %>
       <%= immutable_icon %>
     <% end %>

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -48,8 +48,8 @@
 <div class="display_inline_block" style="min-width: 50%">
   <%= show_table(@userfile, :edit_condition => true) do |t| %>
 
-    <% t.edit_cell(:name, :disabled => !@userfile.has_owner_access?(current_user)) do %>
-      <%= text_field_tag "userfile[name]", @userfile.name %>
+    <% t.edit_cell(:name, :disabled => !@userfile.has_owner_access?(current_user)) do |f| %>
+      <%= f.text_field :name %>
     <% end %>
 
     <% t.cell("Created at") do %>
@@ -126,8 +126,8 @@
       </select>
     <% end %>
 
-    <% t.edit_cell(:group_writable, :header => "Project permission on file", :content => (@userfile.group_writable? ? "Read/Write" : "Read"), :disabled => !@userfile.has_owner_access?(current_user)) do %>
-      <%= select_tag("userfile[group_writable]", options_for_select([['Read Only', false],['Read/Write', true]])) %>
+    <% t.edit_cell(:group_writable, :header => "Project permission on file", :content => (@userfile.group_writable? ? "Read/Write" : "Read"), :disabled => !@userfile.has_owner_access?(current_user)) do |f| %>
+      <%= f.select :group_writable, [['Read Only', false],['Read/Write', true]] %>
     <% end %>
 
     <% t.edit_cell("Hidden file", :content => check_box_tag(nil ,nil, @userfile.hidden?, :disabled => true) + "&nbsp;".html_safe + hidden_icon, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
@@ -166,8 +166,8 @@
       <% end %>
     <% end %>
 
-    <% t.edit_cell(:description, :content => simple_format(@userfile.description, :sanitize => true), :show_width => 2, :disabled => (!@userfile.has_owner_access?(current_user))) do %>
-      <%= text_area_tag "userfile[description]", @userfile.description, :rows => 10, :cols => 80 %>
+    <% t.edit_cell(:description, :content => simple_format(@userfile.description, :sanitize => true), :show_width => 2, :disabled => (!@userfile.has_owner_access?(current_user))) do |f| %>
+      <%= f.text_area :description, :rows => 10, :cols => 80 %>
     <% end %>
 
   <% end %>

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -48,7 +48,7 @@
 
     <%
       t.edit_cell(:type, :content => @user.type.underscore.titleize, :disabled => !((current_user.has_role?(:site_manager) || current_user.has_role?(:admin_user)) && not_admin_user(@user))) do |f|
-        f.select :type, options_for_select(roles_for_user(current_user))
+        f.select :type, roles_for_user(current_user)
       end
     %>
 


### PR DESCRIPTION
Hi, the most of table tags are replaced when seems straight and appropriate. A few involving old tags helpers are lefts as is). Not sure about bracket with space after f.____, the codebase is ragtag, even against the recommendations I like space, seems more readable, erb is full of markup/separators already.