### PR TITLE
NeuroHub invitations can be sent using login names

### DIFF
--- a/BrainPortal/app/models/invitation.rb
+++ b/BrainPortal/app/models/invitation.rb
@@ -36,7 +36,7 @@ class Invitation < Message
   def self.send_out(sender, group, users)
     self.send_message(users,
       :message_type => "notice",
-      :header       =>  "You've been invited to join project #{group.name}",
+      :header       =>  "You've been invited by #{sender.full_name} to join project #{group.name}",
       :group_id     =>  group.id,
       :send_email   =>  true,
       :sender_id    =>  sender.id,
@@ -58,8 +58,12 @@ will allow you to join.
   end
 
   def add_description #:nodoc:
-    self.description = "You've been invited to join project #{group.name}.\n\n"+
-                       "[[Accept][/invitations/#{self.id}][put]]"
+    self.description = <<-CB_MARKUP
+      You've been invited to join project #{group.name} by
+      your colleague #{self.sender.full_name}.
+
+      [[Accept][/invitations/#{self.id}][put]]
+    CB_MARKUP
     self.save!
   end
 

--- a/BrainPortal/app/views/nh_invitations/new.html.erb
+++ b/BrainPortal/app/views/nh_invitations/new.html.erb
@@ -31,7 +31,10 @@
     <%= form_tag nh_invitations_path, action: "create" do |f| %>
       <fieldset>
         <%= label :emails, "Emails" %>
-        <div class="field_note">Enter one or several email addresses separated by blanks or commas.</div>
+        <div class="field_note">
+          Enter one or several email addresses separated by blanks or commas.
+          You can also provide CBRAIN or NeuroHub usernames if you know them.
+        </div>
         <%= text_field_tag :emails %>
       </fieldset>
       <%= hidden_field_tag "nh_project_id", @nh_project.id %>

--- a/BrainPortal/app/views/nh_projects/show.html.erb
+++ b/BrainPortal/app/views/nh_projects/show.html.erb
@@ -199,7 +199,7 @@
       </div>
     <% end %>
 
-    <% if @proj_dps.present? %>
+    <% if @proj_dps.exists? %>
       <div class="card-row">
         <div class="card-item">
           <div>


### PR DESCRIPTION
This allows NeuroHub users to invite other users using their login names as well as their email addresses.

I also fixed/improved some messages and invitations.