### PR TITLE
avoid exception nil.inputs_readonly fix

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/templates/portal.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/portal.rb.erb
@@ -117,7 +117,7 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
   # The symbol can be passed to methods such as Userfile.find_accessible_by_user().
   # Depending on the value, more or less files are allowed to be processed.
   def file_access
-    @_file_access ||= (self.class.properties[:readonly_input_files].present? || self.tool_config.inputs_readonly ? :read : :write)
+    @_file_access ||= (self.class.properties[:readonly_input_files].present? || self.tool_config.try(:inputs_readonly) ? :read : :write)
   end
 
 % unless defaults.empty?


### PR DESCRIPTION
I noted exceptions in production when method is checked on nil. This should fix it.