### PR TITLE
allow create new task without any toolconfig fix #1078

### DIFF
--- a/BrainPortal/app/controllers/tasks_controller.rb
+++ b/BrainPortal/app/controllers/tasks_controller.rb
@@ -205,7 +205,7 @@ class TasksController < ApplicationController
 
     # Filter list of files as provided by the get request
     file_ids = params[:file_ids] || []
-    if @tool_config.inputs_readonly || @task.class.properties[:readonly_input_files]
+    if @tool_config.try(:inputs_readonly) || @task.class.properties[:readonly_input_files]
       access = :read
     else
       access = :write


### PR DESCRIPTION
this will fix bug when creating a task without selecting a toolconfig were generating an exception.