### PR TITLE
New hide_filtered() method

### DIFF
--- a/BrainPortal/app/models/exception_log.rb
+++ b/BrainPortal/app/models/exception_log.rb
@@ -35,7 +35,7 @@ class ExceptionLog < ApplicationRecord
 
   # Create an exception record based on exception, user, current request.
   def self.log_exception(exception, user, request)
-    params  = request.params.hide_filtered
+    params  = request.params.hide_filtered # this is not a ActionController::Parameters obj
     session = request.session
     hdrs    = request.headers.to_h.select { |k| k =~ /\A[A-Z]/ }
 

--- a/BrainPortal/app/models/message.rb
+++ b/BrainPortal/app/models/message.rb
@@ -219,6 +219,11 @@ class Message < ApplicationRecord
 
     admin_list = WorkGroup.find_by_id(RemoteResource.current_resource.meta[:error_message_mailing_list]) || User.all_admins.to_a
 
+    # Filter the request params to make things pretty and safe, even for admins.
+    filtered_params = request_params.is_a?(ActionController::Parameters) ?
+                      request_params.to_unsafe_hash.hide_filtered        :
+                      request_params.hide_filtered
+
     # Message for developers/admin
     Message.send_message(admin_list,
       :message_type  => :error,
@@ -231,7 +236,7 @@ class Message < ApplicationRecord
                         "Hostname: #{Socket.gethostname}\n" +
                         "Process ID: #{Process.pid}\n" +
                         "Process Name: #{$0.sub(/[\s\0]+\z/,"")}\n" +
-                        "Params: #{request_params.hide_filtered.inspect}\n" +
+                        "Params: #{filtered_params.inspect}\n" +
                         "Exception: #{exception.class.to_s}: #{exception.message}\n" +
                         "\n" +
                         exception.backtrace[0..30].join("\n") +

--- a/BrainPortal/lib/cbrain_extensions/hash_extensions/conversions.rb
+++ b/BrainPortal/lib/cbrain_extensions/hash_extensions/conversions.rb
@@ -59,19 +59,13 @@ module CBRAINExtensions #:nodoc:
         end.join(' ')
       end
 
-      if defined?(Rails)
-        # Remove sensitive parameters.
-        def hide_filtered!
-          keys.each do |k|
-            self[k] =  "[FILTERED]" if  Rails.configuration.filter_parameters.any? {|f| k =~ /#{f}/ }
-            self[k] = self[k].hide_filtered if self[k].respond_to?(:hide_filtered)
-          end
-          self
-        end
-
-        def hide_filtered #:nodoc:
-          clone.hide_filtered!
-        end
+      # Filter a hash to remove sensitive info. Usually for params.
+      # Will filter based on the +filter_parameters+ config of Rails.
+      # This method was removed from Hash in Rails 5.1.
+      def hide_filtered
+        filtered_keys   = Rails.application.config.filter_parameters.presence || [ :password, :token, :ssh_key ]
+        filter_object   = ActionDispatch::Http::ParameterFilter.new(filtered_keys)
+        filter_object.filter(self.clone)
       end
 
       # For API calls that receive Hash objects,


### PR DESCRIPTION
In old Rails there used to be a method called 'hide_filtered" for hash objects; we had a temporary replacement but this PR replaces it properly with a call to a class in ActionDispatch.

You can test this on the command-line. To check the exception reports, try adding `raise 'oh no'` in some of your controllers, especially those handling parameters with passwords.