### PR TITLE
CBRAIN users can generate API token

### DIFF
--- a/BrainPortal/app/models/cbrain_session.rb
+++ b/BrainPortal/app/models/cbrain_session.rb
@@ -130,6 +130,26 @@ class CbrainSession
   end
 
   ###########################################
+  # Session duplication
+  ###########################################
+
+  # Returns a duplicate of the current session
+  # but with a new token and a cleaned-up session
+  # (no filters etc). Usually this is for users
+  # to generate their own API token in the interface.
+  def duplicate_with_new_token
+    new_model = @model.dup
+    new_model.session_id = SecureRandom.hex
+    new_sess = self.class.new(new_model)
+    new_sess.clear
+    new_sess.delete :guessed_remote_ip
+    new_sess.delete :guessed_remote_host
+    new_sess[:api] = 'yes'
+    new_sess.touch_unless_recent
+    new_sess
+  end
+
+  ###########################################
   # Hash-like interface to session attributes
   ###########################################
 

--- a/BrainPortal/app/views/users/new_token.html.erb
+++ b/BrainPortal/app/views/users/new_token.html.erb
@@ -1,0 +1,59 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2020
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'New API Token' %>
+
+<h2>New API Token</h2>
+
+We have just generated a new API token for you.
+<p>
+<pre><%= @new_token %></pre>
+<p>
+If you are a developer and want to automate working
+with CBRAIN or NeuroHub, this token will be needed
+to access the APIs.
+<p>
+Refer to the CBRAIN API documentation
+for more information.
+<p>
+<strong>A note about this token</strong>:
+
+<% pretty_how_long = SessionHelpers::SESSION_API_TOKEN_VALIDITY.inspect %>
+<ul>
+  <li>
+    This token will only be valid for <%= pretty_how_long %>.
+  </li>
+  <li>
+    Every time a request is made with it, it becomes valid for another <%= pretty_how_long %>.
+  </li>
+  <li>
+    The first time it is used, the IP address of the connecting client will be
+    recorded and only connections from that IP address will be valid.
+  </li>
+  <li>
+    If a subsequent connection comes from any other IP address at any time,
+    the token will immediately be invalidated.
+  </li>
+</ul>
+

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -155,6 +155,30 @@
 
   <% end %>
 
+  <%= show_table(@user, :as => :user, :header => 'Sessions And Tokens', :edit_condition => false) do |t| %>
+    <% t.cell "Active Sessions", :show_width => 2 do %>
+
+       <table class="simple">
+         <tr>
+           <th>IP</th><th>Last access</th>
+         </tr>
+         <% @active_sessions.to_a.each do |sess| %>
+         <tr>
+           <td><%= sess.data[:guessed_remote_ip].presence || '(None yet)' %></td>
+           <td>
+             <%= to_localtime(sess.updated_at, :datetime) %> (<%= pretty_elapsed(Time.now - sess.updated_at, :num_components => 3) %> ago)
+           </td>
+         </tr>
+         <% end %>
+       </table>
+
+       <% if @user.id == current_user.id %>
+         <p>
+         <%= link_to('Generate new API token', new_token_users_path, :class => "button", :method => :post ) %>
+       <% end %>
+    <% end %>
+  <% end %>
+
   <%= show_table(@user, :as => :user, :header => 'Zenodo Publishing', :edit_condition => edit_permission?(@user)) do |t| %>
 
     <% t.edit_cell(:zenodo_sandbox_token,

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
     collection do
       get  'request_password'
       post 'send_password'
+      post 'new_token'
     end
   end
 

--- a/BrainPortal/lib/session_helpers.rb
+++ b/BrainPortal/lib/session_helpers.rb
@@ -77,6 +77,15 @@ module SessionHelpers
     orig_ip   = large_info.data[:guessed_remote_ip]
     # The method cbrain_request_remote_ip comes from RequestHelpers module
     remote_ip = cbrain_request_remote_ip rescue "UnknownIP-#{rand(1000000)}"
+
+    # If orig_ip is blank, it's probably the first use of
+    # this token, so we just record it.
+    if orig_ip.blank?
+      orig_ip                             = remote_ip
+      large_info.data[:guessed_remote_ip] = remote_ip
+    end
+
+    # If they differ, log and invalidate the session
     if orig_ip != remote_ip
       # Log the error in many places
       user = large_info.user


### PR DESCRIPTION
They get a new page with a new token ready
to be used for API requests.

Right now the new page is only on the CBRAIN side, I'll add a similar on to the NeuroHub side too.

Possible improvement: adding a button to send the token to the clipboard. Requires Javascript however.