### PR TITLE
Boutiques descriptors can use other shells.

### DIFF
--- a/Bourreau/spec/boutiques/boutiques_tester_spec.rb
+++ b/Bourreau/spec/boutiques/boutiques_tester_spec.rb
@@ -224,6 +224,19 @@ describe "Bourreau Boutiques Tests" do
           expect( task.cluster_commands[0].strip ).to eq( '/minimalApp -a value' )
         end
 
+        # Test that optional "shell" in descriptor trigger the creation of a wrapper
+        it "should create wrapper commands for alternate shells" do
+          @descriptor['shell'] = 'myFakeShell'
+          task = @generateTask.( { a: 'value' } )
+          expect( task.cluster_commands[0].strip ).to match(
+            /
+            myFakeShell\s*<<'BoutiquesShellWrapper'\s+
+            \/minimalApp\s-a\svalue\s+
+            BoutiquesShellWrapper
+            /x
+          )
+        end
+
         # Test output flag substitution
         it "should correctly subsitute cluster_commands with output keys" do
           @descriptor['command-line'] += ' [OUT-KEY]'
@@ -320,7 +333,7 @@ describe "Bourreau Boutiques Tests" do
             next # after_form does not need to check this here, since rails puts a value in the hash
           end
           # Run the generated command line from cluster_commands (-2 to ignore export lines and the echo log at -1)
-          exit_code = runTestScript( FileNamesToPaths.( @task.cluster_commands[-2].gsub('./'+TestScriptName,'') ), test[3] || [] )
+          exit_code = runTestScript( FileNamesToPaths.( @task.cluster_commands[-2].strip.gsub('./'+TestScriptName,'') ), test[3] || [] )
           # Check that the exit code is appropriate
           expect( exit_code ).to eq( test[2] )
         end

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -167,6 +167,21 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
       return super
     end
 
+%   shell            = descriptor['shell'].presence
+%   cmdline_template = descriptor['command-line']
+%   shell_wrap_start = "#{shell} <<'BoutiquesShellWrapper'"
+%   shell_wrap_end   = "BoutiquesShellWrapper"
+%   shell_wrap_start=shell_wrap_end="" if shell.nil? || shell =~ /\A(bash|\/bin\/bash|sh|\/bin\/sh)\z/
+    # Command template from the descriptor.
+% if shell_wrap_end.present?
+    # The descriptor specified that it is to be run with: <%= shell %>
+% end
+    command_template = <<-'COMMAND_TEMPLATE'
+<%= shell_wrap_start %>
+<%= cmdline_template %>
+<%= shell_wrap_end %>
+    COMMAND_TEMPLATE
+
     # Environment variables from Boutiques descriptor
 % if eVars.empty?
     envVars = []
@@ -200,10 +215,8 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
     envVars + [ <<-'CMD' ]
 %   else
     # Command-line to run <%= name %> and save its exit status
-    envVars + [ <<-'CMD', "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
+    envVars + [ command_template, "echo $? > ./#{exit_cluster_filename.bash_escape}" ]
 %   end
-      <%= descriptor['command-line'] %>
-    CMD
 % else
     params = self.params
 
@@ -340,14 +353,10 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 %   end
 %   if (descriptor['custom'] || {})['cbrain:ignore-exit-status']
     # Generate the final command-line to run <%= name %>
-    envVars + [ apply_template(<<-'CMD', keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>) ] + outfileMoveCommands
-      <%= descriptor['command-line'] %>
-    CMD
+    envVars + [ apply_template(command_template, keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>) ] + outfileMoveCommands
 %   else
     # Generate the final command-line to run <%= name %>
-    command = apply_template(<<-'CMD', keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>)
-      <%= descriptor['command-line'] %>
-    CMD
+    command = apply_template(command_template, keys<%= flags.empty? ? '' : ', flags: flags' %><%= seps.empty? ? '' : ', separators: seps' %>)
 
     # And save its exit status
     envVars + [ command, "echo $? > ./#{exit_cluster_filename.bash_escape}" ] + outfileMoveCommands


### PR DESCRIPTION
If the descriptor contains the "shell" entry, and the
value is something other than bash, then the
command will be wrapped by two more lines:

theshell <<'BoutiquesShellWrapper'
the-command-here
BoutiquesShellWrapper