### PR TITLE
SSH masters now fail if tunnels can't be opened.

### DIFF
--- a/BrainPortal/app/controllers/custom_filters_controller.rb
+++ b/BrainPortal/app/controllers/custom_filters_controller.rb
@@ -56,13 +56,7 @@ class CustomFiltersController < ApplicationController
 
     filter_class   = Class.const_get(filter_param)
     @custom_filter = filter_class.new(custom_filter_params(filter_class))
-
     @custom_filter.user_id = current_user.id
-
-
-    if @custom_filter.errors.empty?
-      flash[:notice] = "Filter successfully created."
-    end
 
     respond_to do |format|
       if @custom_filter.save

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -662,11 +662,17 @@ class Userfile < ApplicationRecord
       return file
     end
 
+    # Update or create the actual content by invoking the block
     file.cache_prepare
-    SyncStatus.ready_to_modify_cache(file) do
+    SyncStatus.ready_to_modify_cache(file, 'InSync') do
       yield file.cache_full_path # allow programmer to provide content for the file
     end
-    file.sync_to_provider
+
+    # A bit of info tracking
+    myself       = RemoteResource.current_resource
+    backtrace    = (Rails.backtrace_cleaner.clean caller).first || "Unknown"
+    file.addlog("Scratch file content created or updated on #{myself.name} (#{file.size || '?'} bytes) from #{backtrace}")
+
     file
   end
 

--- a/BrainPortal/lib/ssh_master.rb
+++ b/BrainPortal/lib/ssh_master.rb
@@ -508,20 +508,26 @@ class SshMaster
   # string as part of another 'ssh' command.
   def ssh_shared_options(control_master="no")
     socket = self.control_path
-    args_string =
-                      " -p #{@port}"                          +
-                      " -A"                                   +
-                      " -o ConnectTimeout=10"                 +
 
-                      " " + ssh_config_options_as_string()    +
+    # Base options that are always present
+    args_string  = " -p #{@port}"
+    args_string += " -A"
+    args_string += " -o ConnectTimeout=10"
+    args_string += " -o ExitOnForwardFailure=yes"
+    args_string += " " + ssh_config_options_as_string()
 
-    (@nomaster ?      "" :
-                      " -o ServerAliveInterval=30"            +
-                      " -o ServerAliveCountMax=5"             +
-                      " -o ControlMaster=#{control_master}"   +
-                      " -o ControlPath=#{socket}"
-    )                                                         +
-                      " #{@user}@#{@host} "
+    # When @nomaster is true, it means we're not even building
+    # the options for an existing master.
+    if ! @nomaster
+      args_string += " -o ServerAliveInterval=30"
+      args_string += " -o ServerAliveCountMax=5"
+      args_string += " -o ControlMaster=#{control_master}"
+      args_string += " -o ControlPath=#{socket}"
+    end
+
+    # Finally, user and host
+    args_string += " #{@user}@#{@host} "
+
     args_string
   end
 


### PR DESCRIPTION
This requires the ssh option ExitOnForwardFailure which by now
is supported on most UNIX systems.

Also:
* slight improvments to CustomFilters create()
* scratch userfiles get logging info when created/updated