### PR TITLE
Added resource usage tracking.

### DIFF
--- a/Bourreau/app/models/cputime_resource_usage_for_cbrain_task.rb
+++ b/Bourreau/app/models/cputime_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/cputime_resource_usage_for_cbrain_task.rb

--- a/Bourreau/app/models/resource_usage.rb
+++ b/Bourreau/app/models/resource_usage.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/resource_usage.rb

--- a/Bourreau/app/models/space_resource_usage.rb
+++ b/Bourreau/app/models/space_resource_usage.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/space_resource_usage.rb

--- a/Bourreau/app/models/space_resource_usage_for_cbrain_task.rb
+++ b/Bourreau/app/models/space_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/space_resource_usage_for_cbrain_task.rb

--- a/Bourreau/app/models/space_resource_usage_for_userfile.rb
+++ b/Bourreau/app/models/space_resource_usage_for_userfile.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/space_resource_usage_for_userfile.rb

--- a/Bourreau/app/models/time_resource_usage.rb
+++ b/Bourreau/app/models/time_resource_usage.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/time_resource_usage.rb

--- a/Bourreau/app/models/walltime_resource_usage_for_cbrain_task.rb
+++ b/Bourreau/app/models/walltime_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/walltime_resource_usage_for_cbrain_task.rb

--- a/BrainPortal/app/controllers/resource_usage_controller.rb
+++ b/BrainPortal/app/controllers/resource_usage_controller.rb
@@ -1,0 +1,81 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Controller for managing ResourceUsage objects.
+class ResourceUsageController < ApplicationController
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_action :login_required
+  before_action :admin_role_required
+
+  AllowedReports = %w( SpaceResourceUsageForUserfile
+                       SpaceResourceUsageForCbrainTask
+                       CputimeResourceUsageForCbrainTask
+                       WalltimeResourceUsageForCbrainTask
+                     )
+
+  # Only accessible to the admin user.
+  def index #:nodoc:
+    @scope      = scope_from_session
+
+    # We always have an implicit filter by 'type'
+    type_filter = @scope.filters.detect { |f| f.attribute == 'type' }
+    @maintype   = type_filter.try(:value)
+    if @maintype.blank?
+      @maintype   = AllowedReports.first
+      type_filter = ViewScopes::Scope::Filter.new
+      type_filter.attribute = 'type'
+      type_filter.value     = @maintype
+      @scope.filters.unshift(type_filter)
+    end
+
+    scope_default_order(@scope, 'created_at')
+
+    @base_scope   = base_scope
+                    .where('resource_usage.type' => @maintype)
+                    .includes( [:user, :group,
+                                :userfile, :data_provider,
+                                :cbrain_task, :remote_resource, :tool, :tool_config] )
+    @view_scope   = @scope.apply(@base_scope)
+
+    @scope.pagination ||= Scope::Pagination.from_hash({ :per_page => 15 })
+    @resource_usages = @scope.pagination.apply(@view_scope) # funky plural here
+
+    @total_plus      = @view_scope.where("resource_usage.value > 0").sum(:value)
+    @total_minus     = @view_scope.where("resource_usage.value < 0").sum(:value)
+    @total           = @total_plus + @total_minus
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
+  end
+
+  # Create list of RUs visible to current user.
+  def base_scope() #:nodoc:
+    scope = ResourceUsage.where(nil)
+    scope
+  end
+
+end
+

--- a/BrainPortal/app/controllers/resource_usage_controller.rb
+++ b/BrainPortal/app/controllers/resource_usage_controller.rb
@@ -26,7 +26,7 @@ class ResourceUsageController < ApplicationController
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   before_action :login_required
-  before_action :admin_role_required
+  #before_action :admin_role_required
 
   AllowedReports = %w( SpaceResourceUsageForUserfile
                        SpaceResourceUsageForCbrainTask
@@ -73,7 +73,11 @@ class ResourceUsageController < ApplicationController
 
   # Create list of RUs visible to current user.
   def base_scope() #:nodoc:
-    scope = ResourceUsage.where(nil)
+    if current_user.has_role? :admin_user
+      scope = ResourceUsage.where(nil)
+    else
+      scope = ResourceUsage.where('resource_usage.user_id' => current_user.id)
+    end
     scope
   end
 

--- a/BrainPortal/app/helpers/resource_usage_helper.rb
+++ b/BrainPortal/app/helpers/resource_usage_helper.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Helper methods for resource usage views.
+module ResourceUsageHelper
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Prints a pretty colorized value for the ResourceUsage;
+  # Time: "1234 seconds (20 minutes and 34 seconds)"
+  # Space: "+ 123 kb" or "- 123 kb" etc
+  # Returns an empty string if the value is 0
+  def pretty_resource_usage_value(ru)
+    val = ru.value
+    return "" if val.blank?
+    return "" if ru == 0
+    if ru.is_a?(TimeResourceUsage)
+      report  = pluralize(val, "second")
+      report += " (" + pretty_elapsed(val) + ") " if val > 59
+      return report
+    end
+    if val >= 0
+       ('<span color="green">+</span>&nbsp;' + colored_pretty_size(val)).html_safe
+    else
+       ('<span color="red">-</span>&nbsp;' +   colored_pretty_size(-val)).html_safe
+    end
+  end
+
+end
+

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -58,6 +58,9 @@ class CbrainTask < ApplicationRecord
 
   belongs_to            :workdir_archive, :class_name => 'Userfile', :foreign_key => :workdir_archive_userfile_id, :optional => true
 
+  # Resource usage is kept forever even if task is destroyed.
+  has_many              :resource_usage
+
   # Pseudo Attributes (not saved in DB)
   # These are filled in by calling capture_job_out_err().
   attr_accessor  :cluster_stdout, :cluster_stderr, :script_text
@@ -195,10 +198,13 @@ class CbrainTask < ApplicationRecord
                         "Restarting Setup", "Restarting Cluster", "Restarting PostProcess" ]
 
   # List of status for tasks that active in any way.
