### PR TITLE
boutiques parameter line breaks

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
@@ -438,7 +438,7 @@
     # Get group parameters
     id = group['id']
     name = group['name']
-    groupDescription = group['description']
+    groupDescription = group['description'].presence || ''
     groupParams = gIdToPrms[id]
     mbrs = gIdToMbrs[id]
     defaultChecked = group['one-is-required'] || required.any? { |p| mbrs.include? p["id"] }
@@ -450,9 +450,12 @@
         <%= name %> <%% groupCheckbox.('<%= id %>',<%= defaultChecked %>) %>
       </h3>
       <h5 style="font-size : 9.5pt; font-weight: normal; padding-top: 2px;" class="grp-desc">
-        <%= groupDescription %>
+        <%- groupDescription.split("\n").each do |line| %>
+          <%= line %> <br>
+        <%- end %>
       </h5>
-    </div><%%= "<br>".html_safe %>
+    </div>
+    <br>
     <%# Write group parameters (required ones first) %>
     <%- groupParams.each { |p| parameter.(p, true) if required.any? { |r| p["id"]==r["id"] } } -%>
     <%- groupParams.each { |p| parameter.(p, true) if optional.any? { |t| p["id"]==t["id"] } } -%>

--- a/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
@@ -301,7 +301,7 @@
 <%%# Generate a parameter's description block for +desc+ %>
 <%% description = lambda do |desc, isGroupMember = false| %>
   <span class="tsk-prm-desc">
-    <%%= desc %><%%= "<br><br>".html_safe if isGroupMember %>
+    <%%= desc.split("\n").map { |s| h(s) }.join("<br>").html_safe if desc %><%%= "<br><br>".html_safe if isGroupMember %>
   </span>
 <%% end %>
 


### PR DESCRIPTION
This is to allow boutiques parameters descriptions include line breaks (Darius request).

I was not able to reopen previous https://github.com/aces/cbrain/pull/1151, so I opened this new pr

see 1151 for previous discussions. This is lightweight version compared to the previous, only tackles the params in task view but does not need any imports. 

PS. Personally, I think displaying parameters in verbatim mode (`<pre>`) would look nicer, though I know that not everybody likes fixed fonts. Perhaps, a subset of html/bbcode/markdown may allow for more eye candy.