### PR TITLE
Several fixes all bundled together.

### DIFF
--- a/Bourreau/script/cbrain_remote_ctl
+++ b/Bourreau/script/cbrain_remote_ctl
@@ -47,13 +47,7 @@
 #   script/rails server thin -d -e <environment> -p <port> -b 127.0.0.1 -P pidfile
 #
 # and finally removing the database.yml file. Any database.yml file
-# already present before doing all this will be backed up in
-#
-#     database.yml.cbrain_remote_bak.
-#
-# Note that if stdin contains nothing (zero bytes) the current
-# database.yml file will be used, or the script will restore and use
-# the backup file 'database.yml.cbrain_remote_bak'.
+# already present before doing all this will be erased.
 #
 #
 # To stop the Rails app:
@@ -197,25 +191,16 @@ fatal("Port argument must be a number greater than 1024 and less than 65530") un
 
 db_yml_text = mode == "start" ? (STDIN.read || "") : ""
 db_file     = rails_home + "/config/database.yml"
-db_file_bak = rails_home + "/config/database.yml.cbrain_remote_bak"
 
 # Install or restore database.yml if necessary
 db_exists  = File.exist?(db_file)
-bak_exists = File.exist?(db_file_bak)
 blank_yml  = db_yml_text !~ /\S/
 
 if blank_yml #  blank? use what db.yml is already here
-  if db_exists
-    # nothing to do
-  elsif bak_exists
-    File.rename(db_file_bak,db_file)
-  else
+  if ! db_exists
     fatal("Could not find a database.yml file for the Rails application!")
   end
 else # db text is provided to us
-  if db_exists
-    File.rename(db_file,db_file_bak) # will crush existing bak file
-  end
   # Optional: change stuff in it, depending on the environment
   unless ENV['CBRAIN_FRONTEND_HOSTNAME'].nil? || ENV['CBRAIN_FRONTEND_HOSTNAME'] =~ /^\s*$/
     db_yml_text.sub!(/hostname:\s*\S+/,"hostname: #{ENV['CBRAIN_FRONTEND_HOSTNAME']}")

--- a/BrainPortal/app/helpers/resource_link_helper.rb
+++ b/BrainPortal/app/helpers/resource_link_helper.rb
@@ -255,7 +255,7 @@ module ResourceLinkHelper
     return "(None)" if user.blank?
     cb_error "This method requires the first argument to be a User object." unless user.is_a?(User)
     capture do
-      html_tool_tip(link_to_user_if_accessible(user,current_user,options), :offset_x => 60 ) do
+      html_tool_tip(link_to_user_if_accessible(user,current_user,options), :offset_x => 0, :offset_y => 20 ) do
         (
         "<div class=\"left_align\">\n" +
         "#{h(user.full_name)}<br>\n" +

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2523,12 +2523,15 @@ chmod o+x . .. ../.. ../../..
       # of these blocks can be scheduled to run, but only one will execute at at any given time.
       next if File.exists?(cache_path.to_s) && File.size(cache_path.to_s) > 0
       # Run singularity build command
-      tool_config_system("umask 000; #{singularity_executable_name} build #{cache_path.to_s.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape}")
-      # Singularity command can generate 'implausibly old time stamp' when pulling a docker image (due to tar), we ignore it.
-      # Not sure if it is still true for `build` command, leave it just in case.
-      # Remove all lines (use ^ and $) that contains this message.
-      cb_error "Cannot build singularity image" if
-        !File.size?(cache_path.to_s)
+      out, err = tool_config_system("umask 000; #{singularity_executable_name} build #{cache_path.to_s.bash_escape} #{singularity_index_location.bash_escape}#{singularity_image_name.bash_escape}")
+      # Check that all is OK; if not we store the captured outputs for investigation
+      if ! File.exists?(cache_path.to_s) || File.size(cache_path.to_s) < 500.kilobytes
+        capfile = "singularity_build_traces-#{self.run_id}.txt"
+        File.open(capfile,"w") do |fh|
+          fh.write("=== Stdout ===\n#{out}\n=== Stderr ===\n#{err}\n=== ====== ===\n")
+        end
+        cb_error "Cannot build singularity image. Captured outputs are in #{capfile}"
+      end
     end
 
     self.addlog("Image stored as scratch userfile '#{scratch_userfile.name}' (ID #{scratch_userfile.id})")

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -720,6 +720,8 @@ class Userfile < ApplicationRecord
     def valid_for?(userfile) #:nodoc:
       return true if @conditions.empty?
       @conditions.all? { |condition| condition.call(userfile) }
+    rescue
+      false
     end
 
     def ==(other) #:nodoc:

--- a/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
@@ -130,7 +130,7 @@
   <%%
     values = @task.params[name.to_sym] if name && values.nil?
     values = values.is_a?(Enumerable) ? values.compact : [values].compact
-    first = values.pop
+    first  = values.shift
   %>
   <ul class="tsk-prm-list">
     <li>
@@ -343,7 +343,8 @@
         )
     <%- else -%>
         # File input dropdown
-        dropdown.(id, id,
+        name = id <%= list ? '+ "[]"' : '' %>
+        dropdown.(id, name,
           input_files.map { |f| [ f.id.to_s, f.name ] },
           optional: <%= opt %>
         )

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -674,8 +674,11 @@
       var trigger = $(this);
       var tool_tip_id = trigger.data("tool-tip-id");
       var tool_tip = $("#" + tool_tip_id);
-      var offset_x = trigger.data("offset-x") || '30';
+      var offset_x = trigger.data("offset-x");
       var offset_y = trigger.data("offset-y") || '0';
+      if (typeof offset_x == 'undefined') {
+        offset_x = '30';
+      }
 
       var x = trigger.position().left + parseInt(offset_x, 10);
       var y = trigger.position().top  + parseInt(offset_y, 10);


### PR DESCRIPTION
1- The controls channel for Bourreau has a new 'StopYourself'
   command, which is much more efficient than the old way
   of stopping the rails app using an external script.
   Fixes #55 .
2- The 'ibc' utility provides access to it with the 'J' command
3- Tooltips in the interface could never be positioned
   at offset_x set to 0 because 0 is falsy in javascript. Fixed.
4- We no longer ever keep a backup of database.yml on remote sites.
5- Userfiles viewers that have conditions which crash no
   longer prevent the 'show' page from rendering; instead the
   viewer is ignored and removed from the available list.
   Fixes #25
6- Task forms for boutiques tasks will present list
   inputs in proper order.
   Fixes #830
7- Support for lists for File inputs in boutiques
   Fixes #831
8- When erasing a task, if the associated archive cannot be erased too
   it will be tagged with the admin-owned Tag 'TaskDestroyed', so the
   admin can find them and deleted them separately later.
   Fixes #45 