-  ACTIVE_STATUS    = QUEUED_STATUS | PROCESSING_STATUS | RECOVER_STATUS | RESTART_STATUS
+  ACTIVE_STATUS     = QUEUED_STATUS | PROCESSING_STATUS | RECOVER_STATUS | RESTART_STATUS
+
+  # List of status for tasks that are in a final state.
+  FINAL_STATUS      = COMPLETED_STATUS | FAILED_STATUS | [ "Terminated" ]
 
   # List of all status keywords.
-  ALL_STATUS       = ACTIVE_STATUS | COMPLETED_STATUS | RUNNING_STATUS | FAILED_STATUS | OTHER_STATUS
+  ALL_STATUS        = ACTIVE_STATUS | COMPLETED_STATUS | RUNNING_STATUS | FAILED_STATUS | OTHER_STATUS
 
   ##################################################################
   # Core Object Methods

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2611,7 +2611,7 @@ chmod o+x . .. ../.. ../../..
     false
   end
 
-  protected
+  public # the callbacks below are handled by after_status_transtion()
 
   # Add up CPU usage when a task goes to "Data Ready" state
   def track_resource_usage_cpu(prevstate) #:nodoc:
@@ -2621,6 +2621,8 @@ chmod o+x . .. ../.. ../../..
     qsub_file = Pathname.new(task_workdir) + qsub_stdout_basename
     num_seconds_info = extract_cpu_times_from_qsub_wrapper(qsub_file)
     return unless num_seconds_info.present?
+
+    #TODO sacct -n -p -o JobID,UserCPU,CPUTime,TotalCPU,CPUTimeRAW,Elapsed -j 2896567
 
     cpu_time  = num_seconds_info[:user_tot] + num_seconds_info[:syst_tot]
 
