### PR TITLE
Show table context

### DIFF
--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -79,12 +79,20 @@ module ShowTableHelper
       # Appearance
       @header          = options[:header].presence || "Info"
 
-      # Form information; this will be provider to Rails' FormBuilder if the
+      # Form information; this will be provided to Rails' FormBuilder if the
       # ShowTable helpers are used with blocks that receive an argument.
       @form_helper     = options[:form_helper].presence
+
+      # If no form_helper is provided explicitely, we build our own
+      # out of these options. This is the default behavior in fact.
       @url             = options[:url].presence
       @method          = options[:method].presence || ((object.is_a?(ApplicationRecord) && object.new_record?) ? :post : :put)
       @as              = options[:as].presence || @object.class.to_s.underscore
+
+      # Safety check to prevent devs from mixing up forms and objects
+      if @form_helper && @form_helper.object != @object
+        raise "Error: the form helper provided is not associated with our object!"
+      end
 
       # Template code
       @block           = options[:block]
@@ -366,6 +374,7 @@ module ShowTableHelper
 
   private
 
+  # Returns a create or update URL for the object
   def url_for_object_form(object) #:nodoc:
     if object.new_record?
       url_for( :controller  => params[:controller], :action => :create )

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -58,7 +58,7 @@ module ShowTableHelper
     attr_reader   :header
     attr_reader   :as
     attr_reader   :object
-    attr_writer   :form_helper
+    attr_accessor :form_helper # can be set externally
 
     # Create a new TableBuilder for +object+ using +template+ for rendering.
     # Available +options+ are the same as for the +show_table+ helper method.
@@ -81,7 +81,7 @@ module ShowTableHelper
 
       # Form information; this will be provider to Rails' FormBuilder if the
       # ShowTable helpers are used with blocks that receive an argument.
-      @form_helper     = nil
+      @form_helper     = options[:form_helper].presence
       @url             = options[:url].presence
       @method          = options[:method].presence || ((object.is_a?(ApplicationRecord) && object.new_record?) ? :post : :put)
       @as              = options[:as].presence || @object.class.to_s.underscore
@@ -322,22 +322,56 @@ module ShowTableHelper
   #  will be added next to the header/title to switch into edition mode.
   def show_table(object, options = {}, &block)
 
-    url = options[:url].presence
     edit_condition = options[:edit_condition].present?
+    url            = options[:url].presence
+
     if url.blank? && edit_condition && object.is_a?(ApplicationRecord)
-      url = { :controller  => params[:controller] }
-      if object.new_record?
-        url[:action] = :create
-      else
-        url[:action] = :update
-        url[:id]     = object.id
-      end
-      url = url_for(url)
+      url = url_for_object_form(object)
     end
+
     tb = TableBuilder.new(object, self, options.merge(:block => block, :url => url,
                                                       :edit_condition => edit_condition))
 
     render :partial => 'shared/show_table', :locals => { :tb => tb }
+  end
+
+  # This method is similar to show_table(), except it only creates
+  # the form helper for the object and yields it to its block. It does
+  # not generate a show table, but can be used to wrap several show_table()
+  # calls as along as each of them is provided explicitely that helper
+  # to their :form_helper option.
+  #
+  # E.g. template code (abridged):
+  #
+  #    show_table_context(object) do |cf|
+  #      show_table(object, :form_helper => cf) do |f|
+  #        f.cell_stuff etc
+  #      end
+  #      show_table(object, :form_helper => cf) do |f|
+  #        f.cell_stuff etc
+  #      end
+  #    end
+  def show_table_context(object, options = {}, &block)
+
+    url     = options[:url].presence
+    method  = options[:method].presence || ((object.is_a?(ApplicationRecord) && object.new_record?) ? :post : :put)
+    as      = options[:as].presence     || object.class.to_s.underscore
+
+    if url.blank? && object.is_a?(ApplicationRecord)
+      url   = url_for_object_form(object)
+    end
+
+    render :partial => 'shared/show_table_context', :locals => { :object => object, :url => url, :method => method, :as => as, :block => block }
+  end
+
+  private
+
+  def url_for_object_form(object) #:nodoc:
+    if object.new_record?
+      url_for( :controller  => params[:controller], :action => :create )
+    else
+      url_for( :controller  => params[:controller], :action => :update, :id => object.id )
+    end
   end
 
 end

