### PR TITLE
A bit of robustness-related code tweaks.

### DIFF
--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -633,12 +633,12 @@ class RemoteResource < ApplicationRecord
     running = self.is_alive?(what) # this updates @info or @ping as a side-effect
     if running
       if what == :info
-        self.meta[:info_cache]             = @info rescue nil # save from rare race conditions
-        self.meta[:info_cache_last_update] = Time.now.utc
+        self.meta[:info_cache]             = @info        rescue nil # save from rare race conditions
+        self.meta[:info_cache_last_update] = Time.now.utc rescue nil
         return @info
       else
-        self.meta[:ping_cache]             = @ping rescue nil # save from rare race condition
-        self.meta[:ping_cache_last_update] = Time.now.utc
+        self.meta[:ping_cache]             = @ping        rescue nil # save from rare race condition
+        self.meta[:ping_cache_last_update] = Time.now.utc rescue nil
         return @ping
       end
     end

--- a/BrainPortal/app/views/custom_filters/_task_custom_filter.html.erb
+++ b/BrainPortal/app/views/custom_filters/_task_custom_filter.html.erb
@@ -29,7 +29,7 @@
     <%= text_field_tag "custom_filter[name]", @custom_filter.name %>
   <% end %>
 
-  <% t.edit_cell(:data_type, :header => "Tasks", :content => (@custom_filter.data_type||[]).map(&:constantize).map(&:pretty_name).sort.join(", ")) do %>
+  <% t.edit_cell(:data_type, :header => "Tasks", :content => (@custom_filter.data_type.presence||[]).map(&:constantize).map(&:pretty_name).sort.join(", ")) do %>
     <%= task_type_select("data[type]", {:task_types => current_user.available_tools.map(&:cbrain_task_class_name).sort, :selector => @custom_filter.data_description_type, :include_top => true }, :multiple => true, :size => 10) %>
   <% end %>
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/csv_file/csv_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/csv_file/csv_file.rb
@@ -39,7 +39,7 @@ class CSVFile < TextFile
 
   def is_viewable? #:nodoc:
     return false unless self.size.presence
-    return false unless self.size < 200_000  # smaller than the limit in TextFile
+    return false unless self.size < 400_000  # smaller than the limit in TextFile
     return false unless is_locally_synced?
     true
   end


### PR DESCRIPTION
CbrainMailer won't even attempt to send
emails if the From address is missing.

Avoid race condition is caching info for remote resource.

Handle some bad historical task filter object's data.

CSV file size viewer limit increased.