@@ -2651,7 +2653,7 @@ chmod o+x . .. ../.. ../../..
   # a final status.
   def track_resource_usage_final(prevstate) #:nodoc:
     SpaceResourceUsageForCbrainTask.create(
-      :value              => self.cluster_workdir_size, # just FYI
+      :value              => self.cluster_workdir_size || 0, # just FYI
       :user_id            => self.user_id,
       :group_id           => self.group_id,
       :cbrain_task_id     => self.id,

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -90,6 +90,10 @@ class ClusterTask < CbrainTask
   before_destroy :before_destroy_terminate_and_rm_workdir
   validate       :task_is_proper_subclass
 
+  # Resource usage tracking
+  after_status_transition '*', 'Data Ready',                       :track_resource_usage_cpu
+  after_status_transition '*', Regexp.new(FINAL_STATUS.join('|')), :track_resource_usage_final
+
 
 
   ##################################################################
@@ -1172,6 +1176,51 @@ class ClusterTask < CbrainTask
     content = File.read(basename)
     return nil if content !~ /CBRAIN Task Exiting/
     content
+  end
+
+  # Returns the values of the 'times' command
+  # we insert in the qsub wrapper script. Returns
+  # nil if the values can't be parsed out.
+  #
+  #   CBRAIN Task Starting At 1567533649 : 2019-09-03 14:00:49
+  #   __CBRAIN_CAPTURE_PLACEHOLDER__
+  #   CBRAIN Task Ending With Status 0 After 91844 seconds, at 1567625493 : 2019-09-04 15:31:33
+  #
+  #   CBRAIN Task CPU Times Start
+  #   0m0.015s 0m0.024s
+  #   1516m58.086s 9m50.590s
+  #   CBRAIN Task CPU Times End
+  #   CBRAIN Task Exiting
+  def extract_cpu_times_from_qsub_wrapper(filename)
+    return nil unless File.exists?(filename.to_s)
+    content = File.read(filename.to_s).tr("\n"," ")
+    return nil if content !~
+       /After\s(\d+)\sseconds
+        .*
+        CBRAIN\sTask\sCPU\sTimes\sStart
+        \s+
+        (\d+)m([\d\.]+)s  \s+  (\d+)m([\d\.]+)s  \s*
+        (\d+)m([\d\.]+)s  \s+  (\d+)m([\d\.]+)s  \s*
+        \s+
+        CBRAIN\sTask\sCPU\sTimes\sEnd
+       /x
+
+    (walltime,
+     user_loc_m, user_loc_s, syst_loc_m, syst_loc_s,
+     user_tot_m, user_tot_s, syst_tot_m, syst_tot_s) = Regexp.last_match[1..8]
+
+    user_loc = (user_loc_m.to_i * 60.0) + user_loc_s.to_f
+    syst_loc = (syst_loc_m.to_i * 60.0) + syst_loc_s.to_f
+    user_tot = (user_tot_m.to_i * 60.0) + user_tot_s.to_f
+    syst_tot = (syst_tot_m.to_i * 60.0) + syst_tot_s.to_f
+
+    {
+      :walltime => walltime,
+      :user_loc => user_loc, # cpu time of wrapper process only, not useful
+      :syst_loc => syst_loc, # cpu time of wrapper process only, not useful
+      :user_tot => user_tot, # cpu time of wrapper and subprocesses
+      :syst_tot => syst_tot, # cpu time of wrapper and subprocesses
+    }
   end
 
   # Checks that the content of some output file properly
@@ -2560,6 +2609,56 @@ chmod o+x . .. ../.. ../../..
     return true if ClusterTask.descendants.include? self.class
     self.errors.add(:base, "is not a proper subclass of ClusterTask.")
     false
+  end
+
+  protected
+
+  # Add up CPU usage when a task goes to "Data Ready" state
+  def track_resource_usage_cpu(prevstate) #:nodoc:
+    task_workdir = self.full_cluster_workdir
+    return unless task_workdir.present?
+
+    qsub_file = Pathname.new(task_workdir) + qsub_stdout_basename
+    num_seconds_info = extract_cpu_times_from_qsub_wrapper(qsub_file)
+    return unless num_seconds_info.present?
+
+    cpu_time  = num_seconds_info[:user_tot] + num_seconds_info[:syst_tot]
+
+    CputimeResourceUsageForCbrainTask.create(
+      :value              => cpu_time,
+      :user_id            => self.user_id,
+      :group_id           => self.group_id,
+      :cbrain_task_id     => self.id,
+      :remote_resource_id => self.bourreau_id,
+      :tool_id            => self.tool.id,
+      :tool_config_id     => self.tool_config_id,
+    )
+
+    wall_time = num_seconds_info[:walltime]
+
+    WalltimeResourceUsageForCbrainTask.create(
+      :value              => wall_time,
+      :user_id            => self.user_id,
+      :group_id           => self.group_id,
+      :cbrain_task_id     => self.id,
+      :remote_resource_id => self.bourreau_id,
+      :tool_id            => self.tool.id,
+      :tool_config_id     => self.tool_config_id,
+    )
+  end
+
+  # Add a task workdir size and the status of a task that reach
+  # a final status.
+  def track_resource_usage_final(prevstate) #:nodoc:
+    SpaceResourceUsageForCbrainTask.create(
+      :value              => self.cluster_workdir_size, # just FYI
+      :user_id            => self.user_id,
+      :group_id           => self.group_id,
+      :cbrain_task_id     => self.id,
+      :remote_resource_id => self.bourreau_id,
+      :tool_id            => self.tool.id,
+      :tool_config_id     => self.tool_config_id,
+    )
   end
 
 end

--- a/BrainPortal/app/models/cputime_resource_usage_for_cbrain_task.rb
+++ b/BrainPortal/app/models/cputime_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,29 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks increases of time usage for cbrain tasks
+class CputimeResourceUsageForCbrainTask < TimeResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+end
+

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -241,6 +241,9 @@ class DataProvider < ApplicationRecord
   belongs_to              :group
   has_many                :userfiles, :dependent => :restrict_with_exception
 
+  # Resource usage is kept forever even if data provider is destroyed.
+  has_many                :resource_usage
+
   api_attr_visible        :name, :type, :user_id, :group_id, :online, :read_only, :description
 
   # A class to represent a file accessible through SFTP or available locally.

--- a/BrainPortal/app/models/group.rb
+++ b/BrainPortal/app/models/group.rb
@@ -60,6 +60,9 @@ class Group < ApplicationRecord
   belongs_to              :site, :optional => true
   belongs_to              :creator, :class_name => "User", :optional => true
 
+  # Resource usage is kept forever even if group is destroyed.
+  has_many                :resource_usage
+
   api_attr_visible        :name, :description, :type, :site_id, :invisible
 
   # Returns the unique and special group 'everyone'

--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -97,6 +97,9 @@ class RemoteResource < ApplicationRecord
   belongs_to            :group
   has_many              :sync_status
 
+  # Resource usage is kept forever even if remote resource is destroyed.
+  has_many              :resource_usage
+
   after_destroy         :after_destroy_clean_sync_status
 
 

--- a/BrainPortal/app/models/resource_usage.rb
+++ b/BrainPortal/app/models/resource_usage.rb
@@ -1,0 +1,91 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks creation, delete, increases and decreases of various
+# resources (e.g. bytes for userfiles, seconds for tasks etc)
+# Summing values for incompatible types are of course meaningless.
+class ResourceUsage < ApplicationRecord
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  self.table_name = 'resource_usage' # no pluralize here!
+
+  cbrain_abstract_model! # objects of this class are not to be instanciated
+
+  validates_presence_of :value
+
+  belongs_to            :user,            optional: true
+  belongs_to            :group,           optional: true
+  belongs_to            :userfile,        optional: true
+  belongs_to            :data_provider,   optional: true
+  belongs_to            :cbrain_task,     optional: true
+  belongs_to            :remote_resource, optional: true
+  belongs_to            :tool,            optional: true
+  belongs_to            :tool_config,     optional: true
+
+  before_save :record_names_and_types
+
+  # If any of the "_id" attributes are provided,
+  # the we also automatically fill in the duplicated
+  # information that we keep about the associated object.
+  def record_names_and_types #:nodoc:
+    if self.user
+      self.user_type            ||= self.user.type
+      self.user_login           ||= self.user.login
+    end
+
+    if self.group
+      self.group_type           ||= self.group.type
+      self.group_name           ||= self.group.name
+    end
+
+    if self.userfile
+      self.userfile_type        ||= self.userfile.type
+      self.userfile_name        ||= self.userfile.name
+      self.data_provider_id     ||= self.userfile.data_provider.id
+    end
+
+    if self.data_provider
+      self.data_provider_type   ||= self.data_provider.type
+      self.data_provider_name   ||= self.data_provider.name
+    end
+
+    if self.cbrain_task
+      self.cbrain_task_type     ||= self.cbrain_task.type
+      self.cbrain_task_status   ||= self.cbrain_task.status
+    end
+
+    if self.remote_resource
+      self.remote_resource_name ||= self.remote_resource.name
+    end
+
+    if self.tool
+      self.tool_name            ||= self.tool.name
+    end
+
+    if self.tool_config
+      self.tool_config_version_name ||= self.tool_config.version_name
+    end
+  end
+
+end
+

--- a/BrainPortal/app/models/resource_usage.rb
+++ b/BrainPortal/app/models/resource_usage.rb
@@ -45,7 +45,7 @@ class ResourceUsage < ApplicationRecord
   before_save :record_names_and_types
 
   # If any of the "_id" attributes are provided,
-  # the we also automatically fill in the duplicated
+  # then we also automatically fill in the duplicated
   # information that we keep about the associated object.
   def record_names_and_types #:nodoc:
     if self.user

--- a/BrainPortal/app/models/space_resource_usage.rb
+++ b/BrainPortal/app/models/space_resource_usage.rb
@@ -1,0 +1,32 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks creation, delete, increases and decreases of various disk space resources.
+# Abstract class, more specific subclasses are to be used.
+class SpaceResourceUsage < ResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  cbrain_abstract_model! # objects of this class are not to be instanciated
+
+end
+

--- a/BrainPortal/app/models/space_resource_usage_for_cbrain_task.rb
+++ b/BrainPortal/app/models/space_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,29 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks the task workdir size for a task in a FINAL status
+class SpaceResourceUsageForCbrainTask < SpaceResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+end
+

--- a/BrainPortal/app/models/space_resource_usage_for_userfile.rb
+++ b/BrainPortal/app/models/space_resource_usage_for_userfile.rb
@@ -1,0 +1,29 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks creation, delete, increases and decreases of disk space resources for userfiles.
+class SpaceResourceUsageForUserfile < SpaceResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+end
+

--- a/BrainPortal/app/models/time_resource_usage.rb
+++ b/BrainPortal/app/models/time_resource_usage.rb
@@ -1,0 +1,34 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks creation, delete, increases and decreases of various time resources.
+# Abstract class, more specific subclasses are to be used.
+#
+# I doubt we'll ever get negative consumption values...
+class TimeResourceUsage < ResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  cbrain_abstract_model! # objects of this class are not to be instanciated
+
+end
+

--- a/BrainPortal/app/models/tool.rb
+++ b/BrainPortal/app/models/tool.rb
@@ -57,6 +57,9 @@ class Tool < ApplicationRecord
   has_many                :tool_configs, :dependent => :destroy
   has_many                :bourreaux, -> { distinct }, :through => :tool_configs
 
+  # Resource usage is kept forever even if tool is destroyed.
+  has_many                :resource_usage
+
   api_attr_visible        :name, :user_id, :group_id, :category, :description, :url
 
   # Returns the single ToolConfig object that describes the configuration

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -45,6 +45,8 @@ class ToolConfig < ApplicationRecord
   belongs_to      :group
   belongs_to      :container_image, :class_name => 'Userfile', :foreign_key => :container_image_userfile_id, :optional => true
 
+  # Resource usage is kept forever even if tool config is destroyed.
+  has_many        :resource_usage
 
   # first character must be alphanum, and can contain only alphanums, '.', '-', '_', ':' and '@'
   # must be unique per pair [tool, server]

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -106,6 +106,9 @@ class User < ApplicationRecord
   has_many                :custom_filters,  :dependent => :destroy
   has_many                :exception_logs,  :dependent => :destroy
 
+  # Resource usage is kept forever even if account is destroyed.
+  has_many                :resource_usage
+
   api_attr_visible :login, :full_name, :email, :type, :site_id, :time_zone, :city, :last_connected_at, :account_locked
 
   # Returns the admin user

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -1031,11 +1031,12 @@ class Userfile < ApplicationRecord
     delta = self.size - (prev_value || 0)
     return true if delta == 0
     SpaceResourceUsageForUserfile.create(
-      :value            => delta,
-      :user_id          => self.user_id,
-      :group_id         => self.group_id,
-      :userfile_id      => self.id,
-      :data_provider_id => self.data_provider_id,
+      :value              => delta,
+      :user_id            => self.user_id,
+      :group_id           => self.group_id,
+      :userfile_id        => self.id,
+      :data_provider_id   => self.data_provider_id,
+      :remote_resource_id => RemoteResource.current_resource.id,
    )
    true
   end
@@ -1044,11 +1045,12 @@ class Userfile < ApplicationRecord
   def track_resource_usage_destroy #:nodoc:
     return true unless self.id && self.size && self.size > 0
     SpaceResourceUsageForUserfile.create(
-      :value            => -(self.size),
-      :user_id          => self.user_id,
-      :group_id         => self.group_id,
-      :userfile_id      => self.id,
-      :data_provider_id => self.data_provider_id,
+      :value              => -(self.size),
+      :user_id            => self.user_id,
+      :group_id           => self.group_id,
+      :userfile_id        => self.id,
+      :data_provider_id   => self.data_provider_id,
+      :remote_resource_id => RemoteResource.current_resource.id,
    )
    true
   end

--- a/BrainPortal/app/models/walltime_resource_usage_for_cbrain_task.rb
+++ b/BrainPortal/app/models/walltime_resource_usage_for_cbrain_task.rb
@@ -1,0 +1,29 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2019
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Tracks increases of time usage for cbrain tasks
+class WalltimeResourceUsageForCbrainTask < TimeResourceUsage
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+end
+

--- a/BrainPortal/app/views/layouts/_section_account.html.erb
+++ b/BrainPortal/app/views/layouts/_section_account.html.erb
@@ -50,6 +50,7 @@
           <%= link_to 'Servers', bourreaux_path %><BR>
           <%= link_to 'Tools', tools_path %><BR>
           <%= link_to 'Tool Versions', tool_configs_path %><BR>
+          <%= link_to 'Usage', resource_usage_index_path %><BR>
         <% end %>
       <% end %>
       <% help_url = RemoteResource.current_resource.help_url %>

--- a/BrainPortal/app/views/layouts/_section_menu.html.erb
+++ b/BrainPortal/app/views/layouts/_section_menu.html.erb
@@ -99,6 +99,9 @@
            <li <%= set_selected(params[:controller], :access_profiles) %>>
              <%= link_to 'Profiles', access_profiles_path %>
            </li>
+           <li <%= set_selected(params[:controller], :resource_usage) %>>
+             <%= link_to 'Usage', resource_usage_index_path %>
+           </li>
            <li <%= set_selected(params[:controller], :sites) %>>
              <%= link_to 'Sites', sites_path %>
            </li>

--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -52,7 +52,7 @@
 <p>
 
 <fieldset>
-  <legend>Usage Summary</legend>
+  <legend>Table Description</legend>
   <p class="medium_paragraphs">
   This is a <em>very wide</em> report table. It contains
   resource usage records for disk space and time consumed.
@@ -79,7 +79,12 @@
   If a resource was destroyed (e.g. a non-<strong>Cached</strong> column is empty), these stay behind
   and provide filtering options. It makes it possible to compute resource usage reports for
   deleted resources.
-  <p>
+</fieldset>
+
+<p>
+
+<fieldset>
+  <legend>Usage Summary (including filters)</legend>
 
   <%= pluralize @resource_usages.total_entries, "usage record" %>:
   <%= pretty_resource_usage_value(@maintype.constantize.new(:value => @total_plus)) %>
@@ -156,14 +161,8 @@
         :sortable => false,
       ) { |ru| link_to_userfile_if_accessible(ru.userfile) }
     else
