### PR TITLE
Added script_epilogue to ToolConfig objects.

### DIFF
--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -214,6 +214,7 @@ class ToolConfigsController < ApplicationController
          end
          @tool_config.env_array       += (other_tc.env_array || [])
          @tool_config.script_prologue  = "#{@tool_config.script_prologue}\n#{other_tc.script_prologue}"
+         @tool_config.script_epilogue  = "#{@tool_config.script_epilogue}\n#{other_tc.script_epilogue}"
          flash[:notice] = "Appended info from another Tool Config."
        else
          flash[:notice] = "No changes made."
@@ -233,7 +234,7 @@ class ToolConfigsController < ApplicationController
 
     respond_to do |format|
       new_record = @tool_config.new_record?
-      if @tool_config.save_with_logging(current_user, %w( env_array script_prologue ncpus extra_qsub_args
+      if @tool_config.save_with_logging(current_user, %w( env_array script_prologue script_epilogue ncpus extra_qsub_args
                                                           container_image_userfile_id containerhub_image_name
                                                           container_engine container_index_location ))
         if new_record
@@ -277,7 +278,7 @@ class ToolConfigsController < ApplicationController
 
   def tool_config_params #:nodoc:
     params.require(:tool_config).permit(
-      :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue,
+      :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue, :script_epilogue,
       :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_index_location,
       :container_engine, :extra_qsub_args,
       # The configuration of a tool in a VM managed by a

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -604,11 +604,20 @@ class ClusterTask < CbrainTask
 
     # Build script
     script  = ""
+    # Add prologues in specialization order
     script += bourreau_glob_config.to_bash_prologue if bourreau_glob_config
     script += tool_glob_config.to_bash_prologue     if tool_glob_config
     script += tool_config.to_bash_prologue          if tool_config
+    # Add CBRAIN special inits
     script += self.supplemental_cbrain_tool_config_init
+    # Add the command
     script += "\n\n" + command + "\n\n"
+    # Add epilogues in reverse order
+    script += tool_config.to_bash_epilogue          if tool_config
+    script += tool_glob_config.to_bash_epilogue     if tool_glob_config
+    script += bourreau_glob_config.to_bash_epilogue if bourreau_glob_config
+
+    # Write the temp script
     File.open(scriptfile,"w") { |fh| fh.write(script) }
 
     # Execute and capture
@@ -1795,6 +1804,9 @@ class ClusterTask < CbrainTask
 # CbrainTask '#{self.name}' commands section
 #{command_script}
 
+#{tool_config          ? tool_config.to_bash_epilogue          : ""}
+#{tool_glob_config     ? tool_glob_config.to_bash_epilogue     : ""}
+#{bourreau_glob_config ? bourreau_glob_config.to_bash_epilogue : ""}
     SCIENCE_SCRIPT
     sciencefile = self.science_script_basename.to_s
     File.open(sciencefile,"w") do |io|

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -135,6 +135,26 @@
 
 
 
+  <%= show_table @tool_config, :form_helper => cf, :header => "BASH initialization epilogue",
+                 :edit_condition => check_role(:admin_user) do |t| %>
+
+    <% t.edit_cell(:script_epilogue, :content => full_description(@tool_config.script_epilogue),
+                   :no_header => true) do |f| %>
+      <%= f.text_area :script_epilogue, :cols => 80, :rows => 10 %>
+
+      <p>
+      <div class="wide_field_explanation">
+        This is a multi line partial BASH script, meant to match the prologue above. The code
+        here will be execute after the task's processing code.
+        Note that this script MUST be silent, as outputing text (like in <em>echo</em> statements)
+        could interfere with the proper processing of the tasks output.
+      </div>
+    <% end %>
+
+  <% end %>
+
+
+
   <%= show_table(@tool_config, :form_helper => cf, :header => "Container", :edit_condition => check_role(:admin_user)) do |t| %>
     <% t.edit_cell(:container_engine, :header => "Container engine") do |f| %>
       <%= f.select :container_engine, [["None", ''], ['Docker', 'Docker'], ['Singularity', 'Singularity']], :title => 'Container type' %>

--- a/BrainPortal/app/views/tool_configs/show.html.erb
+++ b/BrainPortal/app/views/tool_configs/show.html.erb
@@ -59,16 +59,25 @@
   <p>
 
   <fieldset>
-    <legend>BASH script prologues</legend>
-    This section displays the full BASH initialization prologue script for the configuration shown above.
+    <legend>BASH scripts wrappers</legend>
+    This section displays the full BASH initialization prologue and epilogue script for the configuration shown above.
     <% if ( (@bourreau_glob_config ? 1 : 0) + (@tool_glob_config ? 1 : 0) + (@tool_config? 1 : 0) ) > 1 %>
-      It is preceded by the BASH prologues of other relevant global configurations.
+      It is surrounded by the BASH prologues or epilogues of other relevant global configurations.
     <% end %>
     The commands are shown in the order of execution.
     <p>
 
     <pre class="script_preview">
-      <%= @bourreau_glob_config.to_bash_prologue if @bourreau_glob_config %><%= @tool_glob_config.to_bash_prologue if @tool_glob_config %><%= @tool_local_config.to_bash_prologue if @tool_local_config %>
+<%= @bourreau_glob_config.to_bash_prologue if @bourreau_glob_config %>
+<%= @tool_glob_config.to_bash_prologue     if @tool_glob_config     %>
+<%= @tool_local_config.to_bash_prologue    if @tool_local_config    %>
+##########################################
+#### [Wrapped commands would be here] ####
+##########################################
+
+<%= @tool_local_config.to_bash_epilogue    if @tool_local_config    %>
+<%= @tool_glob_config.to_bash_epilogue     if @tool_glob_config     %>
+<%= @bourreau_glob_config.to_bash_epilogue if @bourreau_glob_config %>
     </pre>
 
   </fieldset>

--- a/BrainPortal/db/migrate/20191023211144_add_script_epilogue_to_tool_config.rb
+++ b/BrainPortal/db/migrate/20191023211144_add_script_epilogue_to_tool_config.rb
@@ -1,0 +1,5 @@
+class AddScriptEpilogueToToolConfig < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tool_configs, :script_epilogue, :text, :after => :script_prologue
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191002174842) do
+ActiveRecord::Schema.define(version: 20191023211144) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -378,6 +378,7 @@ ActiveRecord::Schema.define(version: 20191002174842) do
     t.integer  "bourreau_id"
     t.text     "env_array",                   limit: 65535
     t.text     "script_prologue",             limit: 65535
+    t.text     "script_epilogue",             limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "group_id"


### PR DESCRIPTION
This will allow a sysadmin to wrap a tool's command
properly. E.g. to switch the UNIX group of the execution:

* In prologue:

sg othergroup bash << 'SwitchUnixGroup'

* In epilogue:

SwitchUnixGroup

This will fix #738 