### PR TITLE
Added JSON descriptor for BoutiquesDemo task.

### DIFF
--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task_descriptors/boutiques_demo.json
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task_descriptors/boutiques_demo.json
@@ -1,0 +1,103 @@
+{
+    "name":           "BoutiquesDemo",
+    "tool-version":   "5.1.2",
+    "schema-version": "0.5",
+    "author":         "Pierre Rioux",
+    "description":    "A demo CBRAIN task using a Boutiques descriptor. This program runs the UNIX 'du' command on a file or directory.",
+    "descriptor-url": "https://github.com/aces/cbrain/blob/master/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task_descriptors/boutiques_demo.json",
+    "command-line": "du [ALL] [HUMAN] [FOLLOW_LINKS] [CBRAIN_INPUT] | tee [DU_OUTPUT_NAME]",
+    "inputs": [
+        {
+            "name":              "Input file or directory",
+            "id":                "my_input",
+            "description":       "Any file or directory in CBRAIN",
+            "type":              "File",
+            "optional":          false,
+            "list":              false,
+            "value-key":         "[CBRAIN_INPUT]"
+        },
+        {
+            "name":              "Name of report",
+            "id":                "my_output_name",
+            "description":       "The name of the text report containing the output of the 'du' command",
+            "type":              "String",
+            "optional":          false,
+            "list":              false,
+            "value-key":         "[DU_OUTPUT_NAME]"
+        },
+        {
+            "name":              "All files",
+            "id":                "option_a",
+            "description":       "Whether or not to provide a breakdown of each and every file",
+            "type":              "Flag",
+            "optional":          true,
+            "command-line-flag": "-a",
+            "value-key":         "[ALL]"
+        },
+        {
+            "name":              "Human readable values",
+            "id":                "option_h",
+            "description":       "If true, units will be shown in readable human values, otherwise in blocks",
+            "type":              "Flag",
+            "optional":          true,
+            "command-line-flag": "-h",
+            "value-key":         "[HUMAN]"
+        },
+        {
+            "name":              "Follow initial symlinks",
+            "id":                "option_upper_h",
+            "description":       "If true, initial symlinks are followed. Needed for file collections in CBRAIN",
+            "type":              "Flag",
+            "optional":          true,
+            "default-value":     true,
+            "command-line-flag": "-H",
+            "value-key":         "[FOLLOW_LINKS]"
+        }
+    ],
+    "output-files": [
+        {
+            "name":          "Output report",
+            "id":            "du_report_out",
+            "description":   "The output of the 'du' command",
+            "optional":      false,
+            "list":          false,
+            "path-template": "[DU_OUTPUT_NAME]"
+        }
+    ],
+    "groups": [
+        {
+            "id": "files",
+            "name": "Files",
+            "members": [
+                "my_output_name",
+                "my_input"
+            ]
+        },
+        {
+            "id": "options",
+            "name": "Options",
+            "members": [
+                "option_a",
+                "option_h",
+                "option_upper_h"
+            ]
+        }
+    ],
+    "tags": {
+        "domain": [
+            "boutiques",
+            "testing",
+            "cbrain",
+            "platform",
+            "internal"
+        ]
+    },
+    "suggested-resources": {
+        "cpu-cores":         1,
+        "ram":               1,
+        "walltime-estimate": 60
+    },
+    "custom": {
+        "cbrain:readonly-input-files": true
+    }
+}


### PR DESCRIPTION
This PR includes a single file, a boutiques descriptor for a sample CBRAIN task that runs the UNIX `du` command, with a few options.

The base CBRAIN installation didn't even have a single Boutiques descriptor, so I figured I might provide a demo one.  I wrote it from scratch, if you look at it you can see how elegantly I aligned everything in the JSON file. This will fix #828 .

The task form interface looks like this:

![Screen Shot 2019-07-22 at 18 43 30](https://user-images.githubusercontent.com/777588/61670481-ca9d3500-acb1-11e9-8a68-6617b1b3e25b.png)