-      t.column("Task Type", :cbrain_task,
-        :sortable => true,
-        :filters  => scoped_filters_for(
-          @base_scope, @base_scope, :cbrain_task_id,
-          scope: @scope,
-          label: 'cbrain_tasks.type',
-          association: [CbrainTask, 'id', 'cbrain_task_id']
-        )
+      t.column("Task", :cbrain_task,
+        :sortable => false,
       ) do |ru|
         task = ru.cbrain_task
         if task
@@ -253,7 +252,19 @@
 
       t.column("Cached Task Type", :cbrain_task_type,
         :sortable => true,
-        :filters  => default_filters_for(@base_scope, :cbrain_task_type)
+        :filters  => scoped_filters_for(
+          @base_scope, @scope, :cbrain_task_type,
+          format: lambda do |format_info|
+            value, label, base, view = *format_info
+            label = label.sub(/^CbrainTask::/,"")
+            {
+              :value     => value,
+              :label     => "#{label} (of #{base})",
+              :indicator => view,
+              :empty     => view == 0
+            }
+          end
+        )
       ) { |ru| (ru.cbrain_task_type || "").sub(/CbrainTask::/,"") }
 
       t.column("Cached Task Status", :cbrain_task_status,
@@ -278,7 +289,7 @@
       t.column("Version", :tool_config,
         :sortable => true,
         :filters  => scoped_filters_for(
-          @base_scope, @base_scope, :tool_config_id,
+          @base_scope, @view_scope, :tool_config_id,
           scope: @scope,
           label: 'tool_configs.version_name',
           association: [ToolConfig, 'id', 'tool_config_id']

--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -87,6 +87,13 @@
   <% if @total_plus > 0 && @total_minus < 0 %>
     (Total: <%= pretty_resource_usage_value(@maintype.constantize.new(:value => @total)) %>)
   <% end %>
+  <% if @resource_usages.total_entries > 1 %>
+    (Average: <%= pretty_resource_usage_value(
+                    @maintype.constantize.new(
+                     :value => (@total.to_f / @resource_usages.total_entries.to_f)
+                    )
+                  ) %>)
+  <% end %>
 </fieldset>
 
 <%=

--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -1,0 +1,290 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title @maintype =~ /Userfile/    ? 'File Deltas'      :
+         @maintype =~ /Cputime/     ? 'Task CPU times'   :
+         @maintype =~ /Walltime/    ? 'Task Walltimes'   :
+         @maintype =~ /Space.*Task/ ? 'Task Final Space' : "" %>
+
+<div class="menu_bar">
+  <% buttons =
+     [ [ 'Userfile Disk Space', 'SpaceResourceUsageForUserfile'      ],
+       [ 'Task CPU Time',       'CputimeResourceUsageForCbrainTask'  ],
+       [ 'Task Walltime',       'WalltimeResourceUsageForCbrainTask' ],
+       [ 'Task Final Status',   'SpaceResourceUsageForCbrainTask'    ],
+     ]
+  %>
+
+  <% buttons.each do |pair|
+       button_label, maintype = pair
+  %>
+    <%= link_to button_label,
+        url_for(scope_filter_params(@scope, :set, {
+          :attribute => 'type',
+          :value     => maintype,
+        })),
+        :class => "button menu_button"
+    %>
+  <% end %>
+</div>
+
+<p>
+
+<fieldset>
+  <legend>Usage Summary</legend>
+  <p class="medium_paragraphs">
+  This is a <em>very wide</em> report table. It contains
+  resource usage records for disk space and time consumed.
+  Feel free to hide columns using the <strong>+</strong>
+  menu at the left side of the main table header.
+  <p class="medium_paragraphs">
+  <% if    @maintype == 'SpaceResourceUsageForUserfile'      %>
+    It displays the <span color="green">changes of the sizes</span> of all the files,
+    existing as well as deleted.
+  <% elsif @maintype == 'CputimeResourceUsageForCbrainTask'  %>
+    It displays the <span color="green">CPU time</span> accumulated by tasks.
+  <% elsif @maintype == 'WalltimeResourceUsageForCbrainTask' %>
+    It displays the <span color="green">'wall' time</span> accumulated by tasks.
+  <% elsif @maintype == 'SpaceResourceUsageForCbrainTask'    %>
+    It displays the <span color="green">disk space</span> in the work directory,
+    as well as the <span color="green">final status</span> of past tasks. The disk space
+    is not garanteed to be accurate, as this is a expensive resource to compute
+    and is only provided FYI. The main purpose of this report is to compare the
+    final <strong>status</strong>.
+  <% end %>
+  <p class="medium_paragraphs">
+  Columns labeled <strong>Cached</strong> record pieces of information
+  about resources <em>as they were at the time the record was made</em>.
+  If a resource was destroyed (e.g. a non-<strong>Cached</strong> column is empty), these stay behind
+  and provide filtering options. It makes it possible to compute resource usage reports for
+  deleted resources.
+  <p>
+
+  <%= pluralize @resource_usages.total_entries, "usage record" %>:
+  <%= pretty_resource_usage_value(@maintype.constantize.new(:value => @total_plus)) %>
+  <%= pretty_resource_usage_value(@maintype.constantize.new(:value => @total_minus)) if @total_minus < 0 %>
+  <% if @total_plus > 0 && @total_minus < 0 %>
+    (Total: <%= pretty_resource_usage_value(@maintype.constantize.new(:value => @total)) %>)
+  <% end %>
+</fieldset>
+
+<%=
+  scope_minus_type = @scope.dup
+  scope_minus_type.filters.reject! { |f| f.attribute == 'type' }
+  render(:partial => 'shared/active_filters', :locals  => {
+    :scope => scope_minus_type,
+    :model => ResourceUsage,
+  })
+%>
+
+<div class="pagination"></div>
+
+<%=
+  dynamic_scoped_table(@resource_usages,
+    :id    => 'resource_usage_dynamic_table',
+    :class => [ :resource_list ],
+    :scope => @scope,
+    :order_map         => {
+      :user            => { :a => 'users.name',               :j => User           },
+      :group           => { :a => 'groups.name',              :j => Group          },
+      :data_provider   => { :a => 'data_providers.name',      :j => DataProvider   },
+      :remote_resource => { :a => 'remote_resources.name',    :j => RemoteResource },
+      :tool            => { :a => 'tools.name',               :j => Tool           },
+      :tool_config     => { :a => 'tool_config.version_name', :j => ToolConfig     },
+    },
+    :filter_map        => {
+      :user            => { :a => 'user_id'             },
+      :group           => { :a => 'group_id'            },
+      :data_provider   => { :a => 'data_provider_id'    },
+      :remote_resource => { :a => 'remote_resource_id'  },
+      :tool            => { :a => 'tool_id'             },
+      :tool_config     => { :a => 'tool_config_id'      },
+    },
+  ) do |t|
+%>
+  <%
+    t.pagination
+
+    #t.column("Usage Type", :type)
+
+    t.column("Date", :created_at,
+      :sortable => true,
+    ) do |ru|
+      html_tool_tip(to_localtime(ru.created_at, :datetime), :offset_x => 0, :offset_y => 20) do
+        (ru.created_at.in_time_zone.strftime("%a %b %d, %Y at %H:%M:%S %Z") + "<br>" +
+         pretty_elapsed(Time.now - ru.created_at, :num_components => 2) + " ago").html_safe
+      end
+    end
+
+    # --- Main Values ---
+
+    t.column((@maintype =~ /Space/ ? "Disk Space" : "Time"),
+      :value,
+      :sortable => true,
+    ) { |ru| pretty_resource_usage_value(ru) }
+
+    if @maintype =~ /ForUserfile/
+      t.column("Userfile", :userfile,
+        :sortable => false,
+      ) { |ru| link_to_userfile_if_accessible(ru.userfile) }
+    else
+      t.column("Task Type", :cbrain_task,
+        :sortable => true,
+        :filters  => scoped_filters_for(
+          @base_scope, @base_scope, :cbrain_task_id,
+          scope: @scope,
+          label: 'cbrain_tasks.type',
+          association: [CbrainTask, 'id', 'cbrain_task_id']
+        )
+      ) do |ru|
+        task = ru.cbrain_task
+        if task
+          link_to_task_if_accessible(ru.cbrain_task, nil, :name => ru.cbrain_task.pretty_name) +
+          "&nbsp;".html_safe +
+          "(" + colored_status(task.status) + ")"
+        end
+      end
+    end
+
+
+    # --- Common Columns: User, Group, Server ---
+
+    t.column("Owner", :user,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, User)
+    ) { |ru| link_to_user_if_accessible(ru.user) }
+
+    t.column("Project", :group,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, Group)
+    ) { |ru| link_to_group_if_accessible(ru.group) }
+
+    t.column("Server", :remote_resource,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, RemoteResource)
+    ) { |ru| link_to_bourreau_if_accessible(ru.remote_resource) }
+
+    t.column("Cached Owner Type", :user_type,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, :user_type)
+    )
+
+    t.column("Cached Owner Login", :user_login,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, :user_login)
+    )
+
+    t.column("Cached Project Type", :group_type,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, :group_type)
+    )
+
+    t.column("Cached Project Name", :group_name,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, :group_name)
+    )
+
+    t.column("Cached Server Name", :remote_resource_name,
+      :sortable => true,
+      :filters  => default_filters_for(@base_scope, :remote_resource_name)
+    )
+
+    if @maintype =~ /ForUserfile/
+
+      # --- Userfile Columns ---
+
+      t.column("Cached Userfile Type", :userfile_type,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :userfile_type)
+      )
+
+      t.column("Cached Userfile Name", :userfile_name,
+        :sortable => true,
+      )
+
+      # --- DataProvider Columns ---
+
+      t.column("Provider", :data_provider,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, DataProvider)
+      ) { |ru| link_to_data_provider_if_accessible(ru.data_provider) }
+
+      t.column("Cached Provider Type", :data_provider_type,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :data_provider_type)
+      )
+
+      t.column("Cached Provider Name", :data_provider_name,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :data_provider_name)
+      )
+
+    elsif @maintype =~ /ForCbrainTask/
+
+      # --- CbrainTask Columns ---
+
+      t.column("Cached Task Type", :cbrain_task_type,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :cbrain_task_type)
+      ) { |ru| (ru.cbrain_task_type || "").sub(/CbrainTask::/,"") }
+
+      t.column("Cached Task Status", :cbrain_task_status,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :cbrain_task_status)
+      ) { |ru| colored_status(ru.cbrain_task_status) }
+
+      # --- Tool Columns ---
+
+      t.column("Tool", :tool,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, Tool)
+      ) { |ru| ru.tool ? link_to(ru.tool.name, tool_path(ru.tool.id)) : "" }
+
+      t.column("Cached Tool Name", :tool_name,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :tool_name)
+      )
+
+      # --- ToolConfig Columns ---
+
+      t.column("Version", :tool_config,
+        :sortable => true,
+        :filters  => scoped_filters_for(
+          @base_scope, @base_scope, :tool_config_id,
+          scope: @scope,
+          label: 'tool_configs.version_name',
+          association: [ToolConfig, 'id', 'tool_config_id']
+        )
+      ) { |ru| ru.tool_config ? link_to(ru.tool_config.version_name, tool_config_path(ru.tool_config)) : "" }
+
+      t.column("Cached Version", :tool_config_version_name,
+        :sortable => true,
+        :filters  => default_filters_for(@base_scope, :tool_config_version_name)
+      )
+
+    end
+
+  %>
+
+<% end %>

