### PR TITLE
Data Tracking Framework.

### DIFF
--- a/Bourreau/app/models/data_usage.rb
+++ b/Bourreau/app/models/data_usage.rb
@@ -1,0 +1,1 @@
+../../../BrainPortal/app/models/data_usage.rb

--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -284,9 +284,16 @@ class GroupsController < ApplicationController
 
   def group_params #:nodoc:
     if current_user.has_role?(:admin_user)
-      params.require_as_params(:group).permit(:name, :description, :not_assignable, :site_id, :creator_id, :invisible, :user_ids => [])
-    else
-      params.require_as_params(:group).permit(:name, :description, :not_assignable, :user_ids => [])
+      params.require_as_params(:group).permit(
+        :name, :description, :not_assignable,
+        :site_id, :creator_id, :invisible, :track_usage,
+        :user_ids => []
+      )
+    else # non admin users
+      params.require_as_params(:group).permit(
+        :name, :description, :not_assignable,
+        :user_ids => []
+      )
     end
   end
 

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -1266,6 +1266,7 @@ class UserfilesController < ApplicationController
     tarfile      = create_relocatable_tar_for_userfiles(userfiles_list,current_user.login)
     tarfile_name = "#{specified_filename}.tar.gz"
     send_file tarfile, :stream  => true, :filename => tarfile_name
+    userfiles_list.each { |userfile| DataUsage.increase_downloads(current_user, userfile) }
     CBRAIN.spawn_fully_independent("Download Clean Tmp #{current_user.login}") do
       sleep 3000
       File.delete(tarfile)

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -1080,6 +1080,7 @@ class UserfilesController < ApplicationController
                      :group_id          => my_group_id,
                      :crush_destination => crush_destination
                   )
+            DataUsage.increase_copies(current_user, u)
           end
           raise "file collision: there is already such a file on the other provider" unless res
           success_list << u
@@ -1256,6 +1257,7 @@ class UserfilesController < ApplicationController
     if userfiles_list.size == 1 && userfiles_list[0].is_a?(SingleFile)
       userfile = userfiles_list[0]
       fullpath = userfile.cache_full_path
+      DataUsage.increase_downloads(current_user, userfile)
       send_file fullpath, :stream => true, :filename => is_blank ? fullpath.basename : specified_filename
       return
     end

--- a/BrainPortal/app/models/data_usage.rb
+++ b/BrainPortal/app/models/data_usage.rb
@@ -32,7 +32,7 @@ class DataUsage < ApplicationRecord
   belongs_to :user,  :optional => false
   belongs_to :group, :optional => false
 
-  validates_uniqueness_of :user_id, :scope => [ :group_id ]
+  validates_uniqueness_of :user_id, :scope => [ :group_id, :yearmonth ]
 
   def self.increase_views(user, userfile)
     return nil unless userfile.group.track_usage?

--- a/BrainPortal/app/models/data_usage.rb
+++ b/BrainPortal/app/models/data_usage.rb
@@ -20,7 +20,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Model representing usage of files in select groups
+# Model representing usage of files in groups
+# configured for usage tracking.
+#
+# The main keys are the triplet [user_id, group_id, yearmonth]
+#
+# A record with a particular triplet will count the number of
+# userfiles used in four possible contexts, and their total
+# number of files in them (the sum of their num_files attributes).
+#
+# So for instance, for the context 'downloads', if a file
+# collection of 20 files is downloaded, two attributes will
+# be increased like this:
+#
+#   downloads_count     += 1
+#   downlaods_numfiles  += 20
+#
+# Data tracking only happens for groups that are configured
+# for this by the administrator. This is normally done to
+# gather usage data about static datasets.
 class DataUsage < ApplicationRecord
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
@@ -34,21 +52,33 @@ class DataUsage < ApplicationRecord
 
   validates_uniqueness_of :user_id, :scope => [ :group_id, :yearmonth ]
 
