### PR TITLE
Boutiques: Fix for inputs 'multi' with dropdown

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
@@ -319,7 +319,8 @@
   <%- enum_vals = param["value-choices"] %>
   <%- if not enum_vals.nil? -%>
         # Enum value dropdown
-        dropdown.(id, id,
+        name = id <%= list ? '+ "[]"' : '' %>
+        dropdown.(id, name,
           <%= enum_vals.map { |v| [v, v] } %>,
           optional: <%= opt %>,
           default:  <%= "\"#{defaults.find { |d| d['id']==id }['default-value']}\"" rescue "nil" %>

--- a/script/update_cb_all.sh
+++ b/script/update_cb_all.sh
@@ -42,7 +42,7 @@ A) for both Bourreau and BrainPortal:
 B) for BrainPortal only:
 
   - rake db:migrate
-  - rake db:sanity:check 
+  - rake db:sanity:check
   - rake assets:precompile
   - chmod -R a+rX BrainPortal/public
 


### PR DESCRIPTION
When list is 'true' in a dropdown with a provided list of acceptable value.

Problem still: can't select more than one value. For that we need to
rewrite (or add a new) dropdown widget.

This will partially fix #848 .