--- a/BrainPortal/app/views/resource_usage/index.html.erb
+++ b/BrainPortal/app/views/resource_usage/index.html.erb
@@ -1,0 +1,30 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Resource Usage' %>
+
+<div id="resource_usage_table" class="index_block">
+  <%= render :partial => 'resource_usage_table' %>
+</div>
+

--- a/BrainPortal/app/views/resource_usage/index.js.erb
+++ b/BrainPortal/app/views/resource_usage/index.js.erb
@@ -1,0 +1,27 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2012
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<%= render :partial  => "shared/flash_update" %>
+jQuery("#resource_usage_table").html(<%= html_for_js(render(:partial => 'resource_usage_table')) %>).trigger("new_content")
+

--- a/BrainPortal/app/views/tasks/_resource_usage.html.erb
+++ b/BrainPortal/app/views/tasks/_resource_usage.html.erb
@@ -1,0 +1,47 @@
+
+<% rus = ResourceUsage.where(:cbrain_task_id => @task.id).all.to_a %>
+<% if rus.present? %>
+  <fieldset>
+    <legend>Resource Usage History</legend>
+    <table class="simple">
+      <tr>
+        <th>Date</th>
+        <th>Task Status</th>
+        <th>Usage Type</th>
+        <th>Time Used</th>
+        <th>Disk Space Used</th>
+      </tr>
+      <% rus.each do |ru| %>
+        <% type = ru.is_a?(CputimeResourceUsageForCbrainTask)  ? "CPU"        :
+                  ru.is_a?(WalltimeResourceUsageForCbrainTask) ? "Walltime"   :
+                  ru.is_a?(SpaceResourceUsageForCbrainTask)    ? "Disk Space" :
+                  "Unknown"
+        %>
+        <tr>
+          <td><%= pretty_past_date ru.created_at %></td>
+          <td><%= ru.cbrain_task_status.present? ? colored_status(ru.cbrain_task_status) : "-" %></td>
+          <td><%= type %></td>
+
+          <% if type =~ /CPU|Walltime/ %>
+            <td><%= pluralize(ru.value, "second") %>
+              <% if ru.value > 59 %>
+                (<%= pretty_elapsed(ru.value, :num_components => 3) %>)
+              <% end %>
+            </td>
+          <% else %>
+            <td></td>
+          <% end %>
+
+          <% if type =~ /Disk/ %>
+            <td><%= colored_pretty_size(ru.value) %></td>
+          <% else %>
+            <td></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </table>
+  </fieldset>
+
+  <br>
+<% end %>
+