+  # Increase the number of views for the group associated
+  # with +userfile+, by user +user+. Does nothing if
+  # the userfile's group is not configrued for usage tracking.
   def self.increase_views(user, userfile)
     return nil unless userfile.group.track_usage?
     self.addcount(user.id, userfile.group.id, userfile.num_files, :views)
   end
 
+  # Increase the number of downloads for the group associated
+  # with +userfile+, by user +user+. Does nothing if
+  # the userfile's group is not configrued for usage tracking.
   def self.increase_downloads(user, userfile)
     return nil unless userfile.group.track_usage?
     self.addcount(user.id, userfile.group.id, userfile.num_files, :downloads)
   end
 
+  # Increase the number of file copies for the group associated
+  # with +userfile+, by user +user+. Does nothing if
+  # the userfile's group is not configrued for usage tracking.
   def self.increase_copies(user, userfile)
     return nil unless userfile.group.track_usage?
     self.addcount(user.id, userfile.group.id, userfile.num_files, :copies)
   end
 
+  # Increase the number of processed files for the group associated
+  # with +userfile+, by user +user+. Does nothing if
+  # the userfile's group is not configrued for usage tracking.
   def self.increase_task_setups(user, userfile)
     return nil unless userfile.group.track_usage?
     self.addcount(user.id, userfile.group.id, userfile.num_files, :task_setups)
@@ -56,7 +86,13 @@ class DataUsage < ApplicationRecord
 
   protected
 
-  def self.addcount(user_id, group_id, num_files, attname)
+  # Increases a pair of attributes in a model instance
+  # associated with +user_id+, +group_id+ and the current
+  # timestamp. The attribute name +attname+ must be one of
+  # 'views', 'copies', 'task_setups', or 'downloads'.
+  # The {name}_count attribute will be increased by 1, and
+  # the {name}_numfiles will be increased by num_files.
+  def self.addcount(user_id, group_id, num_files, attname) #:nodoc:
     # Find or create the tracking record
     yearmonth = Time.now.utc.strftime("%Y-%m")
     track = DataUsage.find_or_create_by(

--- a/BrainPortal/app/models/data_usage.rb
+++ b/BrainPortal/app/models/data_usage.rb
@@ -1,0 +1,77 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Model representing usage of files in select groups
+class DataUsage < ApplicationRecord
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  validates_presence_of :user_id
+  validates_presence_of :group_id
+  validates_presence_of :yearmonth
+
+  belongs_to :user,  :optional => false
+  belongs_to :group, :optional => false
+
+  validates_uniqueness_of :user_id, :scope => [ :group_id ]
+
+  def self.increase_views(user, userfile)
+    return nil unless userfile.group.track_usage?
+    self.addcount(user.id, userfile.group.id, userfile.num_files, :views)
+  end
+
+  def self.increase_downloads(user, userfile)
+    return nil unless userfile.group.track_usage?
+    self.addcount(user.id, userfile.group.id, userfile.num_files, :downloads)
+  end
+
+  def self.increase_copies(user, userfile)
+    return nil unless userfile.group.track_usage?
+    self.addcount(user.id, userfile.group.id, userfile.num_files, :copies)
+  end
+
+  def self.increase_task_setups(user, userfile)
+    return nil unless userfile.group.track_usage?
+    self.addcount(user.id, userfile.group.id, userfile.num_files, :task_setups)
+  end
+
+  protected
+
+  def self.addcount(user_id, group_id, num_files, attname)
+    # Find or create the tracking record
+    yearmonth = Time.now.utc.strftime("%Y-%m")
+    track = DataUsage.find_or_create_by(
+      :user_id   => user_id,
+      :group_id  => group_id,
+      :yearmonth => yearmonth,
+    )
+    # Update the two attributes (e.g. views_count and views_numfiles)
+    attname_count    = "#{attname}_count".to_sym
+    attname_numfiles = "#{attname}_numfiles".to_sym
+    track[attname_count]    += 1
+    track[attname_numfiles] += num_files || 1
+    track.save
+  rescue
+    nil # probably a race condition, doesn't matter all that much
+  end
+
+end

--- a/BrainPortal/app/views/groups/new.html.erb
+++ b/BrainPortal/app/views/groups/new.html.erb
@@ -49,6 +49,9 @@
       <p>
       Make this a system group invisible to normal users:
       <%= f.check_box :invisible %>
+      <p>
+      Turn on usage tracking for files in this project:
+      <%= f.check_box :track_usage %>
     <% end %>
 
     <p>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -68,20 +68,31 @@
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
     <% end %>
 
-    <% if current_user.has_role?(:admin_user) && @group.is_a?(WorkGroup) %>
-      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do |f| %>
-        <%= f.check_box :invisible %>
-      <% end %>
-    <% else %>
-      <% t.empty_cell %>
-    <% end %>
-
     <% t.edit_cell("Not assignable", :content => check_box_tag(nil ,nil, @group.not_assignable?, :disabled => true)) do |f| %>
       <%= f.check_box :not_assignable %>
       <div class="field_explanation">
          If checked, normal members will not be able to assign files or other
          resources to this project (but editors are always allowed to do so).
       </div>
+    <% end %>
+
+    <% if current_user.has_role?(:admin_user) && @group.is_a?(WorkGroup) %>
+
+      <% t.edit_cell("Invisible", :content => check_box_tag(nil ,nil, @group.invisible?, :disabled => true)) do |f| %>
+        <%= f.check_box :invisible %>
+        <div class="field_explanation">
+          If checked, the project will not be shown in the list of projects.
+        </div>
+      <% end %>
+
+      <% t.edit_cell("Track Usage", :content => check_box_tag(nil ,nil, @group.track_usage?, :disabled => true)) do |f| %>
+        <%= f.check_box :track_usage %>
+        <div class="field_explanation">
+          If checked, the system will track overall usage of files in this project
+          (views, downloads etc) per month.
+        </div>
+      <% end %>
+
     <% end %>
 
   <% end %>

--- a/BrainPortal/app/views/portal/report.html.erb
+++ b/BrainPortal/app/views/portal/report.html.erb
@@ -37,6 +37,7 @@
               [ 'Tool',           'tool_id' ],
               [ 'City',           'city' ],
               [ 'Country',        'country' ],
+              [ 'Year/Month',     'yearmonth' ],
             ]
    #restricted_att_list = @model_atts.blank? ? full_att_list : full_att_list.select { |pair| @model_atts.include?(pair[1].to_sym) }
    restricted_att_list = @model_atts.blank? ? [] : full_att_list.select { |pair| @model_atts.include?(pair[1].to_sym) }
