### PR TITLE
Better navigation between CBRAIN <-> NeuroHub

### DIFF
--- a/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
+++ b/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
@@ -1,35 +1,35 @@
 @import "<%= asset_path './normalize.css' %>";
 /*
   LEGEND
-  ├── BREAKPOINTS
-  ├── SPACE
-  ├── PALETTE
-  ├── TYPOGRAPHY
-  ├── LOGOS
-  ├── SHADOWS
-  ├── TRANSITIONS
-  ├── BUTTONS
-  ├── BANNERS
-  ├── ERRORS
-  ├── EMPTY
-  ├── FORMS
-  ├── CARDS
-  ├── TABLES
-  ├── NAVIGATION BAR
-  ├── SECONDARY NAVIGATION BAR
-  ├── FOOTER
-  ├── PAGES
-    ├── BASE
-    ├── SESSIONS
-    ├── SIGNUPS
-    ├── PROJECTS
-    ├── USERS
-    ├── INVITATIONS
-    ├── WELCOME
-    ├── SEARCH
-    ├── LICENSE
-    ├── STORAGES
-  └──
+   - BREAKPOINTS
+   - SPACE
+   - PALETTE
+   - TYPOGRAPHY
+   - LOGOS
+   - SHADOWS
+   - TRANSITIONS
+   - BUTTONS
+   - BANNERS
+   - ERRORS
+   - EMPTY
+   - FORMS
+   - CARDS
+   - TABLES
+   - NAVIGATION BAR
+   - SECONDARY NAVIGATION BAR
+   - FOOTER
+   - PAGES
+     - BASE
+     - SESSIONS
+     - SIGNUPS
+     - PROJECTS
+     - USERS
+     - INVITATIONS
+     - WELCOME
+     - SEARCH
+     - LICENSE
+     - STORAGES
+   -
 
 /*
 =============================================================

--- a/BrainPortal/app/controllers/nh_sessions_controller.rb
+++ b/BrainPortal/app/controllers/nh_sessions_controller.rb
@@ -72,6 +72,9 @@ class NhSessionsController < NeurohubApplicationController
       return
     end
 
+    # Record that the user connected using the NeuroHub login page
+    cbrain_session[:login_page] = 'NeuroHub'
+
     redirect_to neurohub_path
   end
 

--- a/BrainPortal/app/controllers/nh_signups_controller.rb
+++ b/BrainPortal/app/controllers/nh_signups_controller.rb
@@ -36,8 +36,10 @@ class NhSignupsController < NeurohubApplicationController
   end
 
   def create #:nodoc:
-    @signup            = Signup.new(signup_params)
-    @signup.session_id = request.session_options[:id]
+    @signup                    = Signup.new(signup_params)
+    @signup.session_id         = request.session_options[:id]
+    @signup.remote_resource_id = RemoteResource.current_resource.id
+    @signup.form_page          = 'NeuroHub' # Just a keyword that IDs the signup page
     @signup.generate_token
 
     unless can_edit?(@signup)

--- a/BrainPortal/app/controllers/sessions_controller.rb
+++ b/BrainPortal/app/controllers/sessions_controller.rb
@@ -62,6 +62,9 @@ class SessionsController < ApplicationController
       return
     end
 
+    # Record that the user connected using the NeuroHub login page
+    cbrain_session[:login_page] = 'CBRAIN'
+
     respond_to do |format|
       format.html { redirect_back_or_default(start_page_path) }
       format.json { render :json => json_session_info, :status => 200 }
@@ -207,6 +210,7 @@ class SessionsController < ApplicationController
     from_host ||= 'unknown'
     cbrain_session[:guessed_remote_ip]   = from_ip
     cbrain_session[:guessed_remote_host] = from_host
+    cbrain_session.remote_resource_id    = portal.id # for general navigation help
 
     # Record the user agent
     raw_agent = reqenv['HTTP_USER_AGENT'] || 'unknown/unknown'

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -44,8 +44,10 @@ class SignupsController < ApplicationController
   end
 
   def create #:nodoc:
-    @signup = Signup.new(signup_params)
-    @signup.session_id = request.session_options[:id]
+    @signup                    = Signup.new(signup_params)
+    @signup.session_id         = request.session_options[:id]
+    @signup.remote_resource_id = RemoteResource.current_resource.id
+    @signup.form_page          = 'CBRAIN' # Just a keyword that IDs the signup page
     @signup.generate_token
 
     unless can_edit?(@signup)

--- a/BrainPortal/app/helpers/switcher_helper.rb
+++ b/BrainPortal/app/helpers/switcher_helper.rb
@@ -1,0 +1,117 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2020
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Helper for creating links between related page
+# in CBRAIN and NeuroHub
+module SwitcherHelper
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  CONTROLLER_MAPPINGS = [
+    %w( groups         nh_projects ),
+    %w( data_providers nh_storages ),
+    %w( users          nh_users    ),
+  ]
+
+  # Returns the dashboard path depending on which
+  # login page the current user used to log in.
+  def login_dashboard_path
+    if current_user
+      if cbrain_session[:login_page] == 'NeuroHub'
+        neurohub_path  # /neurohub -> neurohub_portal#welcome
+      else
+        home_path      # /home     -> portal#welcome
+      end
+    end
+
+    # Default is CBRAIN's
+    home_path      # /home     -> portal#welcome
+  end
+
+  def alternate_dashboard_path
+    controller = params[:controller]
+    if controller.to_s =~ /^(neurohub_|nh_)/
+      home_path
+    else
+      neurohub_path  # /neurohub -> neurohub_portal#welcome
+    end
+  end
+
+  # Based on the current controller and action, returns
+  # the equivalent page in the other interface. E.g.
+  # if the current page is groups#show in CBRAIN, this
+  # will return the link to nh_projects#show, and vice
+  # versa. If there is no known equivalent page in the
+  # other interface, this method returns nil.
+  #
+  # This method really only makes sense for GET requests.
+  def alternate_link_path
+    controller = params[:controller] # string
+    action     = params[:action]     # string
+    id         = params[:id]
+
+    # Method 1: switch the controllers and try to see if
+    # the same action exists.
+    if pair = CONTROLLER_MAPPINGS.detect { |p| p.include? controller } # find a pair
+      alt_cont   = pair.detect { |c| c != controller } # get the other one
+      alt_url    = url_for({ :controller => alt_cont, :action => action, :id => id }) rescue nil
+      alt_url  ||= url_for({ :controller => alt_cont, :action => action            }) rescue nil
+      return alt_url if alt_url
+    end
+
+    # Method 2: hardcoded equivalences
+    alt_url = case [ controller, action ]
+
+      when %w( nh_users    myaccount )
+        user_path(:id => current_user.id)
+
+      when %w( users       show ) # in CBRAIN some users can view other users...
+        myaccount_path # but not in NeuroHub, we can only view our own account
+
+      when %w( nh_projects files )
+        switch_groups_path(:id => id)
+
+      when %w( userfiles   index )
+        cur_proj_id = current_project.try(:id)
+        if cur_proj_id
+          files_nh_project_path(:id => cur_pro_id)
+        else
+          nh_projects_path
+        end
+
+    end
+    return alt_url if alt_url
+
+    # No equivalent page
+    nil
+  end
+
+  # This method acts like alternate_link_path
+  # except if not alternate page exists, it
+  # return a path to the dashboard of the alternative
+  # interface.
+  def alternate_page_or_dashboard_path
+    alternate_link_path || alternate_dashboard_path
+  end
+
+end
+

--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -117,6 +117,18 @@ class CbrainSession
     @modified      = true
   end
 
+  # The remote_resource_id attribute
+  # is used to record which portal the user
+  # originally connected from, to aid in navigation.
+  def remote_resource_id
+    self[:remote_resource_id]
+  end
+
+  # See the getter method.
+  def remote_resource_id=(rr_id)
+    self[:remote_resource_id] = rr_id
+  end
+
   ###########################################
   # Hash-like interface to session attributes
   ###########################################

--- a/BrainPortal/app/models/signup.rb
+++ b/BrainPortal/app/models/signup.rb
@@ -34,7 +34,8 @@ class Signup < ApplicationRecord
 
   validate              :login_match_user_format
 
-  belongs_to            :user, :optional => true # link filled after approval
+  belongs_to            :user,            :optional => true # link filled after approval
+  belongs_to            :remote_resource, :optional => true # link filled at creation; older signups miss it
 
   def strip_blanks #:nodoc:
     [

--- a/BrainPortal/app/views/layouts/_neurohub_navbar.html.erb
+++ b/BrainPortal/app/views/layouts/_neurohub_navbar.html.erb
@@ -27,9 +27,12 @@
 
 <% if current_user %>
     <div id="nh_navbar">
-        <a href="/neurohub">
-            <div class="nh_navbar_logo"></div>
-        </a>
+        <%= link_to alternate_page_or_dashboard_path do %>
+          <img src="images/custom_logos/cb-large_white_blue.png" style="height: 2em">
+        <% end %>
+        <%= link_to neurohub_path do %>
+          <div class="nh_navbar_logo"></div>
+        <% end %>
         <div class="nh_navbar_account">
           <div class="text-ellipsis"><%= current_user.full_name %></div>
           <div class="text-ellipsis"><%= current_user.name %></div>

--- a/BrainPortal/app/views/layouts/_section_account.html.erb
+++ b/BrainPortal/app/views/layouts/_section_account.html.erb
@@ -35,6 +35,7 @@
 <div class="account account_git_branch_<%= git_branch.gsub(/\W/,"_") %>">
 
   <span class="home_credits">
+    <%= link_to 'NeuroHub', alternate_page_or_dashboard_path %>
     <% if current_user %>
       <%= link_to "Dashboard", home_path %>
       <%= link_to 'My Account', user_path(current_user) %>

--- a/BrainPortal/app/views/signups/_signups_table.html.erb
+++ b/BrainPortal/app/views/signups/_signups_table.html.erb
@@ -173,7 +173,24 @@
           "(None)"
         end
       end
-     %>
+    %>
+
+    <%
+      t.column("Portal", :remote_resource) do |d|
+        portal = d.remote_resource
+        if (portal)
+          link_to_bourreau_if_accessible(portal)
+        else
+          "(None)"
+        end
+      end
+    %>
+
+    <%
+      t.column("Origin", :form_page,
+        :sortable => true
+      )
+    %>
 
     <%
       t.column("Created", :created_at,

--- a/BrainPortal/app/views/signups/show.html.erb
+++ b/BrainPortal/app/views/signups/show.html.erb
@@ -27,6 +27,14 @@
 
 <% if current_user.present? && current_user.has_role?(:admin_user) %>
 
+  <% if @signup.remote_resource %>
+    This account request was made from portal
+    <%= link_to_bourreau_if_accessible(@signup.remote_resource) %>
+    using the form located on
+    <%= @signup.form_page %>
+    .<p>
+  <% end %>
+
   As an administrator, you can <%= link_to "edit", :action => :edit %> this request.<p>
 
   <% if ! @signup.approved? %>

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200727133517) do
+ActiveRecord::Schema.define(version: 20200804163321) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -323,14 +323,14 @@ ActiveRecord::Schema.define(version: 20200727133517) do
 
   create_table "signups", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "title"
-    t.string   "first",                                       null: false
+    t.string   "first",                                            null: false
     t.string   "middle"
-    t.string   "last",                                        null: false
-    t.string   "institution",                                 null: false
+    t.string   "last",                                             null: false
+    t.string   "institution",                                      null: false
     t.string   "department"
     t.string   "position"
     t.string   "affiliation"
-    t.string   "email",                                       null: false
+    t.string   "email",                                            null: false
     t.string   "website"
     t.string   "street1"
     t.string   "street2"
@@ -341,17 +341,19 @@ ActiveRecord::Schema.define(version: 20200727133517) do
     t.string   "time_zone"
     t.string   "service"
     t.string   "login"
-    t.text     "comment",       limit: 65535
+    t.text     "comment",            limit: 65535
     t.string   "session_id"
     t.string   "confirm_token"
     t.boolean  "confirmed"
     t.string   "approved_by"
     t.datetime "approved_at"
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
-    t.text     "admin_comment", limit: 65535
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.text     "admin_comment",      limit: 65535
     t.integer  "user_id"
-    t.boolean  "hidden",                      default: false
+    t.boolean  "hidden",                           default: false
+    t.integer  "remote_resource_id"
+    t.string   "form_page"
   end
 
   create_table "sites", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
Also:

* we record if the user submitted a new account request
using the CBRAIN form or the NeuroHub form. The info
is shown to the admin, that's all.

* we record if the user connected using the CBRAIN login
page or the NeuroHub login page; this info is not used right now
but could be turned into a "return home" link, as generated
by the new helper code (see login_dashboard_path(), not
used right now)