### PR TITLE
Added SimpleFileExtractor tool

### DIFF
--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/bourreau/simple_file_extractor.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/bourreau/simple_file_extractor.rb
@@ -1,0 +1,185 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# A subclass of CbrainTask::ClusterTask to run SimpleFileExtractor.
+class CbrainTask::SimpleFileExtractor < ClusterTask
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  include RestartableTask
+  include RecoverableTask
+
+  def setup #:nodoc:
+    params       = self.params
+    ids          = params[:interface_userfile_ids]
+
+    # DP statistics
+    dp_counts = Userfile.where(:id => ids).group(:data_provider_id).count
+    dp_files  = Userfile.where(:id => ids).group(:data_provider_id).sum(:num_files)
+    dp_sizes  = Userfile.where(:id => ids).group(:data_provider_id).sum(:size)
+    self.addlog("DataProvider storage summary:")
+    dp_counts.each do |dp_id,count|
+      dp       = DataProvider.find(dp_id)
+      dp_size  = dp_sizes[dp_id]
+      dp_files = dp_files[dp_id]
+      self.addlog("DataProvider '#{dp.name}': #{count} entries, #{dp_files} files, #{dp_size} bytes")
+    end
+
+    # Verify data providers
+    ok  = true
+    dps = DataProvider.where(:id => dp_counts.keys).to_a
+    dps.each do |dp|
+      next if dp.is_fast_syncing?
+      self.addlog("Error: DataProvider '#{dp.name}' is not a local storage.")
+      ok = false
+    end
+    return false if ! ok
+
+    # Sync input files
+    self.addlog "Synchronizing input collections (#{ids.size} inputs)"
+    start_sync   = 1.day.ago
+    tot_files    = 0
+    tot_size     = 0
+    ids.each_with_index do |id,i|
+      userfile=FileCollection.find(id)
+      if Time.now - start_sync > 10.minutes # prints a message every ten minutes
+        self.addlog("Synchronizing collection #{i+1}/#{ids.size}: \"#{userfile.name}\"")
+        start_sync = Time.now
+      end
+      userfile.sync_to_cache
+      tot_files += userfile.num_files
+      tot_size  += userfile.size
+    end
+
+    self.addlog "Synchronized #{tot_size} bytes in #{tot_files} files"
+
+    safe_mkdir("extracted",0700)
+
+    true
+  end
+
+  # This task does not submit anything on the cluster
+  def cluster_commands #:nodoc:
+    nil
+  end
+
+  def save_results #:nodoc:
+    params = self.params
+    ids    = params[:interface_userfile_ids]
+
+    # Main inputs
+    patterns  = patterns_as_array(params[:patterns].presence || {})
+    file_cols = FileCollection.where(:id => ids).to_a
+
+    # Error and warning helpers
+    error_examples = {}
+    error_counts   = {}
+
+    log_it = ->(message,pat,userfile,extpath) {
+      extpath &&= extpath.sub((userfile.cache_full_path.parent.to_s+"/"),"")
+      error_examples[message] ||= (
+        "Pattern: '#{pat}', Collection #{userfile.id} '#{userfile.name}'" +
+        (extpath.blank? ? "" : ", Matched extraction file: '#{extpath}'")
+      )
+      error_counts[message] ||= 0
+      error_counts[message]  += 1
+    }
+
+    # Main loop for extracting stuff
+    self.addlog "Extracting files"
+
+    start_extract = 1.day.ago
+    file_cols.each_with_index do |userfile,i|
+
+      # Prints a progress message every ten minutes
+      if Time.now - start_extract > 10.minutes
+        self.addlog("Extracting from collection ##{i+1}/#{file_cols.size}: \"#{userfile.name}\"")
+        start_extract = Time.now
+      end
+
+      cache_path = userfile.cache_full_path.parent
+      patterns.each do |pat|
+        pat = Pathname.new(pat).cleanpath
+        # Quick safety check just like in after_form on portal side
+        cb_error "Wrong pattern encountered: #{pat}" if
+          (! pat.relative?) || (! pat.to_s.index('/')) || (pat.to_s.start_with? "../")
+        path_pattern = cache_path + pat
+        globbed_paths=Dir.glob(path_pattern.to_s)
+        if globbed_paths.empty?
+          log_it.("No files matched pattern", pat, userfile, nil)
+          next
+        end
+        globbed_paths.each do |filepath|
+          if ! filepath.start_with?(cache_path.to_s)
+            log_it.("Extraction outside collection", pat, userfile, filepath)
+            next
+          end
+          if File.symlink?(filepath)
+            log_it.("Trying to extract a symbolic link", pat, userfile, filepath)
+            next
+          end
+          if ! File.file?(filepath)
+            log_it.("Trying to extract a non regular file", pat, userfile, filepath)
+            next
+          end
+          basename = File.basename(filepath)
+          if File.file?("extracted/#{basename}")
+            log_it.("Trying to extract a file with a name matching something already extracted", pat, userfile, filepath)
+            next
+          end
+          system "cp #{filepath.to_s.bash_escape} extracted/#{basename.bash_escape}"
+        end # each globbed file
+      end # each pattern
+    end # each FileCollection
+
+    # Log warnings and errors
+    if error_examples.present?
+      self.addlog "Some errors or warnings occurred; a count and a single example is given below."
+    end
+    error_examples.keys.each do |message|
+      count   = error_counts[message]
+      example = error_examples[message]
+      self.addlog "#{count}x : #{message}; Example: #{example}"
+    end
+
+    # Save final output
+    out_name = params[:output_file_name] + "-" + self.run_id
+    self.addlog("Saving extracted collection #{out_name}")
+    output_file = safe_userfile_find_or_new(FileCollection, :name => out_name)
+    output_file.save!
+    params[:output_file_id] = output_file.id
+    self.addlog("Adding content to collection #{out_name}")
+    output_file.cache_copy_from_local_file("extracted")
+
+    self.addlog_to_userfiles_these_created_these( file_cols , [ output_file ] )
+
+    true
+  end
+
+  # Add here the optional error-recovery and restarting
+  # methods described in the documentation if you want your
+  # task to have such capabilities. See the methods
+  # recover_from_setup_failure(), restart_at_setup() and
+  # friends, described in the CbrainTask Programmer Guide.
+
+end
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/common/simple_file_extractor.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/common/simple_file_extractor.rb
@@ -1,0 +1,47 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Model code common to the Bourreau and Portal side for SimpleFileExtractor.
+class CbrainTask::SimpleFileExtractor
+
+  # In the params, the list of patterns is maintained as a hash:
+  #   { "0" => "pat1", "1" => "pat2", etc }
+  # This returns just the array of values, while preserving the ordering
+  # that the keys encode:
+  #   [ "pat1", "pat2" etc ]
+  def patterns_as_array(pat_hash)
+    keys      = pat_hash.keys.sort { |a,b| a.to_i <=> b.to_i }
+    pat_array = keys.map { |i| pat_hash[i].presence }.compact
+    pat_array
+  end
+
+  # This does the opposite of patterns_as_array; given
+  # an array of patterns, returns a hash where the keys are
+  # the index of the array
+  def patterns_as_hash(pat_array)
+    pat_hash = {}
+    pat_array.each_with_index { |pat,i| pat_hash[i.to_s] = pat }
+    pat_hash
+  end
+
+end
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/portal/simple_file_extractor.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/portal/simple_file_extractor.rb
@@ -1,0 +1,113 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# A subclass of CbrainTask to launch SimpleFileExtractor.
+class CbrainTask::SimpleFileExtractor < PortalTask
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # RDOC comments here, if you want, although the method
+  # is created with #:nodoc: in this template.
+  def self.default_launch_args #:nodoc:
+    {
+      :patterns => {}, # keys are numeric, values are the patterns
+    }
+  end
+
+  def before_form #:nodoc:
+    params = self.params
+    ids    = params[:interface_userfile_ids].presence || []
+
+    self.validate_input_ids(ids)
+    ""
+  end
+
+  def after_form #:nodoc:
+    params = self.params
+    ids    = params[:interface_userfile_ids].presence || []
+
+    self.validate_input_ids(ids) # just like we did in before_form
+
+    # Validate output file name
+    out_name = params[:output_file_name].presence
+    self.params_errors.add(:output_file_name, "provided contains some unacceptable characters.") unless
+      FileCollection.is_legal_filename?(out_name)
+
+    # Clean up pattern list
+    patterns = patterns_as_array(params[:patterns].presence || {})
+    patterns = patterns.map(&:presence).compact
+    patterns = patterns.map { |pat| Pathname.new(pat).cleanpath }
+    params[:patterns] = patterns_as_hash(patterns.map(&:to_s)) # write back cleaned list
+
+    # Validate them and report errors; note that here the array contains Pathname objects
+    #
+    # Expect things like:
+    #
+    #   */*txt
+    #   */subdir/abc.txt
+    #   */subdir/*/*.txt
+    #   FileColName*/*/*.txt
+    patterns.each_with_index do |pat,idx|
+      if ! pat.relative?
+        self.params_errors.add("patterns[#{idx}]", "is not a relative path")
+      end
+      if ! pat.to_s.index('/') # must contain at least 2 components
+        self.params_errors.add("patterns[#{idx}]", "does not contain at least two levels")
+      end
+      if pat.to_s.start_with? "../"
+        self.params_errors.add("patterns[#{idx}]", "cannot map outside of collections")
+      end
+    end
+
+    ""
+  end
+
+  def final_task_list #:nodoc:
+    return [ self ] # default behavior
+  end
+
+  def untouchable_params_attributes #:nodoc:
+    { :output_file_id => true }
+  end
+
+  # Verifies that all +ids+ are FileCollections
+  # that the user has the permissions to read.
+  def validate_input_ids(ids)
+    cb_error "No files selected" if ids.size == 0
+    selected_inputs = Userfile.find_all_accessible_by_user(self.user, :access_requested => :read).where( 'userfiles.id' => ids )
+
+    # Make sure user can access the content of all these files
+    accessible_count = selected_inputs.count
+    if accessible_count != ids.size
+      cb_error "You do not have read access to all the selected files (only #{accessible_count} out of #{ids.count})"
+    end
+
+    # Make sure they are all FileCollections
+    # TODO support CbrainFileLists ?
+    fc_count = FileCollection.where(:id => ids).count
+    if fc_count != ids.size
+      cb_error "This task requires all inputs to be FileCollections (or subclasses of FileCollection)"
+    end
+  end
+
+end
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/_show_params.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/_show_params.html.erb
@@ -1,0 +1,29 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<br>
+<strong>Output:</strong>
+<p>
+Final file: <%= link_to_userfile_if_accessible params[:output_file_id] %>
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/_task_params.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/_task_params.html.erb
@@ -1,0 +1,50 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<fieldset>
+  <legend>Inputs summary</legend>
+  <% file_ids = params[:interface_userfile_ids] || [] %>
+  <strong><%= file_ids.size %> files to be processed:</strong><BR>
+  <ul>
+    <% file_ids[0,10].each do |id| %>
+      <li><%= link_to_userfile_if_accessible id %></li>
+    <% end %>
+    <% if file_ids.size > 10 %>
+      <li>(<%= file_ids.size - 10 %> more files...)</li>
+    <% end %>
+  </ul>
+</fieldset>
+
+<fieldset>
+  <legend>Extraction patterns:</legend>
+  <% 10.times do |i| %>
+    <%= form.params_text_field "patterns[#{i}]", :size => 120 %><p>
+  <% end %>
+</fieldset>
+
+<fieldset>
+  <legend>Output name</legend>
+  <%= form.params_text_field :output_file_name, :size => 40 %>
+</fieldset>
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/public/edit_params_help.html
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/public/edit_params_help.html
@@ -1,0 +1,125 @@
+
+<!--
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-->
+
+<h3>SimpleFileExtractor</h3>
+
+This program will extract files out of a set of FileCollections.
+The result is a new FileCollection which will be a flat set of all
+the etracted files.
+
+<p>
+
+Files are specified using standard UNIX file 'patterns' (or globs).
+These are <em>not</em> regular expressions.
+
+<p>
+
+File patterns may contain:
+<p>
+
+<dl>
+  <dt>*</dt>
+
+  <dd>
+    A asterix will match zero, one, or many characters in a filename
+    or in path. It will not matcht eh directory separator "/",
+    however.
+  </dd>
+
+  <dt>?</dt>
+
+  <dd>
+    A question mark will match a single character in a filename or
+    in a path component.
+  </dd>
+</dl>
+
+<p>
+
+File patterns will be matched with all the files in all
+the selected FileCollections in input, and files that are matched
+will be extracted and put into the output flat FileCollection.
+
+<p>
+
+All file patterns must include a first component that will be matched
+with the base name of the FileCollection itself. That means a pattern
+will always include at least on "/" character in it.
+
+<p>
+
+This program will <strong>not</strong> extract:
+
+<ul>
+  <li>Subdirectories</li>
+  <li>Symbolic links</li>
+  <li>Other types of special files</li>
+</ul>
+
+For performance reasons, the program will ensure that at execution
+time, the set of files given in input are located on a DataProvider
+that is configured as <em>local</em> storage, to avoid having to
+copy the entire file collection contents before extraction.
+
+<h3>Examples</h3>
+
+Assume we have selected three FileCollections named "Dataset1",
+"CivetOut2" and "BIDS3", and that they contain these files:
+
+<p>
+
+Content of all three collections:<br>
+<pre>
+Dataset1/README.txt
+Dataset1/sales/sales.csv
+Dataset1/sales/sales.txt
+Dataset1/reports/errors.txt
+Dataset1/reports/errors.pdf
+CivetOut2/native/subject.mnc.gz
+CivetOut2/thickness/thick_subject_30mm.txt
+CivetOut2/thickness/thick_subject_40mm.txt
+CivetOut2/surfaces/surf_subject_30mm.txt
+CivetOut2/surfaces/surf_subject_40mm.txt
+BIDS3/Report.txt
+BIDS3/sub-1234/README.txt
+BIDS3/sub-1234/anat/sub-1234.nii.gz
+</pre>
+
+<p>
+The following patterns will each extract these files:
+<p>
+Pattern: *D*/R*.txt<br>
+Files matched: Dataset1/README.txt, BIDS3/Report.txt<br>
+Resulting files in output: README.txt, report.txt
+<p>
+Pattern: */s*/*.txt<br>
+Files matched: Dataset1/sales/sales.txt, CivetOut2/surfaces/surf_subject_30mm.txt, CivetOut2/surfaces/surf_subject_40mm.txt, BIDS3/sub-1234/README.txt<br>
+Resulting files in output: sales.txt, surf_subject_30mm.txt, surf_subject_40mm.txt, README.txt
+<p>
+Pattern: */*/*30mm*<br>
+Files matched: CivetOut2/thickness/thick_subject_30mm.txt, CivetOut2/surfaces/surf_subject_30mm.txt<br>
+Extracted files: thick_subject_30mm.txt, surf_subject_30mm.txt
+<p>
+
+

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/public/tool_info.html
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/simple_file_extractor/views/public/tool_info.html
@@ -1,0 +1,43 @@
+
+<!--
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-->
+
+<h1>SimpleFileExtractor</h1>
+
+This tool can extract arbitrary files from FileCollections
+(or other FileCollection subclasses) based on standard UNIX
+file patterns (filenames with '*' and '?' in them).
+<p>
+The tool will produce a new simple FileCollection containing all the
+extracted files in a single level (basically, a directory with all
+those files).
+<p>
+See the help page for the parameters for more information and recommendations
+about how the patterns must be specified, and what kind of error handling
+the tool provides.
+<p>
+
+<small>
+This tool comes standard as part of the CBRAIN distribution.
+Written by Pierre Rioux, 2021
+</small>

--- a/BrainPortal/lib/generators/cbrain_task/templates/task_params.html.erb
+++ b/BrainPortal/lib/generators/cbrain_task/templates/task_params.html.erb
@@ -67,5 +67,5 @@ List of Userfiles selected:<BR>
 
 Final report name: <%%= form.params_text_field :report %>
 <BR>
-Send report to Prime Minister Stephen Harper: <%%= form.params_check_box :to_ottawa %>
+Send report to Prime Minister Of Canada: <%%= form.params_check_box :to_ottawa %>
 <P>

--- a/BrainPortal/lib/smart_data_provider_interface.rb
+++ b/BrainPortal/lib/smart_data_provider_interface.rb
@@ -44,10 +44,11 @@ module SmartDataProviderInterface
       @real_provider = nil
       return @real_provider
     end
+    dp_hostnames = dp_hostnames.map { |x| x.downcase }
 
     # Create only one provider object, depending on whether we want a network provider
     # or a local provider
-    if dp_hostnames.include?(Socket.gethostname) && File.directory?(dp_remote_dir)
+    if dp_hostnames.include?(Socket.gethostname.downcase) && File.directory?(dp_remote_dir)
       @real_provider = localclass.new
     else
       @real_provider = networkclass.new


### PR DESCRIPTION
This PR adds a new standard CbrainTask, the `SimpleFileExtractor`.


You select a bunch of FileCollections, and provide patterns such as `*/*.txt` or `*/thickness/*30mm*.dat` etc, and it will create a new FileCollection with all these extracted files in a single level.

The program verifies that the input FileCollections are on a local DP.

It will also provide a bunch of statistics and warning messages when collisions occur, or patterns don't match anything, etc.

I took great care of validating as much as possible the globbing code so that no files are extracted outside of their proper collections.