### PR TITLE
Fixed task recovery when failure on cluster.

### DIFF
--- a/Bourreau/app/models/bourreau_worker.rb
+++ b/Bourreau/app/models/bourreau_worker.rb
@@ -421,6 +421,7 @@ class BourreauWorker < Worker
             task.meta[:submit_without_setup] = true
             task.status_transition(task.status, "New") # basically, we will go directly to submit_cluster_job()
           else # simpler cases, we just reset the status and let the task return to main flow.
+            task.meta[:submit_without_setup] = nil
             task.status_transition(task.status, "New")                    if fromwhat    == 'Setup'
             task.status_transition(task.status, "Data Ready")             if fromwhat    == 'PostProcess'
           end

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -721,6 +721,7 @@ class ClusterTask < CbrainTask
       end
       self.update_size_of_cluster_workdir
     rescue => e
+      self.meta[:submit_without_setup] = nil # reset special skip
       self.addlog_exception(e,"Exception raised while setting up:")
       self.status_transition(self.status, "Failed To Setup")
     end

--- a/BrainPortal/app/models/worker.rb
+++ b/BrainPortal/app/models/worker.rb
@@ -21,6 +21,7 @@
 #
 
 require 'log4r'
+require 'sys/proctable'
 
 # = Worker Class
 # This class is responsible for managing a separate UNIX worker subprocess.
@@ -66,9 +67,6 @@ require 'log4r'
 #   wake_up()
 #   is_alive?()
 #
-
-require 'sys/proctable'
-
 class Worker
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:


### PR DESCRIPTION
When task recovery was attempted for 'on cluster' failure,
the worker's code would try to not run the setup method first.
It set a special magic flag in the task's meta to skip
'setup'. But that flag stayed there forever and caused
problems for restarting or other recovery, later on. The
flag is now cleared at a couple of places.