### PR TITLE
Added 'Login With Globus' on NH main page

### DIFF
--- a/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
+++ b/BrainPortal/app/assets/stylesheets/neurohub.scss.erb
@@ -230,7 +230,10 @@ $WARNING_ALT: #db8402;
 $WARNING_DK: #653c02;
 
 $ORCID_BG: #31789b;
-$ORCID_ALT: #a6ce39;
+$ORCID_ALT: #a6ce39; /* the orcid ugly green */
+
+$GLOBUS_BG: #31789b;
+$GLOBUS_ALT: #27518F; /* the globus deep blue */
 
 $CBRAIN_BG: #29b9e8;
 $CBRAIN_WASH: #ecf7fc;
@@ -852,6 +855,12 @@ Button variants: solid, text, and nav.
   color: $ORCID_ALT;
 }
 
+// link to globus information pages
+.globus_home_link {
+  text-decoration: underline;
+  color: $GLOBUS_ALT;
+}
+
 .btn-solid.orcid {
   background-color: $ORCID_BG;
   border-color: $ORCID_BG;
@@ -860,6 +869,19 @@ Button variants: solid, text, and nav.
   &:hover {
     background-color: $ORCID_ALT;
     border-color: $ORCID_ALT;
+    color: $DEFAULT_BG;
+    transition: $TRANSITION_HOVER_ON;
+  }
+}
+
+.btn-solid.globus {
+  background-color: $GLOBUS_BG;
+  border-color: $GLOBUS_BG;
+  color: $DEFAULT_BG;
+  text-decoration: none;
+  &:hover {
+    background-color: $GLOBUS_ALT;
+    border-color: $GLOBUS_ALT;
     color: $DEFAULT_BG;
     transition: $TRANSITION_HOVER_ON;
   }
@@ -915,6 +937,11 @@ Button variants: solid, text, and nav.
 }
 
 .btn-text.orcid {
+  text-decoration: none;
+  color: black;
+}
+
+.btn-text.globus {
   text-decoration: none;
   color: black;
 }

--- a/BrainPortal/app/controllers/nh_users_controller.rb
+++ b/BrainPortal/app/controllers/nh_users_controller.rb
@@ -26,6 +26,7 @@ class NhUsersController < NeurohubApplicationController
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   include OrcidHelpers
+  include GlobusHelpers
 
   before_action :login_required
 
@@ -45,13 +46,15 @@ class NhUsersController < NeurohubApplicationController
 
   def edit #:nodoc:
     @user = User.find(params[:id])
-    @orcid_canonical = orcid_canonize(@user.meta[:orcid])
-    @orcid_uri       = orcid_login_uri()
     unless @user.id == current_user.id
       cb_error "You don't have permission to view this user.", :redirect => :neurohub
       # to change if admin/manager etc added...
       # todo move to security helpers
     end
+
+    @orcid_canonical = orcid_canonize(@user.meta[:orcid])
+    @orcid_uri       = orcid_login_uri() # set to nil if orcid not configured by admin
+    @globus_uri      = globus_login_uri(nh_globus_url) # set to nil if globus not configured by admin
   end
 
   def change_password #:nodoc:

--- a/BrainPortal/app/controllers/users_controller.rb
+++ b/BrainPortal/app/controllers/users_controller.rb
@@ -90,7 +90,7 @@ class UsersController < ApplicationController
       .where( "updated_at > ?", SessionHelpers::SESSION_API_TOKEN_VALIDITY.ago )
       .order(:updated_at)
 
-    @globus_uri = globus_login_uri
+    @globus_uri = globus_login_uri(globus_url)
 
     respond_to do |format|
       format.html # show.html.erb

--- a/BrainPortal/app/views/nh_sessions/new.html.erb
+++ b/BrainPortal/app/views/nh_sessions/new.html.erb
@@ -40,6 +40,7 @@
       <p class="field_note">Note: You can use your CBRAIN account credentials to log in to NeuroHub. </p>
       <%= submit_tag  "Sign in", :class => 'btn-solid secondary' %>
       <%= link_to "Forgot your password?", request_password_users_path, :class => "btn-text cbrain external" %>
+
       <% if @orcid_uri %>
         <p class="text-center heading-sm grey-400 pb-4">OR</p>
         <%= link_to @orcid_uri, :class => "btn-solid orcid" do %>
@@ -49,6 +50,16 @@
         <p class="field_note">This will work if you have already linked your ORCID iD in your NeuroHub account.</p>
         <p class="field_note">You can learn more about ORCID at <%= link_to 'ORCID.org', "https://orcid.org/", :class => 'orcid_home_link' %></p>
       <% end %>
