### PR TITLE
Fix for optional list in task params

### DIFF
--- a/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb
@@ -346,7 +346,7 @@
   <%- end -%>
         )
 
-  <%- if opt && list != true -%>
+  <%- if opt -%>
         # Optional parameter enable/disable toggle
         checkbox.(id)
 


### PR DESCRIPTION
This issue came from the following PR #911. 

By removing `list != true`, we are now able to POST the information about the list because the code https://github.com/aces/cbrain/blob/master/BrainPortal/lib/cbrain_task_generators/templates/task_params.html.erb.erb#L781 is now called. 

We still have an UI issue, when selecting value for an optional value with value-choices, e,g: 

```
        {
            "command-line-flag": "--steps",
            "description": "Longitudinal pipeline steps to run.",
            "id": "steps",
            "list": true,
            "name": "steps",
            "optional": true,
            "type": "String",
            "value-choices": [
                "cross-sectional",
                "template",
                "longitudinal"
            ],
            "value-key": "[STEPS]"
        }
```

The checkbox will not be checked even if value(s) is/are selected. But the value is still send via the POST. 

Close  #1154