--- a/BrainPortal/app/views/tasks/_resource_usage.html.erb
+++ b/BrainPortal/app/views/tasks/_resource_usage.html.erb
@@ -23,20 +23,17 @@
           <td><%= type %></td>
 
           <% if type =~ /CPU|Walltime/ %>
-            <td><%= pluralize(ru.value, "second") %>
-              <% if ru.value > 59 %>
-                (<%= pretty_elapsed(ru.value, :num_components => 3) %>)
-              <% end %>
-            </td>
+            <td><%= pretty_resource_usage_value(ru) %></td>
           <% else %>
             <td></td>
           <% end %>
 
           <% if type =~ /Disk/ %>
-            <td><%= colored_pretty_size(ru.value) %></td>
+            <td><%= pretty_resource_usage_value(ru) %></td>
           <% else %>
             <td></td>
           <% end %>
+
         </tr>
       <% end %>
     </table>

--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -257,6 +257,9 @@
   <% end %>
 
 
+  <%= render :partial => 'resource_usage' %>
+
+
 
   <%
     prettystdout = @task.cluster_stdout || "(None)"

--- a/BrainPortal/app/views/userfiles/_resource_usage.html.erb
+++ b/BrainPortal/app/views/userfiles/_resource_usage.html.erb
@@ -1,0 +1,29 @@
+
+<% rus = @userfile.resource_usage.all.to_a %>
+<% unless rus.empty? %>
+  <%= build_accordion do |acc| %>
+    <%= acc.section "Disk Space History" do %>
+      <table class="simple">
+        <tr>
+          <th>Date</th>
+          <th>Space Delta</th>
+        </tr>
+        <% rus.each do |ru| %>
+          <tr>
+            <td><%= pretty_past_date ru.created_at %></td>
+            <td>
+              <% if ru.value > 0 %>
+                <span color="green">+</span>
+                <%= colored_pretty_size(ru.value) %>
+              <% else %>
+                <span color="red">-</span>
+                <%= colored_pretty_size(-(ru.value)) %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </table>
+    <% end %>
+  <% end %>
+<% end %>
+

