### PR TITLE
store and validate task archive file md5 hash to detect corrupting or tampering resolves #1186

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1663,6 +1663,7 @@ class ClusterTask < CbrainTask
     end
 
     self.addlog("Attempting to restore TaskWorkdirArchive.")
+    
     taskarch_userfile.sync_to_cache
 
     md5 = self.meta[:workdir_archive_hash]

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1668,7 +1668,6 @@ class ClusterTask < CbrainTask
     md5 = self.meta[:workdir_archive_hash]
     if md5.present? and md5 != taskarch_userfile.cache_compute_md5sum  #  presence check is compatibility layer for old tasks archives
       self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
-      # cb_error "Archive of #{self.name} task was tampered with! Unarchiving is aborted"
       return false
     end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1663,12 +1663,12 @@ class ClusterTask < CbrainTask
     end
 
     self.addlog("Attempting to restore TaskWorkdirArchive.")
-    
+
     taskarch_userfile.sync_to_cache
 
     md5 = self.meta[:workdir_archive_hash]
     if md5.present? and md5 != taskarch_userfile.cache_compute_md5sum  #  presence check is compatibility layer for old tasks archives
-      self.addlog("MD5 hash does not match stored record: archive #{taskarch_userfile.name} of task #{self.name} is corrupted.")
+      self.addlog("MD5 hash does not match stored record: task archive #{taskarch_userfile.name} is corrupted.")
       return false
     end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1621,6 +1621,7 @@ class ClusterTask < CbrainTask
       file.save!
       file.cache_copy_from_local_file(tar_file)
       file.cache_erase
+      file.get_hash
       file.save
       self.workdir_archive_userfile_id = file.id
       self.addlog_to_userfiles_created(file)

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1667,7 +1667,7 @@ class ClusterTask < CbrainTask
 
     md5 = self.meta[:workdir_archive_hash]
     if md5.present? and md5 != taskarch_userfile.cache_compute_md5sum  #  presence check is compatibility layer for old tasks archives
-      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
+      self.addlog("MD5 hash does not match stored record: archive #{taskarch_userfile.name} of task #{self.name} is corrupted.")
       return false
     end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1661,6 +1661,8 @@ class ClusterTask < CbrainTask
       return false
     end
 
+    taskarch_userfile.map!(&:check_hash) # validate
+
     self.addlog("Attempting to restore TaskWorkdirArchive.")
 
     taskarch_userfile.sync_to_cache

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1664,7 +1664,10 @@ class ClusterTask < CbrainTask
 
     self.addlog("Attempting to restore TaskWorkdirArchive.")
 
-    taskarch_userfile&.check_hash # validate, save navigation (ampersand) is for smother migration
+    if taskarch_userfile&.integrity_violated?
+      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
+      cb_error "Task archive #{self.name} was tampered with! Unarchiving is aborted"
+    end
     taskarch_userfile.sync_to_cache # for compatibility remove in the next deploy
 
     self.make_cluster_workdir

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1620,7 +1620,7 @@ class ClusterTask < CbrainTask
                  )
       file.save!
       file.cache_copy_from_local_file(tar_file)
-      self.meta[:workdir_archive_hash] = cache_compute_md5sum.presence
+      self.meta[:workdir_archive_hash] = file.cache_compute_md5sum.presence
       file.cache_erase
       file.save
       self.workdir_archive_userfile_id = file.id
@@ -1662,15 +1662,15 @@ class ClusterTask < CbrainTask
       return false
     end
 
+    self.addlog("Attempting to restore TaskWorkdirArchive.")
+    taskarch_userfile.sync_to_cache
+
     md5 = self.meta[:workdir_archive_hash]
-    if md5.present? and md5 != cache_compute_md5sum  #  presence check is compatibility layer for old tasks archives
+    if md5.present? and md5 != taskarch_userfile.cache_compute_md5sum  #  presence check is compatibility layer for old tasks archives
       self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
       # cb_error "Archive of #{self.name} task was tampered with! Unarchiving is aborted"
       return false
     end
-
-    self.addlog("Attempting to restore TaskWorkdirArchive.")
-    taskarch_userfile.sync_to_cache # for compatibility remove in the next deploy
 
     self.make_cluster_workdir
     Dir.chdir(self.full_cluster_workdir) do

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1661,11 +1661,10 @@ class ClusterTask < CbrainTask
       return false
     end
 
