### PR TITLE
save short orcids fixes #1060

### DIFF
--- a/BrainPortal/app/controllers/nh_sessions_controller.rb
+++ b/BrainPortal/app/controllers/nh_sessions_controller.rb
@@ -109,7 +109,7 @@ class NhSessionsController < NeurohubApplicationController
       return
     end
 
-    # Query ORCID, get a JSON record with an ORCID ID.
+    # Query ORCID, get a JSON record with an ORCID iD.
     response = Typhoeus.post(ORCID_TOKEN_URI,
       :body   => {
                    :code          => code,
@@ -121,7 +121,7 @@ class NhSessionsController < NeurohubApplicationController
       :headers => { :Accept       => 'application/json' }
     )
 
-    # Extract the ORCID ID of the user
+    # Extract the ORCID iD of the user
     body  = response.response_body
     json  = JSON.parse(body)
     orcid = json['orcid'].presence || User.random_string # the random string will lead to 'no match'
@@ -130,11 +130,11 @@ class NhSessionsController < NeurohubApplicationController
     users = User.find_all_by_meta_data(:orcid, orcid)
 
     if users.size == 0
-      flash[:error] = "No NeuroHub user matches your ORCID ID. Create a NeuroHub account, or add your ORCID ID to your account."
+      flash[:error] = "No NeuroHub user matches your ORCID iD. Create a NeuroHub account, or add your ORCID ID to your account."
       redirect_to signin_path
       return
     elsif users.size > 1
-      flash[:notice] = "Several NeuroHub user accounts matches your ORCID ID. Using the most recently updated one."
+      flash[:notice] = "Several NeuroHub user accounts matches your ORCID iD. Using the most recently updated one."
       users = [ users.sort_by(&:updated_at).last ]
     end
     user = users.first

--- a/BrainPortal/app/controllers/nh_users_controller.rb
+++ b/BrainPortal/app/controllers/nh_users_controller.rb
@@ -29,6 +29,7 @@ class NhUsersController < NeurohubApplicationController
 
   def show #:nodoc:
     @user = User.find(params[:id])
+    puts 'HELLO HELLO HELLO '
     unless current_user.available_users.to_a.include?(@user)
       cb_error "You don't have permission to view this user.", :redirect => :neurohub
       # probably not needed until admin/manager etc added...
@@ -37,6 +38,7 @@ class NhUsersController < NeurohubApplicationController
 
   def myaccount #:nodoc:
     @user=current_user
+    @orcid_canonical = orcid_canonize(@user.meta[:orcid])
     render :show
   end
 
@@ -71,7 +73,8 @@ class NhUsersController < NeurohubApplicationController
 
     last_update = @user.updated_at
     if @user.update_attributes_with_logging(attr_to_update, current_user)
-      add_meta_data_from_form(@user, [:orcid])
+      mparam = {orcid: orcid_digits(params['meta']['orcid'])}
+      add_meta_data_from_form(@user, [:orcid], mparam)
       if attr_to_update[:password].present?
         flash[:notice] = "Your password was changed."
         @user.update_column(:password_reset, false)

--- a/BrainPortal/app/controllers/nh_users_controller.rb
+++ b/BrainPortal/app/controllers/nh_users_controller.rb
@@ -28,8 +28,8 @@ class NhUsersController < NeurohubApplicationController
   before_action :login_required
 
   def show #:nodoc:
-   @user = User.find(params[:id])
-   unless current_user.available_users.to_a.include?(@user)
+    @user = User.find(params[:id])
+    unless current_user.available_users.to_a.include?(@user)
       cb_error "You don't have permission to view this user.", :redirect => :neurohub
       # probably not needed until admin/manager etc added...
     end
@@ -43,6 +43,7 @@ class NhUsersController < NeurohubApplicationController
 
   def edit #:nodoc:
     @user = User.find(params[:id])
+    @orcid_canonical = orcid_canonize(@user.meta[:orcid])
     unless @user.id == current_user.id
       cb_error "You don't have permission to view this user.", :redirect => :neurohub
       # to change if admin/manager etc added...

--- a/BrainPortal/app/controllers/nh_users_controller.rb
+++ b/BrainPortal/app/controllers/nh_users_controller.rb
@@ -28,9 +28,8 @@ class NhUsersController < NeurohubApplicationController
   before_action :login_required
 
   def show #:nodoc:
-    @user = User.find(params[:id])
-    puts 'HELLO HELLO HELLO '
-    unless current_user.available_users.to_a.include?(@user)
+   @user = User.find(params[:id])
+   unless current_user.available_users.to_a.include?(@user)
       cb_error "You don't have permission to view this user.", :redirect => :neurohub
       # probably not needed until admin/manager etc added...
     end

--- a/BrainPortal/app/views/nh_sessions/new.html.erb
+++ b/BrainPortal/app/views/nh_sessions/new.html.erb
@@ -43,7 +43,7 @@
       <% if @orcid_uri %>
         <p class="text-center heading-sm grey-400 pb-4">OR</p>
         <%= link_to "Login with your ORCID account", @orcid_uri, :class => "btn-solid orcid" %>
-        <p class="field_note">(This will work if you have already entered your ORCID ID in your NeuroHub account's settings)</p>
+        <p class="field_note">(This will work if you have already entered your ORCID iD in your NeuroHub account's settings)</p>
       <% end %>
     <% end %>
   </div>

--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -68,8 +68,8 @@
 
   <fieldset>
     <%= f.label(:orcid, "ORCID iD") %>
-    <%= text_field_tag "meta[orcid]", @user.meta['orcid'], :size => 30 %><br />
-    <p class="field_note"><b>Note:</b> The url prefix is not required just enter all the 16 last symbols of your ORCID iD with dashes between each group of four, for example, 1234-5678-9098-765X
+    <%= text_field_tag "meta[orcid]", @orcid_canonical, :size => 30 %><br />
+    <p class="field_note">You can enter the full ORCID URI, which starts with <strong>https://</strong>, or just the numerical part, e.g. <strong>1234-5678-9012-345X</strong>
 
   </fieldset>
 

--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -67,8 +67,10 @@
   </fieldset>
 
   <fieldset>
-    <%= f.label(:orcid, "Orcid Id") %>
+    <%= f.label(:orcid, "ORCID iD") %>
     <%= text_field_tag "meta[orcid]", @user.meta['orcid'], :size => 30 %><br />
+    <p class="field_note"><b>Note:</b> Enter <em>only</em> 16 digits of your ORCID iD with dashes between each four digits, for example 1234-5678-9012-3456, do not enter the url prefix.
+
   </fieldset>
 
   <fieldset >

--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -69,7 +69,7 @@
   <fieldset>
     <%= f.label(:orcid, "ORCID iD") %>
     <%= text_field_tag "meta[orcid]", @user.meta['orcid'], :size => 30 %><br />
-    <p class="field_note"><b>Note:</b> Enter <em>only</em> 16 digits of your ORCID iD with dashes between each four digits, for example 1234-5678-9012-3456, do not enter the url prefix.
+    <p class="field_note"><b>Note:</b> The url prefix is not required just enter all the 16 last symbols of your ORCID iD with dashes between each group of four, for example, 1234-5678-9098-765X
 
   </fieldset>
 

--- a/BrainPortal/app/views/nh_users/show.html.erb
+++ b/BrainPortal/app/views/nh_users/show.html.erb
@@ -143,8 +143,8 @@
     <div class="card-row">
       <div class="card-item">
         <div>
-          <p class="card-label">Orcid ID</p>
-          <p class="card-text"><%=@user.meta['orcid'].presence || "-" %></p>
+          <p class="card-label">ORCID iD</p>
+          <p class="card-text"><%= @orcid_canonical || "-" %></p>
         </div>
       </div>
     </div>

--- a/BrainPortal/lib/neurohub_helpers.rb
+++ b/BrainPortal/lib/neurohub_helpers.rb
@@ -166,14 +166,9 @@ module NeurohubHelpers
     projs.to_a + user_projs.to_a
   end
 
-  # shortens ORCID iD by dropping url
+  # shortens ORCID iD by dropping url (possibly distorted)
   def orcid_digits(orcid)
-    orcid.gsub(%r{ https:/orcid.org/ |
-                   https://orcid.org/|
-                   http://orcid.org/ |
-                   http://orcid.org/ |
-                   orchid:\          |
-                   orchid:}ix, '')    if orcid.present?
+    orcid.to_s[/\d\d\d\d-\d\d\d\d-\d\d\d\d-\d\d\d[\dX]/i]
   end
 
   # normalizes ORCID iD into the standard/canonical form (the url)

--- a/BrainPortal/lib/neurohub_helpers.rb
+++ b/BrainPortal/lib/neurohub_helpers.rb
@@ -165,4 +165,20 @@ module NeurohubHelpers
     # The possible destinations are described by a set of Groups
     projs.to_a + user_projs.to_a
   end
+
+  # shortens ORCID iD by dropping url
+  def orcid_digits(orcid)
+    orcid.gsub(%r{ https:/orcid.org/ |
+                   https://orcid.org/|
+                   http://orcid.org/ |
+                   http://orcid.org/ |
+                   orchid:\          |
+                   orchid:}ix, '')    if orcid.present?
+  end
+
+  # normalizes ORCID iD into the standard/canonical form (the url)
+  def orcid_canonize(s)
+    "https://orcid.org/#{orcid_digits(s)}" if s.present?
+  end
+
 end


### PR DESCRIPTION
As some users save ORCID iD in the canonical, url form the stripping on save is added.
It is against the ORCID recommendations, but I guess not big deal.
On 'show' page I opted to render the full iD, following ORCID requirements.