@@ -98,6 +99,10 @@ in a tabular layout. Proceed as follow:
               [ 'Projects - count',                            Group.table_name                                     ],
               [ 'Tools - count',                               Tool.table_name                                      ],
               [ 'Tool Versions - count',                       ToolConfig.table_name                                ],
+              [ 'Data Usage - file views',                     DataUsage.table_name + ".combined_views"             ],
+              [ 'Data Usage - file downloads',                 DataUsage.table_name + ".combined_downloads"         ],
+              [ 'Data Usage - file copies',                    DataUsage.table_name + ".combined_copies"            ],
+              [ 'Data Usage - processed',                      DataUsage.table_name + ".combined_task_setups"       ],
             ] : []),
             params[:table_name]
           )
@@ -221,11 +226,28 @@ in a tabular layout. Proceed as follow:
 
 
 
+      <%
+         # Special proc for combined data usage reports
+         if params[:table_name] =~ /\.combined_(views|copies|downloads|task_setups)\z/
+           attname = Regexp.last_match[1]
+           td_content_proc = Proc.new do |vector,td_filters|
+             att_count, att_numfiles = vector
+             capture do
+      %>
+             <%= "#{pluralize(att_count,"entry")} / #{pluralize(att_numfiles,"file")}" %>
+      <%
+             end # capture
+           end # proc
+         end # if
+      %>
+
+
+
       <table id="report_table" class="tablesorter">
 
         <%
            # HTML attribute modifications for vertical headers (default) or wider headers
