### PR TITLE
Fix for issue #749

### DIFF
--- a/Bourreau/app/models/bourreau_worker.rb
+++ b/Bourreau/app/models/bourreau_worker.rb
@@ -523,7 +523,7 @@ class BourreauWorker < Worker
   # Our task might have disappeared. Rare.
   # This is most likely during the reload() at the top of the method.
   rescue ActiveRecord::RecordNotFound => gone_ex
-    if gone_ex.message["Couldn't find #{task.class} with id=#{task.id}"] # our own task?
+    if gone_ex.message["#{task.class}"] && gone_ex.message =~ /=#{task.id}\b/ # our own task?
       worker_log.debug "Task '#{task.bname_tid}' has disappeared. Skipping."
       return # nothing else to do
     else


### PR DESCRIPTION
The code originally checked the exception's error
message and was trying to make sure it contained
something like:

`Couldn't find CbrainTask::Abcd with id=1234`

The problem is that in the message is really:

`Couldn't find CbrainTask::Abcd with 'id'=1234`

Not sure if it's something that was changed in Rails.
Anyway, I made the check a bit less strict.