--- a/BrainPortal/app/views/userfiles/_resource_usage.html.erb
+++ b/BrainPortal/app/views/userfiles/_resource_usage.html.erb
@@ -11,15 +11,7 @@
         <% rus.each do |ru| %>
           <tr>
             <td><%= pretty_past_date ru.created_at %></td>
-            <td>
-              <% if ru.value > 0 %>
-                <span color="green">+</span>
-                <%= colored_pretty_size(ru.value) %>
-              <% else %>
-                <span color="red">-</span>
-                <%= colored_pretty_size(-(ru.value)) %>
-              <% end %>
-            </td>
+            <td><%= pretty_resource_usage_value(ru) %></td>
           </tr>
         <% end %>
       </table>

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -274,4 +274,6 @@
 
 <P>
 <%= render :partial => "layouts/log_report", :locals  => { :log  => @log, :title => 'File Log' } %>
+<p>
+<%= render :partial => "resource_usage" %>
 

--- a/BrainPortal/config/initializers/inflections.rb
+++ b/BrainPortal/config/initializers/inflections.rb
@@ -5,6 +5,7 @@ ActiveSupport::Inflector.inflections(:en) do |inflect|
 
   # CBRAIN Added inflections
   inflect.irregular 'bourreau', 'bourreaux'
-  inflect.irregular 'status', 'status'
+  inflect.irregular 'status',   'status'
+  inflect.irregular 'usage',    'usage'
 end
 

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
   # Documentation
   resources :docs,            :except => [ :edit ], :controller => :help_documents
 
