### PR TITLE
Added a auth_method 'keyboard-interactive' to SFTP

### DIFF
--- a/BrainPortal/app/models/en_cbrain_ssh_data_provider.rb
+++ b/BrainPortal/app/models/en_cbrain_ssh_data_provider.rb
@@ -87,7 +87,10 @@ class EnCbrainSshDataProvider < SshDataProvider
 
     # We should create a nice state machine for the remote rename operations
     self.master # triggers unlocking the agent
-    Net::SFTP.start(remote_host,remote_user, :port => (remote_port.presence || 22), :auth_methods => [ 'publickey' ] ) do |sftp|
+
+    # Stupidly, some SSHDs insist on having 'keyboard-interactive' in the :auth_methods
+    # even if we're not planning ot use it. Probably because of 2FA.
+    Net::SFTP.start(remote_host,remote_user, :port => (remote_port.presence || 22), :auth_methods => [ 'publickey', 'keyboard-interactive' ] ) do |sftp|
 
       req = sftp.lstat(newpath).wait
       return false if req.response.ok?   # file already exists ?

--- a/BrainPortal/app/models/ssh_data_provider_base.rb
+++ b/BrainPortal/app/models/ssh_data_provider_base.rb
@@ -34,7 +34,10 @@ module SshDataProviderBase
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   def net_sftp(user = nil, userfile = nil) #:nodoc:
-    Net::SFTP.start(remote_host, remote_user, :port => (remote_port.presence || 22), :auth_methods => [ 'publickey' ] ) do |sftp|
+
+    # Stupidly, some SSHDs insist on having 'keyboard-interactive' in the :auth_methods
+    # even if we're not planning ot use it. Probably because of 2FA.
+    Net::SFTP.start(remote_host, remote_user, :port => (remote_port.presence || 22), :auth_methods => [ 'publickey', 'keyboard-interactive' ] ) do |sftp|
       yield sftp
     end
   end

--- a/BrainPortal/app/models/userkey_flat_dir_ssh_data_provider.rb
+++ b/BrainPortal/app/models/userkey_flat_dir_ssh_data_provider.rb
@@ -44,10 +44,13 @@ class UserkeyFlatDirSshDataProvider < FlatDirSshDataProvider
     user    = self.user # forced use of the DP owner as the connection ssh user
     key     = user.ssh_key
     id_file = key.send(:private_key_path)
+
+    # Stupidly, some SSHDs insist on having 'keyboard-interactive' in the :auth_methods
+    # even if we're not planning ot use it. Probably because of 2FA.
     Net::SFTP.start(remote_host, remote_user,
         :port         => (remote_port.presence || 22),
         :use_agent    => false,
-        :auth_methods => [ 'publickey' ],
+        :auth_methods => [ 'publickey', 'keyboard-interactive' ],
         :keys         => [ id_file ]
     ) do |sftp|
       yield sftp


### PR DESCRIPTION
Some SSHDs really want keyboard-interactive as an auth method,
probably because of 2FA, even if here in CBRAIN we'll never use
that. Hopefully this change won't block our servers when
sftp sessions are established (I expect not, as ssh should
realize no TTYs are available)