### PR TITLE
Admin can decide if DP use persistent SSH masters

### DIFF
--- a/BrainPortal/app/controllers/bourreaux_controller.rb
+++ b/BrainPortal/app/controllers/bourreaux_controller.rb
@@ -154,6 +154,9 @@ class BourreauxController < ApplicationController
     # Help link for large uploads (shows up in the upload panel)
     add_meta_data_from_form(@bourreau, [ :large_upload_url ])
 
+    # Options for SSH Data Providers
+    add_meta_data_from_form(@bourreau, [ :use_persistent_ssh_masters_for_dps ])
+
     # Amazon EC2 properties
     add_meta_data_from_form(@bourreau, [:amazon_ec2_access_key_id, :amazon_ec2_secret_access_key, :amazon_ec2_region] )
 

--- a/BrainPortal/app/models/ssh_data_provider.rb
+++ b/BrainPortal/app/models/ssh_data_provider.rb
@@ -319,11 +319,14 @@ class SshDataProvider < DataProvider
   # Addendum, Aug 1st 2012: the connection is no longer necessary persistent, by
   # passing the :nomaster=true option to SshMaster when on a Bourreau!
   def master
-    persistent = RemoteResource.current_resource.is_a?(BrainPortal)
+    myself     = RemoteResource.current_resource
+    persistent = myself.meta[:use_persistent_ssh_masters_for_dps] # true, false, or string versions
+    # Default 'persistent' is TRUE for BrainPortals, FALSE for others (e.g. Bourreaux)
+    persistent = RemoteResource.current_resource.is_a?(BrainPortal) if persistent.to_s !~ /\A(true|false)\z/
     @master ||= SshMaster.find_or_create(remote_user,remote_host,remote_port,
                   :category => "DP_#{Process.uid}",
                   :uniq     => self.id.to_s,
-                  :nomaster => ! persistent
+                  :nomaster => (persistent.to_s != 'true')
                 )
     # Unlock agent, in preparation for doing stuff on it
     CBRAIN.with_unlocked_agent(:caller_level => 1)

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -159,7 +159,7 @@
 
   <% end %>
 
-  <% if is_portal %>
+  <% if check_role(:admin_user) && is_portal %>
     <%= show_table(@bourreau, :as => :bourreau, :header => "Mail configuration", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
       <% t.edit_cell(:support_email, :header => "Support email address") do |f| %>
         <%= f.text_field :support_email, :size => 30 %><br/>
@@ -249,6 +249,32 @@
       <% end %>
     <% end %>
 
+    <%= show_table(@bourreau, :as => :bourreau, :header => "Data Providers Options", :edit_condition => @bourreau.has_owner_access?(current_user)) do |t| %>
+        <% persistent = @bourreau.meta[:use_persistent_ssh_masters_for_dps] %>
+        <% persistent = is_portal if persistent.nil? %>
+        <% t.edit_cell 'meta[use_persistent_ssh_masters_for_dps]',
+                       :header  => "Use persistent SSH masters for SSH-based DataProviders",
+                       :content => (persistent.to_s == 'true' ? 'Always' : 'Never') do %>
+          <%= select_tag  'meta[use_persistent_ssh_masters_for_dps]',
+              options_for_select( [ [ "Always", "true" ], [ 'Never', "false" ] ], persistent )
+          %>
+          <br>
+          <p class="wide_field_explanation">
+            When set to 'always', the SSH connections to a data
+            provider's host will persist after the first use. This
+            makes successive data transfers a bit faster because
+            the connection doesn't have to be re-opened every time
+            it is needed. The default it to have this behavior ON
+            ('always') for portals and OFF ('never') for execution
+            servers.
+          </p>
+          <%
+          # The following hidden field is needed so this table receives at least one attribute
+          # when the form is posted.
+          %>
+          <%= hidden_field_tag 'bourreau[ignore_this]', 'meta_update' %>
+        <% end %>
+    <% end %>
 
 
     <% if is_bourreau %>


### PR DESCRIPTION
Each Portal or Bourreau now has an option to allow
using persistent SSH master for data providers.

Default is still exactly as before: yes for Portals,
no for Bourreaux.