-    taskarch_userfile.map!(&:check_hash) # validate
-
     self.addlog("Attempting to restore TaskWorkdirArchive.")
 
-    taskarch_userfile.sync_to_cache
+    taskarch_userfile&.check_hash # validate, save navigation (ampersand) is for smother migration
+    taskarch_userfile.sync_to_cache # for compatibility remove in the next deploy
 
     self.make_cluster_workdir
     Dir.chdir(self.full_cluster_workdir) do

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1621,7 +1621,6 @@ class ClusterTask < CbrainTask
       file.save!
       file.cache_copy_from_local_file(tar_file)
       file.cache_erase
-      file.get_hash
       file.save
       self.workdir_archive_userfile_id = file.id
       self.addlog_to_userfiles_created(file)
@@ -1662,12 +1661,13 @@ class ClusterTask < CbrainTask
       return false
     end
 
-    self.addlog("Attempting to restore TaskWorkdirArchive.")
-
     if taskarch_userfile&.integrity_violated?
-      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
-      cb_error "Task archive #{self.name} was tampered with! Unarchiving is aborted"
+      self.addlog("Work directory cannot be unarchived, MD5 hash of work directory archive does not match stored record: #{self.name}")
+      cb_error "Archive of #{self.name} task was tampered with! Unarchiving is aborted"
+      return false
     end
+
+    self.addlog("Attempting to restore TaskWorkdirArchive.")
     taskarch_userfile.sync_to_cache # for compatibility remove in the next deploy
 
     self.make_cluster_workdir

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
@@ -80,4 +80,26 @@ class SingleFile < Userfile
     self.sync_to_provider
   end
 
+  # compute file md5 hash sum (useful to avoid tampering, e.g. with task archive)
+  def cache_compute_md5sum
+    md5command =
+        case CBRAIN::System_Uname
+        when /Linux/i
+          "md5sum"
+        when /Darwin/i
+          "md5"
+        else
+          "md5sum"
+        end
+    self.sync_to_cache
+
+    content_path = self&.cache_full_path
+    cb_error("Can't find cache path for file #{self.name}") if content_path.blank?
+    md5 = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }
+    md5 = Regexp.last_match[1] if md5.present? && md5.match(/\b([0-9a-fA-F]{32})\b/)
+    cb_error("Can't compute MD5 for file #{self.name}", Errno::EIO) if md5.blank? ||
+        md5.size != 32
+    md5
+  end
+
 end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
@@ -91,14 +91,10 @@ class SingleFile < Userfile
         else
           "md5sum"
         end
-    self.sync_to_cache
-
-    content_path = self&.cache_full_path
-    cb_error("Can't find cache path for file #{self.name}") if content_path.blank?
-    md5 = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }
-    md5 = Regexp.last_match[1] if md5.present? && md5.match(/\b([0-9a-fA-F]{32})\b/)
-    cb_error("Can't compute MD5 for file #{self.name}", Errno::EIO) if md5.blank? ||
-        md5.size != 32
+    content_path = self.cache_full_path  # supposedly always defined
+    out = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }
+    md5 = Regexp.last_match[1] if out.present? && out.match(/\b([0-9a-fA-F]{32})\b/)
+    cb_error("Can't compute MD5 for file #{self.name}") if md5.blank?
     md5
   end
 end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/single_file/single_file.rb
@@ -101,5 +101,4 @@ class SingleFile < Userfile
         md5.size != 32
     md5
   end
-
 end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -68,7 +68,7 @@ class TaskWorkdirArchive < TarArchive
           "md5sum" # hope it works
         end
     if content_path
-      md5 = IO.popen("#{md5command} < #{content_path.bash_escape}","r") { |fh| fh.read }
+      md5 = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }
       md5 = Regexp.last_match[1] if md5.present? && md5.match(/\b([0-9a-fA-F]{32})\b/)
       self.meta[:content_hash] = md5 if md5.present? and self.meta[:content_hash].blank?
     end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -66,7 +66,7 @@ class TaskWorkdirArchive < TarArchive
           "md5sum"
         end
     self.sync_to_cache
