### PR TITLE
API calls can set batch_id for tasks. Fixes #790

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -312,6 +312,11 @@ class TasksController < ApplicationController
       new_task_info[:tool_config_id] = nil # ZAP value, it's incorrect; will likely cause a validation error later on.
     end
 
+    # Validate the batch_id
+    new_task_info[:batch_id] = nil unless
+      new_task_info[:batch_id].present? &&
+      current_user.cbrain_tasks.real_tasks.where(:id => new_task_info[:batch_id]).count == 1
+
     @tool_config = tool_config # for acces in view
 
     # A brand new task object!
@@ -509,6 +514,7 @@ class TasksController < ApplicationController
     # Save old attributes and update the current task to reflect
     # the form's content.
     new_task_attr          = task_params # not the TASK's params[], the REQUEST's params[]
+    new_task_attr.delete(:batch_id) # cannot be changed.
 
     old_tool_config  = @task.tool_config
     old_bourreau     = @task.bourreau
@@ -884,6 +890,7 @@ class TasksController < ApplicationController
     task_attr = params.require_as_params(:cbrain_task).permit(
       :user_id, :group_id, :description,
       :bourreau_id, :tool_config_id,
+      :batch_id,
       :results_data_provider_id, :params => {}
     )
     # There are way too many 'params' in the next bit of code. Two different


### PR DESCRIPTION
Quick test commands:

1) create a JSON file called `in.json` with a new task description

```json
{
  "cbrain_task": {
    "tool_config_id": 78,
    "bourreau_id": 2,
    "user_id": 1,
    "group_id": 1,
    "params": { },
    "batch_id": 202433,
    "description": "TestCreate"
  }
}
```

Adjust all the IDs in there. I chose the task 'SimpleMonitor' which comes with the default CBRAIN install. Chose a batch_id from any of your other tasks.

Sent this to your dev cbrain with curl:

```bash
curl -s -S \
  -D - \
  -X POST \
  --data @"in.json" \
  -H "Accept: application/json" \
  -H "Content-Type: application/json" \
  "http://localhost:3000/tasks?cbrain_api_token=58a314550ed02c20ebb6482ceed5f764"
```

Get the token from your console, with `LargeSessionInfo.order("updated_at desc").limit(1)`.

Run that command multiple times, check with `tv CbrainTask.ctoday` to make sure that all get the same batch_id (or check with the interface in batch mode). Also the curl command itself shoudl return each task objects in JSON.