### PR TITLE
ToolConfigs can have Singularity overlays to mount

### DIFF
--- a/Bourreau/spec/boutiques/boutiques_tester_spec.rb
+++ b/Bourreau/spec/boutiques/boutiques_tester_spec.rb
@@ -63,8 +63,9 @@ describe "Bourreau Boutiques Tests" do
       @boutiquesTask = SchemaTaskGenerator.generate(schema, descriptor)
       @boutiquesTask.integrate if File.exists?(descriptor)
       # Create a new instance of the generated task class
-      @task          = CbrainTask::BoutiquesTest.new
-      @task.params   = {}
+      @task             = CbrainTask::BoutiquesTest.new
+      @task.tool_config = ToolConfig.new
+      @task.params      = {}
       # Assign it a bourreau
       resource = RemoteResource.current_resource
       @task.bourreau_id = resource.id

--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -280,7 +280,7 @@ class ToolConfigsController < ApplicationController
     params.require(:tool_config).permit(
       :version_name, :description, :tool_id, :bourreau_id, :env_array, :script_prologue, :script_epilogue,
       :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_index_location,
-      :container_engine, :extra_qsub_args,
+      :container_engine, :extra_qsub_args, :singularity_overlays_specs,
       # The configuration of a tool in a VM managed by a
       # ScirCloud Bourreau is defined by the following
       # parameters which specify the disk image where the

--- a/BrainPortal/app/models/sing_squashfs_data_provider.rb
+++ b/BrainPortal/app/models/sing_squashfs_data_provider.rb
@@ -225,6 +225,15 @@ class SingSquashfsDataProvider < SshDataProvider
   # Internal support methods
   ########################################################
 
+  public
+
+  # Returns the full paths to the overlays
+  def singularity_overlays_full_paths #:nodoc:
+    self.get_squashfs_basenames.map do |basename|
+      Pathname.new(self.remote_dir) + basename
+    end.map(&:to_s)
+  end
+
   protected
 
   # Returns true if we have to use 'ssh' to
@@ -260,10 +269,10 @@ class SingSquashfsDataProvider < SshDataProvider
     @sq_files ||= self.meta[:squashfs_basenames] # cached_values
 
     if @sq_files.blank? || force
-      remote_cmd  = "cd #{self.remote_dir.bash_escape} && ls -1 | grep '\.squashfs$'"
+      remote_cmd  = "cd #{self.remote_dir.bash_escape} && ls -1'"
       text        = self.remote_bash_this(remote_cmd)
       lines       = text.split("\n")
-      @sq_files   = lines.select { |l| l =~ /\A\S+\.squashfs\z/ }.sort
+      @sq_files   = lines.select { |l| l =~ /\A\S+\.(squashfs|sqs)\z/ }.sort
       self.meta[:squashfs_basenames] = @sq_files
     end
 

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -189,6 +189,20 @@
       </div>
     <% end %>
 
+    <% t.edit_cell(:singularity_overlays_specs, :header => "Singularity Overlays", :show_width => 2) do |f| %>
+      <%= f.text_area :singularity_overlays_specs, :rows => 4, :cols => 120 %>
+        <div class="wide_field_explanation">
+        This field can contain one or several specifications for data overlays
+        to be included when the task is started with Singularity.
+        A specification can be either
+        a full path (e.g. <em>/a/b/data.squashfs</em>),
+        a path with a pattern (e.g. <em>/a/b/data*.squashfs</em>),
+        or a SquashFS Data Provider identified by its ID or name (e.g. <em>dp:123</em>, <em>dp:DpNameHere</em>).
+        In the case of a Data Provider, the overlays will be the files that the provider uses.
+        Separate specifications with blank, commas, or newlines.
+        </div>
+    <% end %>
+
   <% end %>
 
 

--- a/BrainPortal/db/migrate/20200922162525_add_singularity_overlays_specs_to_tool_configs.rb
+++ b/BrainPortal/db/migrate/20200922162525_add_singularity_overlays_specs_to_tool_configs.rb
@@ -1,0 +1,27 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2020
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+class AddSingularityOverlaysSpecsToToolConfigs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tool_configs, :singularity_overlays_specs, :text
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200804163321) do
+ActiveRecord::Schema.define(version: 20200922162525) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -430,6 +430,7 @@ ActiveRecord::Schema.define(version: 20200804163321) do
     t.string   "containerhub_image_name"
     t.string   "container_engine"
     t.string   "container_index_location"
+    t.text     "singularity_overlays_specs",  limit: 65535
     t.index ["bourreau_id"], name: "index_tool_configs_on_bourreau_id", using: :btree
     t.index ["tool_id"], name: "index_tool_configs_on_tool_id", using: :btree
   end


### PR DESCRIPTION
The admin can specify singularity overlays to mount.
The overlays can be specific paths, or refer to
all the overlays assocuated with a SingSquashfsDataProvider.

The make_available() method will detect if a file is
located on such an overlay and create its symlink to
point direcly there without synchronizing.