--- a/BrainPortal/app/views/access_profiles/show.html.erb
+++ b/BrainPortal/app/views/access_profiles/show.html.erb
@@ -40,7 +40,9 @@
 
 <div class="display_inline_block" style="min-width: 50%">
 
-  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user)) do |t| %>
+<%= show_table_context(@access_profile) do |cf| %>
+
+  <%= show_table(@access_profile, :form_helper => cf, :edit_condition => check_role(:admin_user)) do |t| %>
 
     <% t.edit_cell(:name, :content => access_profile_label(@access_profile)) do |f| %>
       <%= f.text_field :name, :class => "cb_colorpick_bg_target" %>
@@ -62,7 +64,7 @@
 
   <% myusers = @access_profile.users.all.sort_by(&:login) %>
 
-  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
+  <%= show_table(@access_profile, :form_helper => cf, :edit_condition => check_role(:admin_user), :header => 'Projects In This Profile') do |t| %>
     <% group_names = (@access_profile.groups.sort_by(&:name).map { |g| link_to_group_if_accessible(g) }.join(", ").html_safe.presence) || "(None)" %>
     <% t.edit_cell(:group_ids, :show_width => 2, :no_header => "Projects", :content => group_names) do %>
 
@@ -86,7 +88,7 @@
     <% end %>
   <% end %>
 
-  <%= show_table(@access_profile, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
+  <%= show_table(@access_profile, :form_helper => cf, :edit_condition => check_role(:admin_user), :header => 'Users With This Profile') do |t| %>
 
     <% if myusers.present? && myusers.count > 0 %>
       <% user_names = (array_to_table(myusers.map { |u| link_to_user_if_accessible(u) }, :table_class => 'simple', :cols => 12).html_safe) %>
@@ -117,6 +119,8 @@
 
     <% end %>
   <% end %>
+
+<% end # show_table_context %>
 
   <p>
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @access_profile.getlog, :title => 'Access Profile Log' } %>

--- a/BrainPortal/app/views/shared/_show_table.html.erb
+++ b/BrainPortal/app/views/shared/_show_table.html.erb
@@ -6,7 +6,7 @@
 
 <div class="inline_edit_field_group">
 
-  <% if tb.editable? %>
+  <% if tb.editable? && ! tb.form_helper %>
     <%= form_for(tb.object,
           :url => tb.url,
           :method => tb.method,
@@ -17,6 +17,9 @@
       <% tb.invoke_block %>
       <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => f } %>
     <% end %>
+  <% elsif tb.editable? && tb.form_helper %>
+      <% tb.invoke_block %>
+      <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => tb.form_helper } %>
   <% else %>
       <% tb.invoke_block %>
       <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => nil } %>

--- a/BrainPortal/app/views/shared/_show_table.html.erb
+++ b/BrainPortal/app/views/shared/_show_table.html.erb
@@ -2,24 +2,42 @@
 <%
 # This partial receives a single local variable,
 # tb, a ShowTableHelper::TableBuilder object
+#
+# There are three modes of using show_table:
+#
+# 1- (more common case) We build a form and put the show table inside.
+# 2- We build a show_table and pass it a form_helper already created elsewhere
+# 3- We build a show_table with no form_helper at all (just showing information).
+#
 %>
 
 <div class="inline_edit_field_group">
 