+  # ResourceUsage
+  resources :resource_usage,  :only => [ :index ]
+
   # Standard CRUD resources
   resources :sites,           :except => [ :edit ]
   resources :custom_filters,  :except => [ :index ]

--- a/BrainPortal/db/migrate/20190913174022_add_resource_usage_table.rb
+++ b/BrainPortal/db/migrate/20190913174022_add_resource_usage_table.rb
@@ -1,0 +1,49 @@
+class AddResourceUsageTable < ActiveRecord::Migration[5.0]
+
+  def change
+    create_table :resource_usage do |t|
+
+      # Type indicate what type of resource and action
+      t.string  :type      # for single table inheritance
+
+      # The value being tracked
+      t.decimal :value, precision: 24
+
+      # Owner and/or group that used the value
+      t.integer :user_id,                  :optional => true
+      t.string  :user_type,                :optional => true
+      t.string  :user_login,               :optional => true
+      t.integer :group_id,                 :optional => true
+      t.string  :group_type,               :optional => true
+      t.string  :group_name,               :optional => true
+
+      # Userfile attributes. If id is present it has priority;
+      # otherwise the local name and type can be used.
+      t.integer :userfile_id,              :optional => true
+      t.string  :userfile_type,            :optional => true
+      t.string  :userfile_name,            :optional => true
+
+      t.string  :data_provider_id,         :optional => true
+      t.string  :data_provider_type,       :optional => true
+      t.string  :data_provider_name,       :optional => true
+
+      # CbrainTask attributes. If id is present it has priority;
+      # otherwise the locally stored attributes can be used.
+      t.integer :cbrain_task_id,           :optional => true
+      t.string  :cbrain_task_type,         :optional => true
+      t.string  :cbrain_task_status,       :optional => true
+
+      t.integer :remote_resource_id,       :optional => true
+      t.string  :remote_resource_name,     :optional => true
+
+      t.integer :tool_id,                  :optional => true
+      t.string  :tool_name,                :optional => true
+
+      t.integer :tool_config_id,           :optional => true
+      t.string  :tool_config_version_name, :optional => true
+
+      t.datetime :created_at,              :null     => false
+    end
+  end
+
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -254,6 +254,33 @@ ActiveRecord::Schema.define(version: 20190828200502) do
     t.index ["type"], name: "index_remote_resources_on_type", using: :btree
   end
 
+  create_table "resource_usage", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "type"
+    t.decimal  "value",                    precision: 24
+    t.integer  "user_id"
+    t.string   "user_type"
+    t.string   "user_login"
+    t.integer  "group_id"
+    t.string   "group_type"
+    t.string   "group_name"
+    t.integer  "userfile_id"
+    t.string   "userfile_type"
+    t.string   "userfile_name"
+    t.string   "data_provider_id"
+    t.string   "data_provider_type"
+    t.string   "data_provider_name"
+    t.integer  "cbrain_task_id"
+    t.string   "cbrain_task_type"
+    t.string   "cbrain_task_status"
+    t.integer  "remote_resource_id"
+    t.string   "remote_resource_name"
+    t.integer  "tool_id"
+    t.string   "tool_name"
+    t.integer  "tool_config_id"
+    t.string   "tool_config_version_name"
+    t.datetime "created_at",                              null: false
+  end
+
   create_table "sanity_checks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "revision_info"
     t.datetime "created_at"

--- a/BrainPortal/public/stylesheets/tablesorter_themes/blue/style.css
+++ b/BrainPortal/public/stylesheets/tablesorter_themes/blue/style.css
@@ -14,7 +14,7 @@ table.tablesorter thead tr th, table.tablesorter tfoot tr th {
 	padding: 4px;
 }
 table.tablesorter thead tr .header {
-	background-image: url(bg.gif);
+	background-image: url(/stylesheets/tablesorter_themes/blue/bg.gif);
 	background-repeat: no-repeat;
 	background-position: center right;
 	cursor: pointer;
@@ -29,10 +29,10 @@ table.tablesorter tbody tr.odd td {
 	background-color:#F0F0F6;
 }
 table.tablesorter thead tr .headerSortUp {
-	background-image: url(asc.gif);
+	background-image: url(/stylesheets/tablesorter_themes/blue/asc.gif);
 }
 table.tablesorter thead tr .headerSortDown {
-	background-image: url(desc.gif);
+	background-image: url(/stylesheets/tablesorter_themes/blue/desc.gif);
 }
 table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSortUp {
 background-color: #8dbdd8;


### PR DESCRIPTION
We have a now a generic structure for recording resource usage changes.
It is an ActiveRecord of class ResourceUsage, with several subclasses:

```
  ResourceUsage (abstract)
  |
  +- SpaceResourceUsage (abstract)
  |   |
  |   +- SpaceResourceUsageForCbrainTask
  |   |
  |   +- SpaceResourceUsageForUserfile
  |
  +- TimeResourceUsage (abstract)
      |
      +- CputimeResourceUsageForCbrainTask
      |
      +- WalltimeResourceUsageForCbrainTask
```

* Whenever a file's size is updated, one SpaceResourceUsageForUserfile
  is created.

* Whenever a task transitions to 'Data Ready', one
  WalltimeResourceUsageForCbrainTask will be created and one
  CputimeResourceUsageForCbrainTask will be created.

* Whenever a task reach a final state, one SpaceResourceUsageForCbrainTask
  record will be created.

All records contain optional associations to the userfiles, tasks,
tools, tool_configs etc. For all of these assocations, because we
want to keep the usage information even after the associated abject
is deleted, we also keep a full copy of some attributes. E.g. for
a task, we keep its type, its status, its tool name, etc.

For the moment, the migration doesn't include the creation of any indexes.