### PR TITLE
Better handling of IP addresses

### DIFF
--- a/BrainPortal/app/controllers/noc_controller.rb
+++ b/BrainPortal/app/controllers/noc_controller.rb
@@ -135,7 +135,7 @@ class NocController < ApplicationController
 
     # Show IP address
     reqenv = request.env || {}
-    @ip_address ||= reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR'] || ""
+    @ip_address ||= request.remote_ip rescue 'UnknownIP'
 
     # Number of exceptions
     @num_exceptions = ExceptionLog.where([ "created_at > ?", this_morning ]).count

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -200,9 +200,10 @@ class SessionsController < ApplicationController
     user   = current_user
     cbrain_session.activate(user.id)
 
-    # Record the best guess for browser's remote host name
+    # Record the best guess for browser's remote host IP and name
     reqenv      = request.env
-    from_ip     = reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR']
+    from_ip     = request.remote_ip rescue nil # utility from Rails
+    from_ip   ||= reqenv['HTTP_X_FORWARDED_FOR'] || reqenv['HTTP_X_REAL_IP'] || reqenv['REMOTE_ADDR'] # fallbacks?
     from_ip     = Regexp.last_match[1] if ((from_ip || "") =~ /(\d+\.\d+\.\d+\.\d+)/) # sometimes we get several IPs with commas
     from_host   = hostname_from_ip(from_ip)
     from_ip   ||= '0.0.0.0'

--- a/BrainPortal/db/seeds_test_api.rb
+++ b/BrainPortal/db/seeds_test_api.rb
@@ -234,7 +234,7 @@ LargeSessionInfo.seed_record!(
   {
     user_id:    admin.id,
     active:     true,
-    data:       {  :guessed_remote_ip   => "::1",
+    data:       {  :guessed_remote_ip   => "127.0.0.1",
                    :guessed_remote_host => "api_test_host",
                    :raw_user_agent      => "Rake_API_Test/ruby",
                    :api                 => "yes",
@@ -249,7 +249,7 @@ LargeSessionInfo.seed_record!(
   {
     user_id:    normal.id,
     active:     true,
-    data:       {  :guessed_remote_ip   => "::1",
+    data:       {  :guessed_remote_ip   => "127.0.0.1",
                    :guessed_remote_host => "api_test_host",
                    :raw_user_agent      => "Rake_API_Test/ruby",
                    :api                 => "yes",
@@ -265,7 +265,7 @@ LargeSessionInfo.seed_record!(
   {
     user_id:    normal.id,
     active:     true,
-    data:       {  :guessed_remote_ip   => "::1",
+    data:       {  :guessed_remote_ip   => "127.0.0.1",
                    :guessed_remote_host => "api_test_host",
                    :raw_user_agent      => "Rake_API_Test/ruby",
                    :api                 => "yes",

--- a/BrainPortal/spec/controllers/sessions_controller_spec.rb
+++ b/BrainPortal/spec/controllers/sessions_controller_spec.rb
@@ -24,7 +24,8 @@ require 'rails_helper'
 
 RSpec.describe SessionsController, :type => :controller do
   let(:cookie_session) { ActionController::TestSession.new(:_csrf_token => 'dummy') }
-  let(:cbrain_session) { mock_model(LargeSessionInfo).as_null_object }
+  # NOTE: the mock model below is not right.... :-( cbrain_sesssion() returns a CbrainSession object!
+  let(:cbrain_session) { mock_model(LargeSessionInfo, :guessed_remote_ip => '0.0.0.0').as_null_object }
   let(:portal)         { double("portal", :portal_locked? => false).as_null_object }
 
   before(:each) do

--- a/BrainPortal/spec/controllers/users_controller_spec.rb
+++ b/BrainPortal/spec/controllers/users_controller_spec.rb
@@ -607,7 +607,7 @@ RSpec.describe UsersController, :type => :controller do
 
     describe "switch" do
       # NOTE: the mock model below is not right.... :-( cbrain_sesssion() returns a CbrainSession object!
-      let(:cbrain_session) { mock_model(LargeSessionInfo, "_csrf_token" => 'dummy csrf', "session_id" => 'session_id', "user_id" => admin.id).as_null_object }
+      let(:cbrain_session) { mock_model(LargeSessionInfo, "guessed_remote_ip" => '0.0.0.0', "_csrf_token" => 'dummy csrf', "session_id" => 'session_id', "user_id" => admin.id).as_null_object }
 
       before(:each) do
         allow(controller).to receive(:cbrain_session).and_return(cbrain_session)


### PR DESCRIPTION
We use Rail's `request.remote_ip` method instead of our own.

When users roam, the IP address and host name will be updated.
In the past, we always showed the IP address that the user
initialy used when logging in.

Also, requests made with API tokens are checked for their
IP addresses, and if they change, the session is de-activated.