+  <%
+   # Case 1: build our form for a single table.
+  %>
   <% if tb.editable? && ! tb.form_helper %>
     <%= form_for(tb.object,
-          :url => tb.url,
+          :url    => tb.url,
           :method => tb.method,
-          :as => tb.as,
-          :html => { :id => "edit_#{tb.as}_#{tb.header}".gsub(/\W+/,"_") },
+          :as     => tb.as,
+          :html   => { :id => "edit_#{tb.as}_#{tb.header}".gsub(/\W+/,"_") },
         ) do |f| %>
       <% tb.form_helper = f %>
       <% tb.invoke_block %>
       <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => f } %>
     <% end %>
+  <%
+   # Case 2: don't build a form, but provide a form_helper to it
+   # (probably created by show_table_context())
+  %>
   <% elsif tb.editable? && tb.form_helper %>
       <% tb.invoke_block %>
       <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => tb.form_helper } %>
+  <%
+   # Case 3: build a table with no form and no form_helper.
+   # This is generally for table with no editable attributes.
+  %>
   <% else %>
       <% tb.invoke_block %>
       <%= render :partial => 'shared/show_table_content', :locals => { :tb => tb, :f => nil } %>

--- a/BrainPortal/app/views/shared/_show_table_context.html.erb
+++ b/BrainPortal/app/views/shared/_show_table_context.html.erb
@@ -1,0 +1,16 @@
+
+<%
+# This template provides a way to regroup together several
+# show_table() into a single form. It is invoked from the helper
+# method show_table_context().
+%>
+
+<%= form_for(object,
+               :url    => url,
+               :method => method,
+               :as     => as,
+               :html   => { :id => "edit_#{as}_#{object.id}".gsub(/\W+/,"_") },
+            ) do |form_helper| %>
+    <% block.call(form_helper) %>
+<% end %>
+

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -84,7 +84,7 @@
     <% end %>
 
     <!-- TERMINATE & REMOVE -->
-    <% if CbrainTask::QUEUED_STATUS.include?(@task.status) %>
+    <% if CbrainTask::QUEUED_STATUS.include?(@task.status) or CbrainTask::PROCESSING_STATUS.include?(@task.status) %>
       <%= link_to 'Terminate Task', { :action => 'operation', :operation => 'terminate', 'tasklist[]' => @task.id }, :confirm => "Are you sure you want to terminate this task?", :class  => "button menu_button", :method => :post %>
     <% end %>
 

--- a/BrainPortal/config/console_rc/lib/pretty_view.rb
+++ b/BrainPortal/config/console_rc/lib/pretty_view.rb
@@ -345,7 +345,7 @@ ToolConfig #%d "%s"
       container_index_location || "",
       containerhub_image_name.presence || "",
       container_image_userfile_id.presence || 0,
-      container_image || "none",
+      container_image.try(:name) || "none",
       extra_qsub_args.presence || ""
   end
 end

--- a/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
+++ b/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
@@ -69,11 +69,31 @@ extend Hirb::Console
   }
 end
 
+# Table view with all attributes
+def tv(*args)
+  no_log do
+    to_show = args.flatten
+    to_show.each_with_index do |obj,idx|
+      if obj.respond_to?(:attributes)
+        table obj.attributes, :unicode => true
+      else
+        table obj, :unicode => true
+      end
+      if idx+1 >= $_PV_MAX_SHOW && to_show.size > $_PV_MAX_SHOW
+        puts "Not showing #{to_show.size - $_PV_MAX_SHOW} other entries..."
+        break
+      end
+    end
+  end
+  true
+end
+
 (CbrainConsoleFeatures ||= []) << <<FEATURES
 ========================================================
 Feature: Hirb pretty model tables, and table helpers
 ========================================================
   Models have pretty unicode tables: User.limit(4)
+  Full attributes in tables with: 'tv obj'
   Console commands 'table' and 'view'
   Toggle with: Hirb.enable ; Hirb.disable
   (See the doc for the gem Hirb for more info)


### PR DESCRIPTION
It is now possible to generate a page with several `show_table()` in it, such that all of them are within the same form. See description of #771 for an example. This PR also includes an example of using this in the AccessProfile `show` page.

This should be very useful to Sergiy to make the new and edit page of ToolConfigs finally be one and the same (see #765 and #650 ).