### PR TITLE
Added CPU time to Network Operation Center

### DIFF
--- a/BrainPortal/app/assets/stylesheets/noc.css
+++ b/BrainPortal/app/assets/stylesheets/noc.css
@@ -47,7 +47,7 @@ body {
 
 .noc_count {
   display: inline-block;
-  font-size: 128px;
+  font-size: 96px;
   margin: 0.2em 0.2em 0.6em 0.2em;
   text-shadow: -1px -1px 2px black,
                -1px  1px 2px black,

--- a/BrainPortal/app/views/noc/dashboard.html.erb
+++ b/BrainPortal/app/views/noc/dashboard.html.erb
@@ -24,10 +24,8 @@
 #
 -%>
 
-<% range = @hours_ago.blank? ? "Today" : "Last " + pluralize(@hours_ago,"hour") %>
-<% title "Activity #{range}" %>
-<% title to_localtime(Time.now, :date) %>
-<% title "at " + to_localtime(Time.now, :time) %>
+<% title "Activity #{@range}" %>
+<% title to_localtime(Time.now, :date) + " at " + to_localtime(Time.now, :time) %>
 
 <head>
   <title><%= RemoteResource.current_resource.name.presence || "CBRAIN" %><%= yield :title %></title>
@@ -56,7 +54,7 @@
 
 <div class="noc_main">
   <div class="noc_panel">
-    <div class="noc_header">Users Today</div><br>
+    <div class="noc_header">Users</div><br>
     <div class="noc_count" style="color: <%= num_users_color %>"><%= @active_users %></div>
   </div>
   <div class="noc_panel">
@@ -65,7 +63,23 @@
   </div>
   <div class="noc_panel">
     <div class="noc_header">Active Transfers</div><br>
-    <div class="noc_count"><%= @data_transfer.zero? ? "none" : colored_pretty_size(@data_transfer) %></div>
+    <div class="noc_count"><%= @data_transfer.zero? ? "-" : colored_pretty_size(@data_transfer) %></div>
+  </div>
+  <div class="noc_panel">
+    <div class="noc_header">CPU Time</div><br>
+    <div class="noc_count">
+      <% if @cpu_time.zero? %>
+        -
+      <% else %>
+        <span style="color: <%= colorwheel_edge_crawl(@cpu_time, @num_hours.hours) %>">
+          <%= pretty_elapsed(@cpu_time, :num_components => 2, :short => true) %>
+        </span>
+      <% end %>
+    </div>
+  </div>
+  <div class="noc_panel">
+    <div class="noc_header">Files Deltas</div><br>
+    <div class="noc_count"><%= @space_delta_P.zero? ? "-" : colored_pretty_size(@space_delta_P) %></div>
   </div>
   <% if @num_exceptions > 0 %>
   <div class="noc_panel">

--- a/BrainPortal/app/views/noc/dashboard.html.erb
+++ b/BrainPortal/app/views/noc/dashboard.html.erb
@@ -77,10 +77,12 @@
       <% end %>
     </div>
   </div>
+<!--
   <div class="noc_panel">
     <div class="noc_header">Files Deltas</div><br>
     <div class="noc_count"><%= @space_delta_P.zero? ? "-" : colored_pretty_size(@space_delta_P) %></div>
   </div>
+-->
   <% if @num_exceptions > 0 %>
   <div class="noc_panel">
     <div class="noc_header">Exceptions</div><br>

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -182,7 +182,10 @@ Rails.application.routes.draw do
   get   "/report",                :controller => :portal, :action => :report
 
   # Network Operation Center; daily status (shows everything publicly!)
-  # get   "/noc/daily",             :controller => :noc,    :action => :daily
+  #get   "/noc/daily",             :controller => :noc,    :action => :daily
+  #get   "/noc/weekly",            :controller => :noc,    :action => :weekly
+  #get   "/noc/monthly",           :controller => :noc,    :action => :monthly
+  #get   "/noc/yearly",            :controller => :noc,    :action => :yearly
 
   # API description, by Swagger
   get   "/swagger",               :controller => :portal, :action => :swagger


### PR DESCRIPTION
Also added weekly, monthly and yearly reports,
but they are not as useful. You can make the
display go through daily -> weekly -> monthly
by adding roll=1 in the params.