### PR TITLE
refactor BrowseProviderFileCaching fixes #1094

### DIFF
--- a/BrainPortal/app/models/sing_squashfs_data_provider.rb
+++ b/BrainPortal/app/models/sing_squashfs_data_provider.rb
@@ -132,7 +132,7 @@ class SingSquashfsDataProvider < SshDataProvider
   end
 
   # Returns (and caches for 6 months) the entries in the DP. +user+ is not used here.
-  # Note that the DataProvider controller also caches this list in a YAML file in /tmp,
+  # Note that the DataProvider controller also caches this list in fast living cache
   # and it considers it valid for only one minute, so it will refresh that way more
   # often than our 6 months long caching here. The thing is, fetching the list from the
   # DP side is the real expensive operation, but also we don't expect the list to change

--- a/BrainPortal/lib/browse_provider_file_caching.rb
+++ b/BrainPortal/lib/browse_provider_file_caching.rb
@@ -47,14 +47,15 @@ class BrowseProviderFileCaching
     end
   end
 
-  # Clear the cache file.
+  # Clear the provider browse cache.
   def self.clear_cache(user, provider, browse_path = nil) #:nodoc:
     Rails.cache.delete(dp_cache_key(user, provider, browse_path))
   end
 
   private
 
-  def self.dp_cache_key(user, provider, browse_path)
+  # The cache key, which depends on user, provider and browse path.
+  def self.dp_cache_key(user, provider, browse_path) #:nodoc:
     "dp_file_list_#{user.try(:id)}-#{provider.try(:id)}-#{browse_path}"
   end
 

--- a/BrainPortal/lib/browse_provider_file_caching.rb
+++ b/BrainPortal/lib/browse_provider_file_caching.rb
@@ -22,14 +22,15 @@
 
 # A stupid class to provide methods to cache
 # the browsing results of a data provider into
-# a file in /tmp ; not OO at all
-#
-# Note: this entire class should be re-engineered to use Rails.cache
 class BrowseProviderFileCaching
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  # Contacts the +provider+ side with provider_list_all(as_user,browse_path) and
+  # How long we cache the results of provider_list_all();
+  BROWSE_CACHE_EXPIRATION = 60.seconds #:nodoc:
+  RACE_CONDITION_DELAY    = 10.seconds # Short delay for concurrent threads
+
+  # Contacts the +provider+ side with provider_list_all(as_user, browse_path) and
   # caches the resulting array of FileInfo objects for 60 seconds.
   # Returns that array. If refresh is set to true, it will force the
   # refresh of the array, otherwise any array that was generated less
@@ -37,51 +38,24 @@ class BrowseProviderFileCaching
   def self.get_recent_provider_list_all(provider, as_user, browse_path = nil, refresh = false) #:nodoc:
 
     refresh = false if refresh.blank? || refresh.to_s == 'false'
-
-    # Check to see if we can simply reload the cached copy
-    cache_file = self.cache_file(provider, as_user, browse_path)
-    if ! refresh && File.exist?(cache_file) && File.mtime(cache_file) > 60.seconds.ago
-       filelisttext = File.read(cache_file)
-       fileinfolist = YAML.load(filelisttext)
-       return fileinfolist
+    key     = dp_cache_key(as_user, provider, browse_path)
+    Rails.cache.fetch(key,
+                      force:              refresh,
+                      expires_in:         BROWSE_CACHE_EXPIRATION,
+                      race_condition_ttl: RACE_CONDITION_DELAY) do
+      provider.provider_list_all(as_user, browse_path)
     end
-
-    # Get info from provider
-    fileinfolist = provider.provider_list_all(as_user, browse_path)
-
-    # Write a new cached copy
-    save_cache(provider, as_user, browse_path, fileinfolist)
-
-    # Return it
-    fileinfolist
-  end
-
-  # Saves the array of FileInfo object in a file in /tmp. See
-  # also the method cache_file for the file's name.
-  def self.save_cache(provider, user, browse_path, fileinfolist) #:nodoc:
-    cache_file = self.cache_file(provider, user, browse_path)
-    tmpcachefile = cache_file + ".#{Process.pid}.tmp";
-    File.open(tmpcachefile,"w") do |fh|
-       fh.write(YAML.dump(fileinfolist))
-    end
-    File.rename(tmpcachefile,cache_file) rescue true  # crush it
   end
 
   # Clear the cache file.
-  def self.clear_cache(provider, user, browse_path) #:nodoc:
-    cache_file = self.cache_file(provider, user, browse_path)
-    File.unlink(cache_file) rescue true
+  def self.clear_cache(user, provider, browse_path = nil) #:nodoc:
+    Rails.cache.delete(dp_cache_key(user, provider, browse_path))
   end
 
   private
 
-  # Generates a file name for a cache file; the name is
-  # specific to both the provider and the user accessing it.
-  def self.cache_file(provider, user, browse_path) #:nodoc:
-    pathkey = browse_path.presence || '.'
-    pathkey = pathkey.gsub(/[^a-zA-Z0-9_\.]/) { |c| c.each_byte.map { |i| sprintf "%%%2.2x",i }.join }
-    cache_file = "/tmp/dp_cache_list_all_#{user.id}.#{provider.id}-#{pathkey}"
-    cache_file
+  def self.dp_cache_key(user, provider, browse_path)
+    "dp_file_list_#{user.try(:id)}-#{provider.try(:id)}-#{browse_path}"
   end
 
 end

--- a/BrainPortal/spec/controllers/data_providers_controller_spec.rb
+++ b/BrainPortal/spec/controllers/data_providers_controller_spec.rb
@@ -241,6 +241,11 @@ RSpec.describe DataProvidersController, :type => :controller do
           allow(data_provider).to receive(:is_browsable?).and_return(true)
           allow(data_provider).to receive(:online?).and_return(true)
           allow(data_provider).to receive(:provider_list_all).and_return(file_info_list)
+
+          # bypassing caching
+          allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache.lookup_store(:memory_store))
+          allow_any_instance_of(ActiveSupport::Cache::MemoryStore).to receive(:exist?).and_return(false)
+          allow_any_instance_of(ActiveSupport::Cache::MemoryStore).to receive(:write).and_return(true)
         end
         context "provider is not browsable" do
           before(:each) do


### PR DESCRIPTION
Refactored provider browsing cache to use default Rails cache. 

People who use in memory caching (memcache etc) might need re-adjust setting if using large providers (e.g. 2 M for 10000 files). Currently non-issue for us as our portal uses disk for caching.