### PR TITLE
[FIX] Disable refresh if needed.

### DIFF
--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -158,7 +158,7 @@
         $(document).ready(function() {
           $('input[name="date_range[date_attribute]"]').on('click change', function(e) {
             if ($('input[name="date_range[date_attribute]"]:checked').val() === "") {
-              $('input[id="refresh_data_table"]').prop( "disabled", true )
+              $('#refresh_data_table').prop( "disabled", true )
             } else {
               $('#refresh_data_table').prop( "disabled", false )
             };

--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -152,7 +152,20 @@
 
       <br>
 
-      <%= submit_tag 'Refresh Table' %>
+      <%= submit_tag 'Refresh Table', :id => "refresh_data_table", :disabled => true %>
+
+      <script type="text/javascript">
+        $(document).ready(function() {
+          $('input[name="date_range[date_attribute]"]').on('click change', function(e) {
+            if ($('input[name="date_range[date_attribute]"]:checked').val() === "") {
+              $('input[id="refresh_data_table"]').prop( "disabled", true )
+            } else {
+              $('input[id="refresh_data_table"]').prop( "disabled", false )
+            };
+          });
+        });
+      </script>
+
     <%end%>
 
   </div>

--- a/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
+++ b/BrainPortal/app/views/resource_usage/_resource_usage_table.html.erb
@@ -160,7 +160,7 @@
             if ($('input[name="date_range[date_attribute]"]:checked').val() === "") {
               $('input[id="refresh_data_table"]').prop( "disabled", true )
             } else {
-              $('input[id="refresh_data_table"]').prop( "disabled", false )
+              $('#refresh_data_table').prop( "disabled", false )
             };
           });
         });


### PR DESCRIPTION
#937 seems to be not reproducible, but if we forgot to change the radio button, no filter will be applied. This PR will unable the `Refresh table` button according to the radio button value. 

Closed #937. 