### PR TITLE
Allows the userfiles page to switch project

### DIFF
--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -738,7 +738,7 @@ class RemoteResource < ApplicationRecord
 
     # Send remote
     Control.site    = self.site
-    Control.timeout = 10
+    Control.timeout = 20
     control         = Control.new(command)
     control.save
 

--- a/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
+++ b/BrainPortal/app/views/data_providers/_one_data_provider_table.html.erb
@@ -125,14 +125,16 @@
 
     %>
 
-    <% t.column("Operations", :operations) do |dp| %>
+    <% t.column("Browse", :operations) do |dp| %>
       <% if dp.is_browsable?(current_user) && dp.can_be_accessed_by?(current_user) && dp.online? %>
         <%= link_to 'Browse', browse_data_provider_path(dp), :class => 'action_link' %>
       <% end %>
     <% end %>
 
-    <% t.column("Inconsistency", :inconsistency) do |dp| %>
-      <%= link_to 'Report', report_data_provider_path(dp), :class => 'action_link' %>
+    <% if check_role(:admin_user) %>
+      <% t.column("Inconsistency", :inconsistency) do |dp| %>
+        <%= link_to 'Report', report_data_provider_path(dp), :class => 'action_link' %>
+      <% end %>
     <% end %>
 
 <% end %>

--- a/BrainPortal/app/views/messages/new_dashboard.html.erb
+++ b/BrainPortal/app/views/messages/new_dashboard.html.erb
@@ -64,9 +64,6 @@
       </span>
     </p>
 
-    <%= f.hidden_field :critical,   :value => false %>
-    <%= f.hidden_field :send_email, :value => false %>
-
     <%= f.hidden_field :variable_text, :value => "" %>
 
     <p>

--- a/BrainPortal/lib/session_helpers.rb
+++ b/BrainPortal/lib/session_helpers.rb
@@ -41,8 +41,8 @@ module SessionHelpers
 
   # Returns currently active project.
   def current_project
-    return nil unless cbrain_session[:active_group_id].present?
-    return nil if     cbrain_session[:active_group_id] == "all"
+    return nil if cbrain_session[:active_group_id].blank?
+    return nil if cbrain_session[:active_group_id] == "all"
 
     if !@current_project || @current_project.id.to_i != cbrain_session[:active_group_id].to_i
       @current_project = Group.find_by_id(cbrain_session[:active_group_id])
@@ -53,7 +53,7 @@ module SessionHelpers
   end
 
   # Returns currently active project  or, if the current project is not assignable for the user, own group.
-  # Serves as default destination project id for many operation
+  # Serves as default destination project id for many operations
   def current_assignable_group
     if current_user.assignable_groups.include? current_project
       current_project

--- a/BrainPortal/lib/switch_group_helpers.rb
+++ b/BrainPortal/lib/switch_group_helpers.rb
@@ -1,0 +1,70 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2021-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Helpers for switching the current group (a state in the session).
+#
+# Used only in the Userfile and Group controllers.
+module SwitchGroupHelpers
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Change the current group of the current user.
+  # The argument group_id can be +nil+ or the string 'all', too.
+  # Returns true if the group was switched, and false if
+  # no change was performed.
+  def switch_current_group(group_id)
+    orig_active_group_id = cbrain_session[:active_group_id].presence
+
+    if group_id.blank? # FIXME I am not sure what that means. Pierre May 2022
+      cbrain_session[:active_group_id] = nil
+      return orig_active_group_id.present?  # say if it was changed or not
+    end
+
+    if group_id == "all"
+      cbrain_session[:active_group_id] = "all"
+      return orig_active_group_id != "all" # changed or not
+    end
+
+    switchable_groups = current_user.listable_groups
+    switchable_groups = switchable_groups.without_everyone if ! current_user.has_role? :admin_user
+    new_group = switchable_groups.find(group_id)
+    cbrain_session[:active_group_id] = new_group.id
+    return orig_active_group_id != new_group.id
+  end
+
+  # This method will set a session flag that will tell the userfiles 'index' action
+  # to add javscript code to the page to clear the persistently selected list of files.
+  def trigger_unselect_of_all_persistent_files
+    cbrain_session[:switched_active_group] = true
+  end
+
+  # This method removes any active column filters for selecting
+  # a particular group for the userfiles and tasks index pages.
+  def remove_group_filters_for_files_and_tasks
+    ['userfiles#index', 'tasks#index'].each do |name|
+      scope = scope_from_session(name)
+      scope.filters.reject! { |f| f.attribute.to_s == 'group_id' }
+      scope_to_session(scope, name)
+    end
+  end
+
+end


### PR DESCRIPTION
Direct urls can link to the file manager with a
parameter that implement a direct switch to another
active project. e.g. /userfiles?switch_group_id=123
This is similar to the switch action in the Groups
controller, but it will also some differences:
* The list of persistently selected files will not be cleared
* If the switched project is public, or if it belongs
  to someone else, the 'view_all' files option will be set.