-           vertical_headers = (params[:table_name] !~ /\.combined_(file|task)_rep\z/)
+           vertical_headers = (params[:table_name] !~ /\.combined_(file|task)_rep|\.combined_(views|downloads|copies|task_setups)\z/)
            th_att     = ""
            th_div_att = " style=\"margin-right: 1.5em\"".html_safe
            if vertical_headers
@@ -468,12 +490,21 @@ in a tabular layout. Proceed as follow:
             </tr>
           <% end %>
 
-       <tr>
-        <th>Dates:</th>
-        <td colspan="2"><%= date_range_panel(date_filtering) %>
-        <small>(Note: the links in the report will NOT include the date restrictions)</small>
-        </td>
-      </tr>
+          <% if @model_atts.include?(:yearmonth) %>
+            <tr class="report_fix_attributes">
+            <th>Year/Month:</th>
+              <td><%= select_tag :yearmonth, options_for_select(@model.group(:yearmonth).order(:yearmonth).pluck(:yearmonth), { :selector => params[:status] }), :multiple => true, :size => 5 %></td>
+            </tr>
+          <% end %>
+
+          <% if ! @model == DataUsage %>
+            <tr>
+              <th>Dates:</th>
+              <td colspan="2"><%= date_range_panel(date_filtering) %>
+                <small>(Note: the links in the report will NOT include the date restrictions)</small>
+             </td>
+            </tr>
+          <% end %>
 
       </table>
 

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -278,6 +278,7 @@
             <% begin %>
               <% if @viewer %>
                 <% if @viewer.errors.empty? %>
+                  <% DataUsage.increase_views(current_user, userfile) %>
                   <%= render :file  => @viewer.partial_path %>
                 <% else %>
                   <%= render :partial  => "viewer_errors" %>

--- a/BrainPortal/app/views/userfiles/show.html.erb
+++ b/BrainPortal/app/views/userfiles/show.html.erb
@@ -278,7 +278,7 @@
             <% begin %>
               <% if @viewer %>
                 <% if @viewer.errors.empty? %>
-                  <% DataUsage.increase_views(current_user, userfile) %>
+                  <% DataUsage.increase_views(current_user, @userfile) %>
                   <%= render :file  => @viewer.partial_path %>
                 <% else %>
                   <%= render :partial  => "viewer_errors" %>

--- a/BrainPortal/config/console_rc/lib/pretty_view.rb
+++ b/BrainPortal/config/console_rc/lib/pretty_view.rb
@@ -48,7 +48,7 @@ end
 
 # Make sure the classes are loaded
 [ Userfile, CbrainTask, User, Group, DataProvider, RemoteResource,
-  RemoteResourceInfo, Site, Tool, ToolConfig, Bourreau, DiskQuota ]
+  RemoteResourceInfo, Site, Tool, ToolConfig, Bourreau, DiskQuota, DataUsage ]
 # Note that it's important to load PortalTask and/or ClusterTask too, because of its own pre-loading of subclasses.
 PortalTask.nil? rescue true
 ClusterTask.nil? rescue true
@@ -371,6 +371,32 @@ DiskQuota #%d
       self.max_files,
       ConsoleCtx.send(:pretty_past_date,created_at),
       ConsoleCtx.send(:pretty_past_date,updated_at)
+  end
+end
+
+class DataUsage
+  def pretview
+    report = <<-VIEW
+DataUsage #%d
+  User:    %d (%s)
+  Group:   %d (%s)
+  Views     (Count)   : %d
+            (NumFiles): %d
+  Downloads (Count)   : %d
+            (NumFiles): %d
+  Copies    (Count)   : %d
+            (NumFiles): %d
+  TaskSetup (Count)   : %d
+            (NumFiles): %d
+    VIEW
+    sprintf report,
+      self.id,
+      user_id,  user.login,
+      group_id, group.name,
+      views_count,       views_numfiles,
+      downloads_count,   downloads_numfiles,
+      copies_count,      copies_numfiles,
+      task_setups_count, task_setups_numfiles
   end
 end
 

--- a/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
+++ b/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
@@ -63,6 +63,12 @@ extend Hirb::Console
                         ),
   'DiskQuota'      => %i( id user_id data_provider_id max_bytes max_files
                         ),
