### PR TITLE
During boot, duplicated SyncStatus are cleaned

### DIFF
--- a/BrainPortal/lib/cbrain_system_checks.rb
+++ b/BrainPortal/lib/cbrain_system_checks.rb
@@ -192,6 +192,16 @@ class CbrainSystemChecks < CbrainChecker #:nodoc:
       puts "C> \t- No SyncStatus objects are associated with obsolete files."
     end
 
+    #-----------------------------------------------------------------------------
+    puts "C> Handling duplicated SyncStatus objects..." # very rare normally
+    #-----------------------------------------------------------------------------
+    myself = RemoteResource.current_resource
+    report = SyncStatus.clean_duplications(myself.id)
+    report.each do |pair,count|
+      puts "C> \t- #{count} x (#{pair[0]},#{pair[1]})"
+    end
+    puts "C> \t- No duplicated SyncStatus objects found." if report.blank?
+
   end
 
 


### PR DESCRIPTION
In very rare circumstances, it seems some SyncStatus
objects are created while violating the uniqness
rules for (:bourreau_id, :userfile_id). The boot
process now identifies them and remove the duplicates.
Otherwise, all synchronization actions fail on
the affected userfiles.