### PR TITLE
Error message for unmatched collobarators emails issue #953

### DIFF
--- a/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
+++ b/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
@@ -211,6 +211,11 @@ $ERROR_WASH: #fcc2c2;
 $ERROR_ALT: #be4040;
 $ERROR_DK: #85000c;
 
+$WARNING_BG: #FFB97B;
+$WARNING_WASH: #FFF8DC;
+$WARNING_ALT: #FFAA1D;
+$WARNING_DK: #FFA500;
+
 $ORCID_BG: #31789b;
 $ORCID_ALT: #a6ce39;
 
@@ -996,6 +1001,11 @@ $variant : error, notice
     color: $ERROR_DK;
     border: 1px solid $ERROR_ALT;
   }
+  @if ($variant == "warning"){
+    background-color: $WARNING_WASH;
+    color: $WARNING_DK;
+    border: 1px solid $WARNING_ALT;
+  }
 }
 
 .flash_error {
@@ -1007,6 +1017,11 @@ $variant : error, notice
   @include banner("notice");
   @include px(7);
   z-index: 1000;
+}
+
+.flash_warning {
+  @include banner("warning");
+  @include px(7);
 }
 
 /*


### PR DESCRIPTION
Note I not sure is there security risk. While neurohub already make it easy to check is user email in the system, the bugfix makes it easier further. May be not big deal may be something should be done to alleviate, like allow users to keep their emails confidential, not sure.