### PR TITLE
Added options for busy loops in diagnostics.

### DIFF
--- a/BrainPortal/app/views/tasks/show.html.erb
+++ b/BrainPortal/app/views/tasks/show.html.erb
@@ -203,7 +203,13 @@
          <% end %>
        <% end %>
        <%= tb.tab("Raw") do %>
-         <pre><%= @task.params.to_yaml :root => "Params" -%></pre>
+         <% yamltext = @task.params.to_yaml(
+                         :root        => "Params", # no longer supported
+                         :indentation => 4,
+                         :line_width  => -1)
+                       .gsub(/!ruby.*/,"") rescue "(Error rendering YAML)"
+         %>
+         <pre><%= yamltext %></pre>
        <% end %>
      <% end %>
   </fieldset>

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/portal/diagnostics.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/portal/diagnostics.rb
@@ -39,6 +39,9 @@ class CbrainTask::Diagnostics < PortalTask
       :cluster_delay         => 0,
       :postpro_delay         => 0,
 
+      :user_busy_loop        => 0,
+      :system_busy_loop      => 0,
+
       :setup_crash           => false,
       :cluster_crash         => false,
       :postpro_crash         => false,
@@ -151,7 +154,7 @@ class CbrainTask::Diagnostics < PortalTask
       task                       = self.dup # not .clone, as of Rails 3.1.10
       task.description           = (desc.blank? ? "" : "#{desc} - ") + "Diagnostics with #{numfiles} files" + (num_copies > 1 ? ", copy #{i+1}." : ".")
       task.params[:copy_number]  = (i + 1)
-      task.params.keys.select { |x| x.to_s =~ /_delay/ }.each do |delay_key|
+      task.params.keys.select { |x| x.to_s =~ /_delay|_busy_loop/ }.each do |delay_key|
         next unless task.params[delay_key].to_s =~ /\A\s*(\d+)\D+(\d+)\s*\z/ #  "3-9" or "3..9" means random between 3 and 9 seconds
         del_from = Regexp.last_match[1].to_i
         del_to   = Regexp.last_match[2].to_i

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/views/_task_params.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/views/_task_params.html.erb
@@ -232,7 +232,20 @@ Toggle all: <%= select_all_checkbox 'dp_check' %>
     Other Options
   </legend>
 
-  <strong>Erase report after it is created: </strong>            <%= form.params_check_box :erase_report %><br>
+  <strong>Erase report after it is created: </strong> <%= form.params_check_box :erase_report %><br>
+  <p>
+  <strong>Busy looping while processing:</strong>
+  <p>
+  <table class="simple">
+    <tr>
+      <th>User CPU:</th>
+      <td><%= form.params_text_field :user_busy_loop, :size => 6 %> seconds</td>
+    </tr>
+    <tr>
+      <th>System CPU:</th>
+      <td><%= form.params_text_field :system_busy_loop, :size => 6 %> seconds</td>
+    </tr>
+  </table>
 </fieldset>
 
 


### PR DESCRIPTION
This will implement #867 .

Works on Linux and macOS (yep, macOS has `/dev/urandom`).