+  'DataUsage'      => %i( id user_id group_id
+                          views_count       views_numfiles
+                          downloads_count   downloads_numfiles
+                          copies_count      copies_numfiles
+                          task_setups_count task_setups_numfiles
+                        ),
 
 }.each do |klassname,fields|
   fields = fields.dup

--- a/BrainPortal/db/migrate/20220324155533_add_group_data_tracking_table.rb
+++ b/BrainPortal/db/migrate/20220324155533_add_group_data_tracking_table.rb
@@ -1,0 +1,54 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+class AddGroupDataTrackingTable < ActiveRecord::Migration[5.0]
+  def change
+
+    # Data tracking flag
+    add_column :groups, :track_usage, :boolean, :default => false, :null => false
+
+    # Data tracking table
+    nf  = { :null => false }
+    nf0 = { :null => false, :default => 0 }
+    create_table :data_usage do |t|
+
+      t.integer :user_id, nf               # which user
+      t.integer :group_id, nf              # which group/project
+      t.string  :yearmonth, nf             # period: "2022-03"
+
+      t.integer :views_count, nf0          # count the number of userfiles viewed during the period
+      t.integer :views_numfiles, nf0       # sum of num_files for these views
+
+      t.integer :downloads_count, nf0      # count the number of userfiles downloaded
+      t.integer :downloads_numfiles, nf0   # sum of num_files for these downloads
+
+      t.integer :task_setups_count, nf0    # count the number of userfiles used to setup tasks
+      t.integer :task_setups_numfiles, nf0 # sum of num_files for these tasks
+
+      t.integer :copies_count, nf0         # count the number of userfiles copied to other DPs
+      t.integer :copies_numfiles, nf0      # sum of num_files for these copies
+
+      t.timestamps
+    end
+
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220315153324) do
+ActiveRecord::Schema.define(version: 20220324155533) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -122,6 +122,22 @@ ActiveRecord::Schema.define(version: 20220315153324) do
     t.index ["user_id"], name: "index_data_providers_on_user_id", using: :btree
   end
 
+  create_table "data_usage", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
+    t.integer  "user_id",                          null: false
+    t.integer  "group_id",                         null: false
+    t.string   "yearmonth",                        null: false
+    t.integer  "views_count",          default: 0, null: false
+    t.integer  "views_numfiles",       default: 0, null: false
+    t.integer  "downloads_count",      default: 0, null: false
+    t.integer  "downloads_numfiles",   default: 0, null: false
+    t.integer  "task_setups_count",    default: 0, null: false
+    t.integer  "task_setups_numfiles", default: 0, null: false
+    t.integer  "copies_count",         default: 0, null: false
+    t.integer  "copies_numfiles",      default: 0, null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+  end
+
   create_table "disk_quotas", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=latin1" do |t|
     t.integer  "user_id"
     t.integer  "data_provider_id"
@@ -160,6 +176,7 @@ ActiveRecord::Schema.define(version: 20220315153324) do
     t.text     "description",    limit: 65535
     t.boolean  "public",                       default: false
     t.boolean  "not_assignable",               default: false
+    t.boolean  "track_usage",                  default: false, null: false
     t.index ["invisible"], name: "index_groups_on_invisible", using: :btree
     t.index ["name"], name: "index_groups_on_name", using: :btree
     t.index ["not_assignable"], name: "index_groups_on_not_assignable", using: :btree


### PR DESCRIPTION
This allows an administrator to mark a WorkGroup
with a 'data tracking' flag. When enabled, the CBRAIN
codebase will count, monthly, the files of those
projects as used in four contexts:

1) downloads using the interface
2) views in the browser
3) copies made to other data providers
4) files used to setup a CBRAIN task

For each context, a value of `+1` is added to a `{context}_count`
and a value of `+userfile.num_files` is added to a `{context}_num_files` counter
(so basically we can see the number of files used in file
collections).

The standard report maker of CBRAIN has been extended to add
four new report types for these values.