### PR TITLE
Added JSON file and inline content-disposition

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -253,7 +253,7 @@ class UserfilesController < ApplicationController
       end
     else
       @userfile.sync_to_cache
-      send_file @userfile.cache_full_path, :stream => true, :filename => @userfile.name
+      send_file @userfile.cache_full_path, :stream => true, :filename => @userfile.name, :disposition => (params[:disposition] || "attachment")
     end
   rescue
     respond_to do |format|

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/json_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/json_file.rb
@@ -1,3 +1,4 @@
+
 #
 # CBRAIN Project
 #
@@ -18,3 +19,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+# Model for text files containing JSON structures.
+class JsonFile < TextFile
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  has_viewer :name => 'JSON raw content', :partial => :json_raw
+
+  def self.file_name_pattern #:nodoc:
+    /\.json\z/i
+  end
+
+end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/views/_json_raw.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/views/_json_raw.html.erb
@@ -5,5 +5,5 @@ Some modern browsers have a built-in JSON viewer.
 <p>
 
 <%= link_to "Browser-based viewer for JSON content",
-    content_userfile_path(@userfile.id, :disposition => 'inline') %>
+    content_userfile_path(@userfile.id, :disposition => 'inline'), :target => :_blank %>
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/views/_json_raw.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/json_file/views/_json_raw.html.erb
@@ -1,0 +1,9 @@
+<p>
+The link below will open this JSON file directly in your browser.
+<p>
+Some modern browsers have a built-in JSON viewer.
+<p>
+
+<%= link_to "Browser-based viewer for JSON content",
+    content_userfile_path(@userfile.id, :disposition => 'inline') %>
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/views/_xml_raw.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/views/_xml_raw.html.erb
@@ -1,0 +1,9 @@
+<p>
+The link below will open this XML file directly in your browser.
+<p>
+Some modern browsers have a built-in XML viewer.
+<p>
+
+<%= link_to "Browser-based viewer for XML content",
+    content_userfile_path(@userfile.id, :disposition => 'inline') %>
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/views/_xml_raw.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/views/_xml_raw.html.erb
@@ -5,5 +5,5 @@ Some modern browsers have a built-in XML viewer.
 <p>
 
 <%= link_to "Browser-based viewer for XML content",
-    content_userfile_path(@userfile.id, :disposition => 'inline') %>
+    content_userfile_path(@userfile.id, :disposition => 'inline'), :target => :_blank %>
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/xml_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/xml_file/xml_file.rb
@@ -25,6 +25,8 @@ class XMLFile < TextFile
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
+  has_viewer :name => 'XML raw content', :partial => :xml_raw
+
   def self.file_name_pattern #:nodoc:
     /\.xml\z/i
   end


### PR DESCRIPTION
This add support for JSON files in CBRAIN.

Also both XML and JSON files can be viewed in the browser's own viewer (Firefox supports both, Chrome only seems to support XML).