### PR TITLE
Added new LORIS hook: csv_data_maker

### DIFF
--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -314,6 +314,7 @@ Rails.application.routes.draw do
     resources :nh_loris_hooks, :only => [] do
       collection do
         post :file_list_maker
+        post :csv_data_maker
       end
     end
 


### PR DESCRIPTION
Allows LORIS users to push arbitrary CSV files to CBRAIN/NeuroHub.

Includes some refactoring of code in common with previous LORIS hook.

You can see the main two action methods are short, and much of the code has been moved into the methods `create_file_for_request` and `render_created_file_report`.

There is no particular issue associated with this feature, though I did talk to @bryancaron about it this week.