-    content_path = self.&cache_full_path
+    content_path = self&.cache_full_path
     if content_path.present?
       begin
         md5 = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -34,6 +34,8 @@ class TaskWorkdirArchive < TarArchive
 
   before_destroy :before_destroy_adjust_task
 
+  before_save :get_hash
+
   def self.file_name_pattern #:nodoc:
     /\ACbrainTask_Workdir_[\w\-]+\.tar(\.gz)?\z/i
   end
@@ -50,6 +52,33 @@ class TaskWorkdirArchive < TarArchive
     # Adjust/save task ; use update_column in order not to change the updated_at value
     task.update_column(:workdir_archived, false)
     return true
+  end
+
+  # compute archive file hash to avoid tampering
+  def get_hash
+    md5command =
+        case CBRAIN::System_Uname
+        when /Linux/i
+          "md5sum"
+        when /Darwin/i
+          "md5"
+        else
+          "md5sum" # hope it works
+        end
+    self.sync_to_cache
+    md5 = IO.popen("#{md5command} < #{self.cache_full_path.bash_escape}","r") { |fh| fh.read }
+    md5 = Regexp.last_match[1] if md5.present? && md5.match(/\b([0-9a-fA-F]{32})\b/)
+    self.meta[:content_hash] = md5 if md5.present? and self.meta[:content_hash].blank?
+  end
+
+  # validate crypto hash to
+  def check_hash
+    md5 = self.meta[:content_hash]
+    if md5.present? and md5 != get_hash  #  compatibility layer for old tasks archives
+      errors.add('md5 hash check changed. Archive #{self.name} has been was tampered with ' )
+      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name } is corrupted.")
+      # cb_error "Tried to unarchive a TaskWorkdirArchive while in the wrong Rails app."
+    end
   end
 
 end

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -80,7 +80,7 @@ class TaskWorkdirArchive < TarArchive
     if md5.present? and md5 != get_hash  #  compatibility layer for old tasks archives
       errors.add('md5 hash check changed. Archive #{self.name} has been was tampered with ' )
       self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name } is corrupted.")
-      # cb_error "Tried to unarchive a TaskWorkdirArchive while in the wrong Rails app."
+      cb_error "Task archive #{self.name} was tampered with! Unarchiving is aborted"
     end
   end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -86,7 +86,7 @@ class TaskWorkdirArchive < TarArchive
     self.meta[:content_hash] = get_hash.presence
   end
 
-  # validate crypto hash to
+  # validate crypto hash
   def integrity_violated?
     md5 = self.meta[:content_hash]
     if md5.present? and md5 != get_hash  #  compatibility layer for old tasks archives

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -75,12 +75,11 @@ class TaskWorkdirArchive < TarArchive
   end
 
   # validate crypto hash to
-  def check_hash
+  def integrity_violated?
     md5 = self.meta[:content_hash]
     if md5.present? and md5 != get_hash  #  compatibility layer for old tasks archives
-      errors.add('md5 hash check changed. Archive #{self.name} has been was tampered with ' )
-      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name } is corrupted.")
-      cb_error "Task archive #{self.name} was tampered with! Unarchiving is aborted"
+      self.addlog("MD5 hash does not match stored record: TaskWorkdirArchive #{self.name} is corrupted.")
+      true
     end
   end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -71,6 +71,7 @@ class TaskWorkdirArchive < TarArchive
       md5 = IO.popen("#{md5command} < #{content_path.to_s.bash_escape}","r") { |fh| fh.read }
       md5 = Regexp.last_match[1] if md5.present? && md5.match(/\b([0-9a-fA-F]{32})\b/)
       self.meta[:content_hash] = md5 if md5.present? and self.meta[:content_hash].blank?
+      md5
     end
   end
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/task_workdir_archive/task_workdir_archive.rb
@@ -34,7 +34,7 @@ class TaskWorkdirArchive < TarArchive
 
   before_destroy :before_destroy_adjust_task
 
-  before_save :save_hash
+  after_save :save_hash
 
   def self.file_name_pattern #:nodoc:
     /\ACbrainTask_Workdir_[\w\-]+\.tar(\.gz)?\z/i


### PR DESCRIPTION
saves md5 hash on task archive file, blocks unarchiving if archive file is tampered or corrupted. md5 retrieval is lightly modified copy of the existing cbrain md5 code so I assume it works on mac

