### PR TITLE
Unarchive a task when the archive is just a plain tar

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1524,14 +1524,18 @@ class ClusterTask < CbrainTask
     Dir.chdir(full) do
 
       if ! File.exists?(tar_file)
-        self.addlog("Cannot unarchive: tar archive does not exist.")
-        return false
+        tar_file.sub!(/\.gz\z/,"") # try without the .gz
+        if ! File.exists?(tar_file)
+          self.addlog("Cannot unarchive: tar archive does not exist.")
+          return false
+        end
       end
 
       self.addlog("Attempting to unarchive work directory.")
 
+      z_opt = (tar_file =~ /\.gz\z/i) ? "z" : ""
       status = with_stdout_stderr_capture(tar_capture) do
-        system("tar", "-xzf", tar_file)
+        system("tar", "-x#{z_opt}f", tar_file)
         $?
       end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -35,7 +35,7 @@ class TaskWorkdirArchive < TarArchive
   before_destroy :before_destroy_adjust_task
 
   def self.file_name_pattern #:nodoc:
-    /\ACbrainTask_Workdir_[\w\-]+\.tar\.gz\z/i
+    /\ACbrainTask_Workdir_[\w\-]+\.tar(\.gz)?\z/i
   end
 
   def self.pretty_type #:nodoc:


### PR DESCRIPTION
This support unarchiving a task if, somehow, the
task archive is not in `tar.gz` but just a plain `.tar`.

There is no mechnism for creating such archives for
the moment except manual intervention.

This implements parts of #1123