### PR TITLE
Boutiques Input Cache Cleaner integrator module  resolves #1203

### DIFF
--- a/Bourreau/lib/boutiques_input_cache_cleaner.rb
+++ b/Bourreau/lib/boutiques_input_cache_cleaner.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_input_cache_cleaner.rb

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -68,7 +68,7 @@ module BoutiquesInputCacheCleaner
         last_cache_access_time = inputfile.local_sync_status.accessed_at
         next if last_cache_access_time > setup_time  # skip, perhaps the file is being accessed by another task
         inputfile.cache_erase
-        self.addlog("Boutiques Integrator's InputCacheCleaner deleted #{inputfile.name} file cache (#{input.cb_invoke_name})")
+        self.addlog("BoutiquesInputCacheCleaner deleted #{inputfile.name} file cache (#{input.cb_invoke_name})")
       end
 
     end

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -51,9 +51,10 @@ module BoutiquesInputCacheCleaner
 
   def save_results #:nodoc:
 
-    return fail unless super # call all the normal code
+    return false unless super # call all the normal code
 
-    setup_time = self.meta[:setup_time] || Time.now
+    setup_time = self.meta[:setup_time]
+    return true if setup_time.nil?
 
     descriptor = self.descriptor_for_save_results
     inputs     = descriptor.custom_module_info('BoutiquesInputCacheCleaner')
@@ -64,8 +65,7 @@ module BoutiquesInputCacheCleaner
 
       Array(invoke_params[inputid]).map(&:presence).compact.each do |inputfileid|
         inputfile = Userfile.find(inputfileid)
-        next if inputfile.local_sync_status.nil? # cache is already deleted  # cache is already deleted
-        last_cache_access_time = inputfile.local_sync_status.accessed_at
+        last_cache_access_time = inputfile.local_sync_status&.accessed_at
         next if last_cache_access_time > setup_time  # skip, perhaps the file is being accessed by another task
         inputfile.cache_erase
         self.addlog("BoutiquesInputCacheCleaner deleted #{inputfile.name} file cache (#{input.cb_invoke_name})")

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -1,0 +1,77 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module adds automatic verification of the
+# type of files selected in a File input of a Boutiques Task.
+#
+# To include the module automatically at boot time
+# in a task integrated by Boutiques, add a new entry
+# in the 'custom' section of the descriptor, like this:
+#
+#   "custom": {
+#       "cbrain:integrator_modules": {
+#           "BoutiquesInputCacheCleaner": [
+#             "my_input1",
+#             "my_input2"
+#           ]
+#       }
+#   }
+#
+# In the example above, any userfile cache selected for the file input
+# named 'my_input1' or 'my_input2' will be deleted after task execution unless CBRAIN
+# notices that another task uses same cache.
+# CBRAIN tries to handle conflict between tasks that share same file based on timestamps.
+# Yet this is a dangerous feature as it might not handle some of races, e.g. with legacy tools
+module BoutiquesInputCacheCleaner
+
+  def setup #:nodoc:
+    self.meta[:setup_time] = Time.now
+    super
+  end
+
+  def save_results #:nodoc:
+
+    return fail unless super # call all the normal code
+
+    setup_time = self.meta[:setup_time] || Time.now
+
+    descriptor = self.descriptor_for_save_results
+    inputs     = descriptor.custom_module_info('BoutiquesInputCacheCleaner')
+
+    inputs.each do |inputid| # 'my_input1', 'my_input2'
+
+      input = descriptor.input_by_id(inputid)
+
+      Array(invoke_params[inputid]).map(&:presence).compact.each do |inputfileid|
+        inputfile = Userfile.find(inputfileid)
+        last_cache_access_time = inputfile.local_sync_status&.accessed_at        
+        next if !last_cache_access_time  # cache is already deleted
+        next if last_cache_access_time > setup_time  # skip, perhaps the file is being accessed by another task
+        inputfile.cache_erase
+        self.addlog("Boutiques Integrator's InputCacheCleaner deleted #{inputfile.name} file cache (parameter #{input.cb_invoke_name})")
+      end
+
+    end
+
+  end
+
+end

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -66,6 +66,7 @@ module BoutiquesInputCacheCleaner
       Array(invoke_params[inputid]).map(&:presence).compact.each do |inputfileid|
         inputfile = Userfile.find(inputfileid)
         last_cache_access_time = inputfile.local_sync_status&.accessed_at
+        next unless last_cache_access_time  # skip, already unsynch 
         next if last_cache_access_time > setup_time  # skip, perhaps the file is being accessed by another task
         inputfile.cache_erase
         self.addlog("BoutiquesInputCacheCleaner deleted #{inputfile.name} file cache (#{input.cb_invoke_name})")

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -44,8 +44,9 @@
 module BoutiquesInputCacheCleaner
 
   def setup #:nodoc:
+    result = super
     self.meta[:setup_time] = Time.now
-    super
+    result
   end
 
   def save_results #:nodoc:
@@ -63,11 +64,11 @@ module BoutiquesInputCacheCleaner
 
       Array(invoke_params[inputid]).map(&:presence).compact.each do |inputfileid|
         inputfile = Userfile.find(inputfileid)
-        last_cache_access_time = inputfile.local_sync_status&.accessed_at        
-        next if !last_cache_access_time  # cache is already deleted
+        next if inputfile.local_sync_status.nil? # cache is already deleted  # cache is already deleted
+        last_cache_access_time = inputfile.local_sync_status.accessed_at
         next if last_cache_access_time > setup_time  # skip, perhaps the file is being accessed by another task
         inputfile.cache_erase
-        self.addlog("Boutiques Integrator's InputCacheCleaner deleted #{inputfile.name} file cache (parameter #{input.cb_invoke_name})")
+        self.addlog("Boutiques Integrator's InputCacheCleaner deleted #{inputfile.name} file cache (#{input.cb_invoke_name})")
       end
 
     end


### PR DESCRIPTION
Hi, this is to expire input file cache as per #1230 . On my tests cache seems disappear, how reliable the current conflict prevention I am less than sure. 