### PR TITLE
Don't show 'link to globus' when admin browsing a user's account page fixes #1179

### DIFF
--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -115,8 +115,10 @@
       <% glob_prov = @user.meta[:globus_provider_name] %>
       <% if glob_user.blank? %>
         <p class="btn-solid globus">
-          <%= link_to @globus_uri, :class => "" do %>
-            Connect your NeuroHub account to a Globus identity provider
+          <% if @user.id == current_user.id  # show button only on user own page, hide on other users pages %>
+            <%= link_to @globus_uri, :class => "" do %>
+              Connect your NeuroHub account to a Globus identity provider
+            <% end %>
           <% end %>
         </p>
         <p class="field_note">
@@ -132,11 +134,13 @@
       <% end %>
       <% if glob_user.present? %>
         <p class="btn-solid globus bg-warning-bg">
-          <%= link_to nh_unlink_globus_path,
-              :class => "",
-              :method  => :post,
-              :data    => { :confirm => "Are you sure you want to unlink your account from this Globus identity?" } do %>
-              Remove this Globus identity from your NeuroHub account
+          <% if @user.id == current_user.id  # show button only on user own page %>
+            <%= link_to nh_unlink_globus_path,
+                :class => "",
+                :method  => :post,
+                :data    => { :confirm => "Are you sure you want to unlink your account from this Globus identity?" } do %>
+                Remove this Globus identity from your NeuroHub account
+            <% end %>
           <% end %>
         </p>
       <% end %>

--- a/BrainPortal/app/views/nh_users/_form.html.erb
+++ b/BrainPortal/app/views/nh_users/_form.html.erb
@@ -114,13 +114,13 @@
       <% glob_user = @user.meta[:globus_preferred_username] %>
       <% glob_prov = @user.meta[:globus_provider_name] %>
       <% if glob_user.blank? %>
-        <p class="btn-solid globus">
-          <% if @user.id == current_user.id  # show button only on user own page, hide on other users pages %>
+        <% if @user.id == current_user.id  # show button only on user own page, hide on other users pages %>
+          <p class="btn-solid globus">
             <%= link_to @globus_uri, :class => "" do %>
               Connect your NeuroHub account to a Globus identity provider
             <% end %>
-          <% end %>
-        </p>
+          </p>
+        <% end %>
         <p class="field_note">
           Globus is a non-profit service for secure, reliable research data management.
           <br>
@@ -133,16 +133,16 @@
         </p>
       <% end %>
       <% if glob_user.present? %>
-        <p class="btn-solid globus bg-warning-bg">
-          <% if @user.id == current_user.id  # show button only on user own page %>
+        <% if @user.id == current_user.id  # show button only on user own page %>
+          <p class="btn-solid globus bg-warning-bg">
             <%= link_to nh_unlink_globus_path,
                 :class => "",
                 :method  => :post,
                 :data    => { :confirm => "Are you sure you want to unlink your account from this Globus identity?" } do %>
                 Remove this Globus identity from your NeuroHub account
             <% end %>
-          <% end %>
-        </p>
+          </p>
+        <% end %>
       <% end %>
     </fieldset>
   <% end %>

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -168,15 +168,19 @@
        <% if prov_id %>
          <strong>Provider name:</strong> <%= prov_name %><br>
          <strong>Provider user:</strong> <%= prov_user %><br>
-         <%= link_to('Unlink this Globus identity', unlink_globus_path,
-               :class  => "button",
-               :method => :post,
-               :data   => { :confirm => "Are you sure you want to unlink your account with this Globus identity?" }
-             )
-         %>
+         <% if @user.id == current_user.id  # show button on user own page, hide on other users pages %>
+           <%= link_to('Unlink this Globus identity', unlink_globus_path,
+                 :class  => "button",
+                 :method => :post,
+                 :data   => { :confirm => "Are you sure you want to unlink your account with this Globus identity?" }
+               )
+           %>
+         <% end %>
        <% else %>
          (No Globus identity linked to your account)<br>
-         <%= link_to 'Link a Globus identity', @globus_uri, :class => 'button globus_button' %>
+         <% if @user.id == current_user.id  # Globus button works only on user own account %>
+           <%= link_to 'Link a Globus identity', @globus_uri, :class => 'button globus_button' %>
+         <% end %>
        <% end %>
     <% end %>
     <% end %>


### PR DESCRIPTION
see the attached issue for full description.
Note that the issue presents itself only on CBRAIN part, just in the case the changes done on NeuroHub side too