+
+      <% if @globus_uri %>
+        <p class="text-center heading-sm grey-400 pb-4">OR</p>
+        <%= link_to @globus_uri, :class => "btn-solid globus" do %>
+          Sign in with Globus
+        <% end %>
+        <p class="field_note">This will work if you have already linked your NeuroHub account to a Globus provider.</p>
+        <p class="field_note">You can learn more about Globus at <%= link_to 'www.globus.org', "https://www.globus.org/", :class => 'globus_home_link' %></p>
+      <% end %>
+
     <% end %>
   </div>
 

--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -70,8 +70,8 @@
     <fieldset>
       <%= f.label(:orcid, "ORCID iD") %>
       <% if @orcid_canonical.blank? %>
-        <p class="btn-text orcid">
-          <%= link_to @orcid_uri, :class => "btn-solid orcid" do %>
+        <p class="btn-solid orcid">
+          <%= link_to @orcid_uri, :class => "" do %>
             <%= image_tag("neurohub/ORCIDiD_iconvector.svg", :alt => "ORCID logo", :class => "orcid_logo") %>
             Connect your NeuroHub account to your ORCID iD
           <% end %>
@@ -102,6 +102,41 @@
               :method  => :post,
               :data    => { :confirm => "Are you sure you want to unlink your account from this ORCID iD?" } do %>
               Remove this ORCID iD from your NeuroHub account
+          <% end %>
+        </p>
+      <% end %>
+    </fieldset>
+  <% end %>
+
+  <% if @globus_uri %>
+    <fieldset>
+      <%= f.label(:globus, "Globus Identity") %>
+      <% glob_user = @user.meta[:globus_preferred_username] %>
+      <% glob_prov = @user.meta[:globus_provider_name] %>
+      <% if glob_user.blank? %>
+        <p class="btn-solid globus">
+          <%= link_to @globus_uri, :class => "" do %>
+            Connect your NeuroHub account to a Globus identity provider
+          <% end %>
+        </p>
+        <p class="field_note">
+          Globus is a non-profit service for secure, reliable research data management.
+          <br>
+          Learn more at <%= link_to "www.globus.org", "https://www.globus.org/", :class => "globus_home_link" %>
+        </p>
+      <% else %>
+        <p class="card-text">
+             Identity Name: <%= glob_user %><br>
+             Identity Provider: <%= glob_prov %>
+        </p>
+      <% end %>
+      <% if glob_user.present? %>
+        <p class="btn-solid globus bg-warning-bg">
+          <%= link_to nh_unlink_globus_path,
+              :class => "",
+              :method  => :post,
+              :data    => { :confirm => "Are you sure you want to unlink your account from this Globus identity?" } do %>
+              Remove this Globus identity from your NeuroHub account
           <% end %>
         </p>
       <% end %>

--- a/BrainPortal/app/views/nh_users/show.html.erb
+++ b/BrainPortal/app/views/nh_users/show.html.erb
@@ -160,6 +160,23 @@
     <div class="card-row">
       <div class="card-item">
         <div>
+          <p class="card-label">Globus ID</p>
+          <p class="card-text btn-text globus">
+          <% glob_user = @user.meta[:globus_preferred_username] %>
+          <% glob_prov = @user.meta[:globus_provider_name] %>
+          <% if glob_user.present? %>
+             Identity Name: <%= glob_user %><br>
+             Identity Provider: <%= glob_prov %>
+          <% else %>
+            Your account is not linked to a Globus identity provider
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div class="card-item">
+        <div>
           <p class="card-label">Last Visit</p>
           <p class="card-text"><%= @user.last_connected_at ? "#{to_localtime(@user.last_connected_at,
           :datetime)} (#{pretty_elapsed(Time.now - @user.last_connected_at, :num_components => 3)} ago)" : "(Never)" %></p>

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -279,9 +279,12 @@ Rails.application.routes.draw do
     get   '/signout'                => 'nh_sessions#destroy'
     get   '/myaccount'              => 'nh_users#myaccount'
 
+    # Globus authentication
+    get   '/nh_globus'              => 'nh_sessions#nh_globus'
+    post  '/nh_unlink_globus'       => 'nh_sessions#nh_unlink_globus'
+
     # ORCID authentication
     get   '/orcid'                  => 'nh_sessions#orcid'
-    # Unlink button
     post  '/unlink_orcid'           => 'nh_users#unlink_orcid'
 
     # Sessions

--- a/BrainPortal/lib/globus_helpers.rb
+++ b/BrainPortal/lib/globus_helpers.rb
@@ -28,8 +28,10 @@ module GlobusHelpers
   GLOBUS_AUTHORIZE_URI = "https://auth.globus.org/v2/oauth2/authorize" # will be issued a GET with params
   GLOBUS_TOKEN_URI     = "https://auth.globus.org/v2/oauth2/token"     # will be issued a POST with a single code
 
-  # Returns the URI to send users to the GLOBUS authentication page
-  def globus_login_uri
+  # Returns the URI to send users to the GLOBUS authentication page.
+  # The parameter globus_action_url should be the URL to the controller
+  # action here in CBRAIN that will received the POST response.
+  def globus_login_uri(globus_action_url)
     return nil unless globus_auth_configured?
 
     # Create the URI to authenticate with GLOBUS
@@ -37,19 +39,19 @@ module GlobusHelpers
       :client_id     => globus_client_id,
       :response_type => 'code',
       :scope         => "urn:globus:auth:scope:auth.globus.org:view_identities openid email profile",
-      :redirect_uri  => globus_url, # generated from Rails routes
+      :redirect_uri  => globus_action_url, # generated from Rails routes
       :state         => globus_current_state, # method is below
     }
     GLOBUS_AUTHORIZE_URI + '?' + globus_params.to_query
   end
 
