### PR TITLE
Bourreau workers propagate stop to subworkers; fix #741

### DIFF
--- a/Bourreau/app/models/bourreau_worker.rb
+++ b/Bourreau/app/models/bourreau_worker.rb
@@ -156,7 +156,10 @@ class BourreauWorker < Worker
   # In the subworker it will do nothing.
   def stop_signal_received_callback #:nodoc:
     if @process_task_list_pid
-      worker_log.info "Propagating STOP to subprocess #{@process_task_list_pid}"
+      # NOTE: in a signal handler it seems we can't invoke the logger.
+      # The superclass has @trap_log to capture and log instead.
+      #OLD: worker_log.info "Propagating STOP to subprocess #{@process_task_list_pid}"
+      @trap_log << [ :info, "Propagating STOP to subprocess #{@process_task_list_pid}" ]
       Process.kill('TERM',@process_task_list_pid) rescue nil
     end
   end


### PR DESCRIPTION
There was a bug that prevented the stop signal from
propagating: basically if logger was invoked from
the signal handler, it crashed and the rest of the signal
handler code was ignored.

The main worker class already had code to mitigate this,
with @trap_log a variable holding log messages that
are sent at the end. So the subworker use that too now.