### PR TITLE
Added new flag to groups: not_assignable. Fixes #962

### DIFF
--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -1118,25 +1118,25 @@ pre {
 .user_project             { background: #500d75; }
 .user_project:active      { background: #500d75; }
 
-.shared_project_point     { color:      #098c09; }
-.shared_project           { background: #098c09; }
-.shared_project:active    { background: #098c09; }
+.shared_project_point     { color:      #00bf09; }
+.shared_project           { background: #00bf09; }
+.shared_project:active    { background: #00bf09; }
 
 .public_project_point     { color:      #9e5400; }
 .public_project           { background: #9e5400; }
 .public_project:active    { background: #9e5400; }
 
-.personal_project_point   { color:      #076969; }
-.personal_project         { background: #076969; }
-.personal_project:active  { background: #076969; }
+.personal_project_point   { color:      #008686; }
+.personal_project         { background: #008686; }
+.personal_project:active  { background: #008686; }
 
-.invisible_project_point  { color:      #70a30a; }
-.invisible_project        { background: #70a30a; }
-.invisible_project:active { background: #70a30a; }
+.invisible_project_point  { color:      #2b97c1; }
+.invisible_project        { background: #2b97c1; }
+.invisible_project:active { background: #2b97c1; }
 
-.empty_project_point      { color:      #16a916; }
-.empty_project            { background: #16a916; }
-.empty_project:active     { background: #16a916; }
+.empty_project_point      { color:      #d7ca0a; }
+.empty_project            { background: #d7ca0a; }
+.empty_project:active     { background: #d7ca0a; }
 
 .giant {
   margin-top: 0.3em;

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -513,8 +513,7 @@ class DataProvidersController < ApplicationController
           :user_id          => @as_user.id,
           :data_provider_id => target_dp.id
         )
-        .raw_first_column('userfiles.name')
-        .to_set
+        .pluck('userfiles.name')
 
       userfiles = registered.reject { |r| collisions.include?(r.name) }
       if collisions.present?

--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -46,7 +46,7 @@ class GroupsController < ApplicationController
     @scope.custom[:button] = true if
       current_user.has_role?(:normal_user) && @scope.custom[:button].nil?
 
-    @base_scope = current_user.assignable_groups.includes(:site)
+    @base_scope = current_user.listable_groups.includes(:site)
     @view_scope = @scope.apply(@base_scope)
 
     @scope.pagination ||= Scope::Pagination.from_hash({ :per_page => 50 })
@@ -256,7 +256,7 @@ class GroupsController < ApplicationController
     elsif params[:id] == "all"
       cbrain_session[:active_group_id] = "all"
     else
-      @group = current_user.viewable_groups
+      @group = current_user.listable_groups
       @group = @group.without_everyone if ! current_user.has_role? :admin_user
       @group = @group.find(params[:id])
       cbrain_session[:active_group_id] = @group.id

--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -284,9 +284,9 @@ class GroupsController < ApplicationController
 
   def group_params #:nodoc:
     if current_user.has_role?(:admin_user)
-      params.require_as_params(:group).permit(:name, :description, :site_id, :creator_id, :invisible, :user_ids => [])
+      params.require_as_params(:group).permit(:name, :description, :not_assignable, :site_id, :creator_id, :invisible, :user_ids => [])
     else
-      params.require_as_params(:group).permit(:name, :description, :user_ids => [])
+      params.require_as_params(:group).permit(:name, :description, :not_assignable, :user_ids => [])
     end
   end
 

--- a/BrainPortal/app/controllers/nh_projects_controller.rb
+++ b/BrainPortal/app/controllers/nh_projects_controller.rb
@@ -36,7 +36,7 @@ class NhProjectsController < NeurohubApplicationController
   end
 
   def create #:nodoc:
-    attributes             = params.require_as_params(:nh_project).permit(:name, :description, :public, :editor_ids => [])
+    attributes             = params.require_as_params(:nh_project).permit(:name, :description, :public, :not_assignable, :editor_ids => [])
 
     @nh_project            = WorkGroup.new(attributes)
     @nh_project.creator_id = current_user.id
@@ -84,7 +84,7 @@ class NhProjectsController < NeurohubApplicationController
       return
     end
 
-    attr_to_update = params.require_as_params(:nh_project).permit(:name, :description, :public, :editor_ids => [])
+    attr_to_update = params.require_as_params(:nh_project).permit(:name, :description, :public, :not_assignable, :editor_ids => [])
     attr_to_update["editor_ids"] = [] if !attr_to_update["editor_ids"]
     success        = @nh_project.update_attributes_with_logging(attr_to_update,current_user)
 

--- a/BrainPortal/app/helpers/groups_helper.rb
+++ b/BrainPortal/app/helpers/groups_helper.rb
@@ -50,7 +50,7 @@ module GroupsHelper
 
     center_legend(nil, groups.map { |g| css_group_type(g) }.uniq.map { |g|
       # 9675: UTF8 white circle, 9679: UTF8 black circle
-      ["<span class=\"#{g}_project_point\">&##{g == "all" ? 9675 : 9679};</span>", "#{g.titleize} Project"]
+      ["<span class=\"#{g}_project_point\">&##{g == "all" ? "x25ef" : "x2b24"};</span>", "#{g.titleize} Project"]
     })
   end
 end

--- a/BrainPortal/app/models/admin_user.rb
+++ b/BrainPortal/app/models/admin_user.rb
@@ -36,6 +36,12 @@ class AdminUser < User
     Group.where(nil)
   end
 
+  # List of groups that the user can list in the interface. Normally, groups that are invisible
+  # are not listed
+  def listable_groups
+    Group.where(nil)
+  end
+
   # List of groups that the user can assign to resources.
   # The user must be a member of one of these groups. Subset
   # of viewable_groups

--- a/BrainPortal/app/models/admin_user.rb
+++ b/BrainPortal/app/models/admin_user.rb
@@ -31,20 +31,16 @@ class AdminUser < User
   end
 
   # List of groups which provide view access to resources.
-  # It is possible for the user not to be a member of one of those groups.
   def viewable_groups
     Group.where(nil)
   end
 
-  # List of groups that the user can list in the interface. Normally, groups that are invisible
-  # are not listed
+  # List of groups that the user can list in the interface.
   def listable_groups
     Group.where(nil)
   end
 
   # List of groups that the user can assign to resources.
-  # The user must be a member of one of these groups. Subset
-  # of viewable_groups
   def assignable_groups
     Group.where(nil)
   end

--- a/BrainPortal/app/models/normal_user.rb
+++ b/BrainPortal/app/models/normal_user.rb
@@ -32,7 +32,7 @@ class NormalUser < User
   end
 
   # List of groups which provide view access to resources.
-  # It is possible for the user not to be a member of one of those groups.
+  # It is possible for the user not to be a member of one of those groups (e.g. public groups)
   def viewable_groups
     Group.where(:id => (self.group_ids + Group.public_group_ids))
   end
@@ -46,16 +46,16 @@ class NormalUser < User
   # List of groups that the user can assign to resources.
   # The user must be a member of one of these groups.
   # Removed from the list:
-  #   the singleton EveryoneGroup
-  #   groups that are marked as "not_assignable" (attribute)
+  # * the singleton EveryoneGroup
+  # * groups that are marked as "not_assignable" (attribute)
   # Always on the list:
-  #   groups that the user created themselves (creator_id == user.id)
-  #   groups that the user is an editor
+  # * groups that the user created themselves (creator_id == user.id)
+  # * groups that the user is an editor
   def assignable_groups
     all_gids        = self.group_ids - [ Group.everyone.id ]
     assignable_gids = Group.where(:id => all_gids).where(:not_assignable => false).pluck(:id)
-    creat_edit_gids = self.editable_group_ids + Group.where(:creator_id => self.id).pluck(:id)
-    Group.where(:id => (assignable_gids | creat_edit_gids).uniq)
+    edit_creat_gids = self.editable_group_ids + Group.where(:creator_id => self.id).pluck(:id)
+    Group.where(:id => (assignable_gids | edit_creat_gids).uniq)
   end
 
   # List of groups that the user can modify (the group's attributes themselves, not the resources)

--- a/BrainPortal/app/models/normal_user.rb
+++ b/BrainPortal/app/models/normal_user.rb
@@ -37,11 +37,25 @@ class NormalUser < User
     Group.where(:id => (self.group_ids + Group.public_group_ids))
   end
 
+  # List of groups that the user can list in the interface. Normally, groups that are invisible
+  # are not listed
+  def listable_groups
+    viewable_groups.where(:invisible => false).without_everyone
+  end
+
   # List of groups that the user can assign to resources.
-  # The user must be a member of one of these groups. Subset
-  # of viewable_groups
+  # The user must be a member of one of these groups.
+  # Removed from the list:
+  #   the singleton EveryoneGroup
+  #   groups that are marked as "not_assignable" (attribute)
+  # Always on the list:
+  #   groups that the user created themselves (creator_id == user.id)
+  #   groups that the user is an editor
   def assignable_groups
-    Group.where(:id => (self.group_ids - [ Group.everyone.id ])).where(:invisible => false)
+    all_gids        = self.group_ids - [ Group.everyone.id ]
+    assignable_gids = Group.where(:id => all_gids).where(:not_assignable => false).pluck(:id)
+    creat_edit_gids = self.editable_group_ids + Group.where(:creator_id => self.id).pluck(:id)
+    Group.where(:id => (assignable_gids | creat_edit_gids).uniq)
   end
 
   # List of groups that the user can modify (the group's attributes themselves, not the resources)

--- a/BrainPortal/app/models/site_manager.rb
+++ b/BrainPortal/app/models/site_manager.rb
@@ -34,7 +34,7 @@ class SiteManager < User
   end
 
   # List of groups which provide view access to resources.
-  # It is possible for the user not to be a member of one of those groups.
+  # It is possible for the user not to be a member of one of those groups (e.g. public groups)
   def viewable_groups
     Group.where(:id => (self.group_ids + Group.public_group_ids + self.site.group_ids))
   end
@@ -46,12 +46,13 @@ class SiteManager < User
   end
 
   # List of groups that the user can assign to resources.
-  # The user must be a member of one of these groups.
+  # This is similar to the list returned for NormalUser but
+  # also includes other workgroups associated with the site.
   def assignable_groups
     all_gids        = self.group_ids + self.site.group_ids - [ Group.everyone.id ]
     assignable_gids = Group.where(:id => all_gids).where(:not_assignable => false).pluck(:id)
-    creat_edit_gids = self.editable_group_ids + Group.where(:creator_id => self.id).pluck(:id)
-    Group.where(:id => (assignable_gids | creat_edit_gids).uniq)
+    edit_creat_gids = self.editable_group_ids + Group.where(:creator_id => self.id).pluck(:id)
+    Group.where(:id => (assignable_gids | edit_creat_gids).uniq)
   end
 
   # List of groups that the user can modify (the group's attributes themselves, not the resources)

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -265,20 +265,11 @@ class User < ApplicationRecord
     return self.is_a?(role.to_s.classify.constantize)
   end
 
-  # Find the tools that this user has access to.
-  def available_tools
-    cb_error "#available_tools called from User base class! Method must be implemented in a subclass."
-  end
-
-  # Find the scientific tools that this user has access to.
-  def available_scientific_tools
-    self.available_tools.where( :category  => "scientific tool" ).order( "tools.select_menu_text" )
-  end
-
-  # Find the conversion tools that this user has access to.
-  def available_conversion_tools
-    self.available_tools.where( :category  => "conversion tool" ).order( "tools.select_menu_text" )
-  end
+  ###############################################
+  #
+  # Group lists
+  #
+  ###############################################
 
   # List of groups which provide view access to resources.
   # It is possible for the user not to be a member of one of those groups.
@@ -288,6 +279,16 @@ class User < ApplicationRecord
 
   def viewable_group_ids
     viewable_groups.pluck('groups.id')
+  end
+
+  # List of groups that the user can list in the interface. Normally, groups that are invisible
+  # are not listed
+  def listable_groups
+    cb_error "#listable_groups called from User base class! Method must be implemented in a subclass."
+  end
+
+  def listable_group_ids
+    listable_groups.pluck('groups.id')
   end
 
   # List of groups that the user can assign to resources.
@@ -308,6 +309,27 @@ class User < ApplicationRecord
 
   def modifiable_group_ids
     modifiable_groups.pluck('groups.id')
+  end
+
+  ###############################################
+  #
+  # Model access lists
+  #
+  ###############################################
+
+  # Find the tools that this user has access to.
+  def available_tools
+    cb_error "#available_tools called from User base class! Method must be implemented in a subclass."
+  end
+
+  # Find the scientific tools that this user has access to.
+  def available_scientific_tools
+    self.available_tools.where( :category  => "scientific tool" ).order( "tools.select_menu_text" )
+  end
+
+  # Find the conversion tools that this user has access to.
+  def available_conversion_tools
+    self.available_tools.where( :category  => "conversion tool" ).order( "tools.select_menu_text" )
   end
 
   # Returns the list of tags available to this user.

--- a/BrainPortal/app/models/user.rb
+++ b/BrainPortal/app/models/user.rb
@@ -272,7 +272,7 @@ class User < ApplicationRecord
   ###############################################
 
   # List of groups which provide view access to resources.
-  # It is possible for the user not to be a member of one of those groups.
+  # It is possible for the user not to be a member of one of those groups (e.g. public groups)
   def viewable_groups
     cb_error "#viewable_groups called from User base class! Method must be implemented in a subclass."
   end
@@ -282,7 +282,7 @@ class User < ApplicationRecord
   end
 
   # List of groups that the user can list in the interface. Normally, groups that are invisible
-  # are not listed
+  # are not listed.
   def listable_groups
     cb_error "#listable_groups called from User base class! Method must be implemented in a subclass."
   end
@@ -292,8 +292,6 @@ class User < ApplicationRecord
   end
 
   # List of groups that the user can assign to resources.
-  # The user must be a member of one of these groups. Subset
-  # of viewable_groups
   def assignable_groups
     cb_error "#assignable_groups called from User base class! Method must be implemented in a subclass."
   end

--- a/BrainPortal/app/views/groups/new.html.erb
+++ b/BrainPortal/app/views/groups/new.html.erb
@@ -52,7 +52,8 @@
     <% end %>
 
     <p>
-    Only the maintainers (creator and editors) can assign resources to this project:
+    Normal members will not be able to assign files or other resources
+    to this project (but editors are always allowed to do so):
     <%= f.check_box :not_assignable %>
 
     <% if current_user.has_role?(:normal_user) %>

--- a/BrainPortal/app/views/groups/new.html.erb
+++ b/BrainPortal/app/views/groups/new.html.erb
@@ -41,17 +41,19 @@
     <%= f.label :description, "Description" %><br />
     <%= f.text_area :description, :rows => 4, :cols => 40 %>
     <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div>
-    </p>
+
     <% if current_user.has_role?(:admin_user) %>
       <p>
       <%= f.label :site_id, "Site:" %>
       <%= site_select "group[site_id]",{}, :prompt => "(Select a site)" %>
-      </p>
       <p>
       Make this a system group invisible to normal users:
       <%= f.check_box :invisible %>
-      <p/>
     <% end %>
+
+    <p>
+    Only the maintainers (creator and editors) can assign resources to this project:
+    <%= f.check_box :not_assignable %>
 
     <% if current_user.has_role?(:normal_user) %>
       <%= hidden_field_tag("group[user_ids][]", current_user.id.to_s) %>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -76,6 +76,11 @@
       <% t.empty_cell %>
     <% end %>
 
+    <% t.edit_cell("Not assignable", :content => check_box_tag(nil ,nil, @group.not_assignable?, :disabled => true)) do |f| %>
+      <%= f.check_box :not_assignable %>
+      <div class="field_explanation">When checked, only the creator and editors can assign resource to this project.</div>
+    <% end %>
+
   <% end %>
 
   <%= show_table(@group, :header => 'Resources') do |t| %>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -78,7 +78,10 @@
 
     <% t.edit_cell("Not assignable", :content => check_box_tag(nil ,nil, @group.not_assignable?, :disabled => true)) do |f| %>
       <%= f.check_box :not_assignable %>
-      <div class="field_explanation">When checked, only the creator and editors can assign resource to this project.</div>
+      <div class="field_explanation">
+         If checked, normal members will not be able to assign files or other
+         things to this project (but editors are always allowed to do so).
+      </div>
     <% end %>
 
   <% end %>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -80,7 +80,7 @@
       <%= f.check_box :not_assignable %>
       <div class="field_explanation">
          If checked, normal members will not be able to assign files or other
-         things to this project (but editors are always allowed to do so).
+         resources to this project (but editors are always allowed to do so).
       </div>
     <% end %>
 

--- a/BrainPortal/app/views/nh_projects/_form.html.erb
+++ b/BrainPortal/app/views/nh_projects/_form.html.erb
@@ -55,7 +55,9 @@
       <%= f.label :not_assignable, "Not&nbsp;assignable".html_safe, :class => "mr-2" %>
       <%= f.check_box :not_assignable %>
       </div>
-      <p class="field_note"><b>Note:</b> If checked, normal members will not be able to assign files or other things to this project (but editors are always allowed to do so).
+      <p class="field_note"><b>Note:</b>
+      If checked, normal members will not be able to assign files or other
+      resources to this project (but editors are always allowed to do so).
       </p>
     </fieldset>
 

--- a/BrainPortal/app/views/nh_projects/_form.html.erb
+++ b/BrainPortal/app/views/nh_projects/_form.html.erb
@@ -50,6 +50,15 @@
       <b>Be careful with this option!</b></p>
     </fieldset>
 
+    <fieldset>
+      <div class="d-flex align-center">
+      <%= f.label :not_assignable, "Not&nbsp;assignable".html_safe, :class => "mr-2" %>
+      <%= f.check_box :not_assignable %>
+      </div>
+      <p class="field_note"><b>Note:</b> If checked, normal members will not be able to assign files or other things to this project (but editors are always allowed to do so).
+      </p>
+    </fieldset>
+
     <% if @nh_project.can_be_edited_by?(current_user) %>
       <% if (@nh_project.users.count > 1) %>
             <div>

--- a/BrainPortal/cbrain_plugins/plugins-report.sh
+++ b/BrainPortal/cbrain_plugins/plugins-report.sh
@@ -18,6 +18,8 @@ if ! test -d installed-plugins ; then
   exit 2
 fi
 
+unset LANG # to make sorting deterministic in the reports
+
 for dir in * ; do
   test $dir = 'cbrain-plugins-base' && continue
   #test $dir = 'installed-plugins'   && continue

--- a/BrainPortal/db/migrate/20200727133517_add_non_assignable_flag_to_groups.rb
+++ b/BrainPortal/db/migrate/20200727133517_add_non_assignable_flag_to_groups.rb
@@ -1,0 +1,35 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2020
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+class AddNonAssignableFlagToGroups < ActiveRecord::Migration[5.0]
+  def up
+    add_column :groups, :not_assignable, :boolean, :default => false
+    add_index  :groups, :not_assignable
+
+    Group.where(:invisible => true).update_all(:not_assignable => true)
+    EveryoneGroup.all              .update_all(:not_assignable => true)
+  end
+
+  def down
+    remove_column :groups, :not_assignable
+  end
+end
+

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200309142414) do
+ActiveRecord::Schema.define(version: 20200727133517) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -145,19 +145,21 @@ ActiveRecord::Schema.define(version: 20200309142414) do
     t.string   "type"
     t.integer  "site_id"
     t.integer  "creator_id"
-    t.boolean  "invisible",                 default: false
-    t.text     "description", limit: 65535
-    t.boolean  "public", default: false
+    t.boolean  "invisible",                    default: false
+    t.text     "description",    limit: 65535
+    t.boolean  "public",                       default: false
+    t.boolean  "not_assignable",               default: false
     t.index ["invisible"], name: "index_groups_on_invisible", using: :btree
     t.index ["public"], name: "index_groups_on_public", using: :btree
     t.index ["name"], name: "index_groups_on_name", using: :btree
+    t.index ["not_assignable"], name: "index_groups_on_not_assignable", using: :btree
     t.index ["type"], name: "index_groups_on_type", using: :btree
   end
 
-  create_table "groups_editors", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "groups_editors", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "group_id"
     t.integer "user_id"
-    t.index ["group_id", "user_id"], name: "index_groups_editors_on_group_id_and_user_id", unique: true
+    t.index ["group_id", "user_id"], name: "index_groups_editors_on_group_id_and_user_id", unique: true, using: :btree
   end
 
   create_table "groups_users", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -175,7 +177,7 @@ ActiveRecord::Schema.define(version: 20200309142414) do
     t.index ["key"], name: "index_help_documents_on_key", unique: true, using: :btree
   end
 
-  create_table "large_session_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "large_session_infos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "session_id",                               null: false
     t.text     "data",       limit: 65535
     t.datetime "created_at"
@@ -264,7 +266,7 @@ ActiveRecord::Schema.define(version: 20200309142414) do
     t.index ["type"], name: "index_remote_resources_on_type", using: :btree
   end
 
-  create_table "resource_usage", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+  create_table "resource_usage", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "type"
     t.decimal  "value",                    precision: 24
     t.integer  "user_id"

--- a/BrainPortal/lib/neurohub_helpers.rb
+++ b/BrainPortal/lib/neurohub_helpers.rb
@@ -32,7 +32,6 @@ module NeurohubHelpers
     id      = id_or_project.is_a?(Group) ? id_or_project.id : id_or_project
     project = user.viewable_groups
                   .where(:type => 'WorkGroup')
-                  .where(:invisible => false)
                   .find(id)
 
     raise ActiveRecord::RecordNotFound unless project.can_be_accessed_by?(user)
@@ -47,9 +46,8 @@ module NeurohubHelpers
   # For the user +user+, this method will return
   # neurohub projects ('available' groups of class WorkGroup)
   def find_nh_projects(user)
-    user.viewable_groups
-        .where(:type      => 'WorkGroup')
-        .where(:invisible => false)
+    user.listable_groups
+        .where(:type => 'WorkGroup')
   end
 
   # Make sure +projects+ are all assignable

--- a/BrainPortal/misc/README.txt
+++ b/BrainPortal/misc/README.txt
@@ -19,5 +19,46 @@ Content:
    We suggest disabling SQL logs with "no_log" first (see the
    console's "cbhelp" command for more information).
 
-2- Nothing else for the moment.
+2- mk_tst_access.rb and tst_access.rb
+
+   In the console in a dev environment:
+
+     load "mk_tst_access.rb"
+
+   will create 4 users:
+
+     a creator
+     an editor
+     a member
+     a non-member
+
+   and 8 WorkGroups, all possible combinations of the
+   three boolean flags :invisible, :public, :not_assignable
+
+   Ralationships are established as:
+
+     * All groups are created by creator,
+     * All groups have creator and editor as editors.
+     * All groups have creator, editor and member as members.
+     * No groups have non-member as member
+
+   in the console, typing:
+
+     load "tst_access.rb"
+
+   will make the program iterate over each member
+   and check the list of groups returned by the methods
+
+     groups
+     viewable_groups
+     listable_groups
+     assignable_groups
+     editable_groups
+     fnp (which invokes find_neurohub_project(user))
+     afnp (which invokes ensure_assignable_nh_projects() on fnb's list)
+
+   Hitting return will move from method to method; Q to stop.
+
+   To cleanup: see the code at the top of "mk_tst_access" to remove the
+   users and workgroups.
 

--- a/BrainPortal/misc/README.txt
+++ b/BrainPortal/misc/README.txt
@@ -35,7 +35,7 @@ Content:
    and 8 WorkGroups, all possible combinations of the
    three boolean flags :invisible, :public, :not_assignable
 
-   Ralationships are established as:
+   Relationships are established as:
 
      * All groups are created by creator,
      * All groups have creator and editor as editors.

--- a/BrainPortal/misc/mk_tst_access.rb
+++ b/BrainPortal/misc/mk_tst_access.rb
@@ -1,0 +1,60 @@
+
+u_class=NormalUser
+g_class=WorkGroup
+
+a_g=Group.where("name like 'g-ac-verif-%'")
+a_g.destroy_all
+a_u=User.where("login like 'u_ac_verif_%'")
+a_u.destroy_all
+
+p_w='abcdABCD1234!@#$'
+
+u_c = u_class.create!(
+    :login     => 'u_ac_verif_creator',
+    :full_name => 'Group Creator',
+    :password  => p_w,
+    :password_confirmation => p_w
+)
+
+u_e = u_class.create!(
+    :login     => 'u_ac_verif_editor',
+    :full_name => 'Group Editor',
+    :password  => p_w,
+    :password_confirmation => p_w
+)
+
+u_m = u_class.create!(
+    :login     => 'u_ac_verif_member',
+    :full_name => 'Group member',
+    :password  => p_w,
+    :password_confirmation => p_w
+)
+
+u_n = u_class.create!(
+    :login     => 'u_ac_verif_nothin',
+    :full_name => 'Group NOTmember',
+    :password  => p_w,
+    :password_confirmation => p_w
+)
+
+[false,true].each do |invisible|
+  [false,true].each do |pub|
+    [false,true].each do |not_assignable|
+      name  = "g-ac-verif"
+      name += invisible      ? "-invis"  : "-visib"
+      name += pub            ? "-publc"  : "-NOpub"
+      name += not_assignable ? "-NOass"  : "-assig"
+      g = WorkGroup.create!(
+        :name           => name,
+        :creator_id     => u_c.id,
+        :invisible      => invisible,
+        :public         => pub,
+        :not_assignable => not_assignable,
+      )
+      g.user_ids   = [ u_c.id, u_e.id, u_m.id ]
+      g.editor_ids = [ u_c.id, u_e.id ]
+    end
+  end
+end
+
+1;

--- a/BrainPortal/misc/tst_access.rb
+++ b/BrainPortal/misc/tst_access.rb
@@ -1,0 +1,36 @@
+
+
+class User
+  include NeurohubHelpers
+  def fnp
+    find_nh_projects(self)
+  end
+  def afnp
+    ensure_assignable_nh_projects(self,fnp)
+  end
+end
+
+def tst_all
+  u_c=User.find_by_login('u_ac_verif_creator')
+  u_e=User.find_by_login('u_ac_verif_editor')
+  u_m=User.find_by_login('u_ac_verif_member')
+  u_n=User.find_by_login('u_ac_verif_nothin')
+
+  [u_c, u_e, u_m, u_n].each do |u|
+    [:groups, :viewable_groups, :listable_groups, :assignable_groups, :editable_groups, :fnp, :afnp].each do |m|
+      groups=u.send(m)
+      puts "==============="
+      puts "User=#{u.name.sub("u_ac_verif_","")} Method=#{m}"
+      groups.to_a.each_with_index_and_size do |g,i,t|
+         name = g.name.sub("g-ac-verif-","")
+         puts "  #{i+1}/#{t} -> #{name}"
+      end
+      print ">>> "
+      return if STDIN.readline.to_s =~ /q/
+    end
+  end
+end
+
+tst_all
+
+1;


### PR DESCRIPTION
The migration in here will also set all groups previously
'invisible' to also be 'not_assignable'. Them in the future we can
make some groups visible yet not assignable separately (e.g.
for datasets)