-  def globus_fetch_token(code)
+  def globus_fetch_token(code, globus_action_url)
     # Query Globus; this returns all the info we need at the same time.
     auth_header = globus_basic_auth_header # method is below
     response = Typhoeus.post(GLOBUS_TOKEN_URI,
       :body   => {
                    :code          => code,
-                   :redirect_uri  => globus_url, # not used but still required
+                   :redirect_uri  => globus_action_url,
                    :grant_type    => 'authorization_code',
                  },
       :headers => { :Accept       => 'application/json',
@@ -113,6 +115,68 @@ module GlobusHelpers
     return false if ! globus_client_id
     return false if ! globus_client_secret
     true
+  end
+
+  # Record the globus identity for the current user.
+  # (This maybe should be made into a User model method)
+  def record_globus_identity(identity)
+    provider_id   = identity['identity_provider']              || cb_error("Globus: No identity provider")
+    provider_name = identity['identity_provider_display_name'] || cb_error("Globus: No identity provider name")
+    pref_username = identity['preferred_username']             || cb_error("Globus: No preferred username")
+
+    # Special case for ORCID, because we already have fields for that provider
+    if provider_name == 'ORCID'
+      orcid = pref_username.sub(/@.*/, "")
+      current_user.meta['orcid'] = orcid
+      current_user.addlog("Linked to ORCID identity: '#{orcid}' through Globus")
+      return
+    end
+
+    current_user.meta[:globus_provider_id]        = provider_id
+    current_user.meta[:globus_provider_name]      = provider_name # used in show page
+    current_user.meta[:globus_preferred_username] = pref_username
+    current_user.addlog("Linked to Globus identity: '#{pref_username}' on provider '#{provider_name}'")
+  end
+
+  # Removes the recorded globus identity for +user+
+  def unlink_globus_identity(user)
+    current_user.meta[:globus_provider_id]        = nil
+    current_user.meta[:globus_provider_name]      = nil
+    current_user.meta[:globus_preferred_username] = nil
+    current_user.addlog("Unlinked Globus identity")
+  end
+
+  # Given a globus identity structure, find the user
+  # that matches it and activate the session for that user.
+  # Returns the user object if found; returns a string error message otherwise.
+  def find_user_with_globus_identity(identity)
+    provider_id   = identity['identity_provider']              || cb_error("Globus: No identity provider")
+    provider_name = identity['identity_provider_display_name'] || cb_error("Globus: No identity provider name")
+    pref_username = identity['preferred_username']             || cb_error("Globus: No preferred username")
+
+    # Special case for ORCID, because we already have fields for that provider
+    if provider_name == 'ORCID'
+      orcid = pref_username.sub(/@.*/, "")
+      users = User.find_all_by_meta_data(:orcid, orcid)
+    else # All other globus providers
+      # We need a user which match both the preferred username and provider_id
+      users = User.find_all_by_meta_data(:globus_preferred_username, pref_username)
+        .to_a
+        .select { |user| user.meta[:globus_provider_id] == provider_id }
+    end
+
+    if users.size == 0
+      Rails.logger.error "GLOBUS warning: no CBRAIN accounts found for identity '#{pref_username}' on provider '#{provider_name}'"
+      return "No CBRAIN user matches your Globus identity. Create a CBRAIN account or link your existing CBRAIN account to your Globus provider."
+    end
+
+    if users.size > 1
+      Rails.logger.error "GLOBUS error: multiple CBRAIN accounts found for identity '#{pref_username}' on provider '#{provider_name}'"
+      return "Several CBRAIN user accounts match your Globus identity. Please contact the CBRAIN admins."
+    end
+
+    # The one lucky user
+    return users.first
   end
 
 end


### PR DESCRIPTION
This is just like the login with globus we already had on CBRAIN.

Changes are:

* the main NeuroHub page has a button;
* the myaccount page on NeuroHub show the identity provider, if any;
* the edit myaccount page allows the user to unlink from the identity provider.