### PR TITLE
Special module support in new Boutiques integrator

### DIFF
--- a/Bourreau/lib/boutiques_file_name_matcher.rb
+++ b/Bourreau/lib/boutiques_file_name_matcher.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_file_name_matcher.rb

--- a/Bourreau/lib/boutiques_file_type_verifier.rb
+++ b/Bourreau/lib/boutiques_file_type_verifier.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_file_type_verifier.rb

--- a/BrainPortal/lib/boutiques_file_name_matcher.rb
+++ b/BrainPortal/lib/boutiques_file_name_matcher.rb
@@ -41,7 +41,7 @@
 module BoutiquesFileNameMatcher
 
   def after_form #:nodoc:
-    descriptor = self.descriptor_for_before_form
+    descriptor = self.descriptor_for_after_form
     verifs     = descriptor.custom_module_info('BoutiquesFileNameMatcher')
 
     verifs.each do |inputid,regexstring| # 'myinput' => "^sub-[a-zA-Z0-9]*$"

--- a/BrainPortal/lib/boutiques_file_name_matcher.rb
+++ b/BrainPortal/lib/boutiques_file_name_matcher.rb
@@ -1,0 +1,66 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module adds automatic verification of the
+# names of files selected in a File input of a Boutiques Task.
+#
+# To include the module automatically at boot time
+# in a task integrated by Boutiques, add a new entry
+# in the 'custom' section of the descriptor, like this:
+#
+#   "custom": {
+#       "cbrain:integrator_modules": {
+#           "BoutiquesFileNameMatcher": {
+#             "my_input": "^sub-[a-zA-Z0-9]*$"
+#           }
+#       }
+#   }
+#
+# In the example above, any userfile selected for the file input
+# named 'my_input' will be validated to make sure its name matches
+# the regular expression /^sub-[a-zA-Z0-9]*$/
+module BoutiquesFileNameMatcher
+
+  def after_form #:nodoc:
+    descriptor = self.descriptor_for_before_form
+    verifs     = descriptor.custom_module_info('BoutiquesFileNameMatcher')
+
+    verifs.each do |inputid,regexstring| # 'myinput' => "^sub-[a-zA-Z0-9]*$"
+      input = descriptor.input_by_id(inputid)
+      regex = Regexp.new(regexstring)
+      #puts_red "In=#{inputid} Regex=#{regex.inspect}"
+      found_match = Array(invoke_params[inputid])
+        .map(&:presence)
+        .compact
+        .all? do |userfileid|
+          file = Userfile.find(userfileid)
+          file.name.match(regex)
+        end
+      if ! found_match
+        params_errors.add(input.cb_invoke_name, "does not have a proper name (should match #{regex.inspect})")
+      end
+    end
+
+    super # call all the normal code
+  end
+
+end

--- a/BrainPortal/lib/boutiques_file_name_matcher.rb
+++ b/BrainPortal/lib/boutiques_file_name_matcher.rb
@@ -53,7 +53,7 @@ module BoutiquesFileNameMatcher
         .compact
         .all? do |userfileid|
           file = Userfile.find(userfileid)
-          file.name.match(regex)
+          file.is_a?(CbrainFileList) || file.name.match(regex) # we don't validate the names of CbrainFileLists
         end
       if ! found_match
         params_errors.add(input.cb_invoke_name, "does not have a proper name (should match #{regex.inspect})")

--- a/BrainPortal/lib/boutiques_file_type_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_type_verifier.rb
@@ -41,7 +41,7 @@
 module BoutiquesFileTypeVerifier
 
   def after_form #:nodoc:
-    descriptor = self.descriptor_for_before_form
+    descriptor = self.descriptor_for_after_form
     verifs     = descriptor.custom_module_info('BoutiquesFileTypeVerifier')
 
     verifs.each do |inputid,typenames| # 'myinput' => [ 'TextFile', 'MincFile' ]

--- a/BrainPortal/lib/boutiques_file_type_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_type_verifier.rb
@@ -1,0 +1,66 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module adds automatic verification of the
+# type of files selected in a File input of a Boutiques Task.
+#
+# To include the module automatically at boot time
+# in a task integrated by Boutiques, add a new entry
+# in the 'custom' section of the descriptor, like this:
+#
+#   "custom": {
+#       "cbrain:integrator_modules": {
+#           "BoutiquesFileTypeVerifier": {
+#             "my_input": [ "TextFile", "MincFile" ]
+#           }
+#       }
+#   }
+#
+# In the example above, any userfile selected for the file input
+# named 'my_input' will be validated to make sure it respond to
+# is_a?() for one of the types in the list.
+module BoutiquesFileTypeVerifier
+
+  def after_form #:nodoc:
+    descriptor = self.descriptor_for_before_form
+    verifs     = descriptor.custom_module_info('BoutiquesFileTypeVerifier')
+
+    verifs.each do |inputid,typenames| # 'myinput' => [ 'TextFile', 'MincFile' ]
+      input = descriptor.input_by_id(inputid)
+      #puts_red "In=#{inputid} Types=#{typenames.inspect}"
+      types = typenames.map(&:constantize)
+      found_match = Array(invoke_params[inputid])
+        .map(&:presence)
+        .compact
+        .all? do |userfileid|
+          file = Userfile.find(userfileid)
+          types.any? { |type| file.is_a?(type) }
+        end
+      if ! found_match
+        params_errors.add(input.cb_invoke_name, "is not of the proper type (should be #{typenames.join(",")})")
+      end
+    end
+
+    super # call all the normal code
+  end
+
+end

--- a/BrainPortal/lib/boutiques_support.rb
+++ b/BrainPortal/lib/boutiques_support.rb
@@ -179,6 +179,10 @@ module BoutiquesSupport
       CbrainFileRevision.for_relpath(path)
     end
 
+    def custom_module_info(modulename)
+      self.custom['cbrain:integrator_modules'][modulename]
+    end
+
     class Input
 
       # This method return the parameter name for the input.


### PR DESCRIPTION
This adds support for including automatically special modules in the class that implements a new boutiques task integration.

This PR comes with the framework modification to support this features, and two sample (and fully operational) modules for adding new validation rules for files based on types or names.

This is very similar to what is described in https://prioux.github.io/new-boutiques-presentation/#/desc_modules except I changed the syntax somewhat. See the comment block at the top of the modules for more info.