### PR TITLE
reduce list of projects for admin resolves #1187

### DIFF
--- a/BrainPortal/app/helpers/select_box_helper.rb
+++ b/BrainPortal/app/helpers/select_box_helper.rb
@@ -108,6 +108,12 @@ module SelectBoxHelper
     groups   = options.has_key?(:groups)   ? (options[:groups]            || []) : current_user.assignable_groups
     groups   = groups.all.to_a if groups.is_a?(ActiveRecord::Relation)
 
+    # for Admin filter out only public, invisible or non_assignable to reduce the clutter
+    groups   =   groups.select do |g|
+      g.instance_of? WorkGroup && (g.public || g.invisible || (g.not_assignable &&
+          g.user_ids.include?(current_user.id ) ))
+    end if current_user.has_role? :adminuser
+
     if selector.respond_to?(:group_id)
       selected = selector.group_id.to_s
     elsif selector.is_a?(Group)

--- a/BrainPortal/app/helpers/select_box_helper.rb
+++ b/BrainPortal/app/helpers/select_box_helper.rb
@@ -123,8 +123,8 @@ module SelectBoxHelper
       current_user_id = current_user.id
       admin_ids = AdminUser.all.pluck(:id) || []
       groups   =   groups.select do |g|
-        (   g.instance_of?(SystemGroup) ||                            # everyone group
-            g.instance_of?(UserGroup) && (admin_ids & g.user_ids).present? ||  # admin usergroups
+        (   g.is_a?(SystemGroup) ||  # everyone group, to make a private tool public
+            g.is_a?(UserGroup) && (admin_ids & g.user_ids).present? ||  # admin usergroups
             g.public ||
             g.invisible ||
             g.not_assignable && (g.user_ids & admin_ids ).present? ||          # notassingable admin groups

--- a/BrainPortal/app/models/work_group.rb
+++ b/BrainPortal/app/models/work_group.rb
@@ -77,7 +77,17 @@ class WorkGroup < Group
     wgs
   end
 
-  def pretty_category_name(as_user) #:nodoc:
+  def pretty_category_name(as_user = nil) #:nodoc:
+    category = pretty_category_name_no_pub(as_user)
+    if category.present? && self.public && ! category.include?('Public') && as_user.has_role?(:admin_user)
+      category.sub(" ", " Public ")
+      # category.split(' ', 2).insert(1, "Public").join  # works even for empty str
+    else
+      category
+    end
+  end
+
+  def pretty_category_name_no_pub(as_user) #:nodoc:
     return @_pretty_category_name if @_pretty_category_name
     if self.invisible?
       @_pretty_category_name = 'Invisible Project'

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -26,7 +26,7 @@
 
 <% if @group.is_a?(WorkGroup) %>
   <div class="menu_bar">
-    <% if (@group.creator_id != current_user.id && !@group.public? && current_user.assignable_group_ids.include?(@group.id) %>
+    <% if @group.creator_id != current_user.id && !@group.public? && current_user.assignable_group_ids.include?(@group.id) %>
       <%= link_to 'Leave Project', {:action => :unregister, :id => @group.id}, :class => "button", :method  => :post %>
     <% end %>
     <% if @group.can_be_edited_by?(current_user) %>

--- a/BrainPortal/app/views/shared/_group_tables.html.erb
+++ b/BrainPortal/app/views/shared/_group_tables.html.erb
@@ -24,22 +24,26 @@
 
 <%
     if current_user.has_role? :admin_user
-      admin_ids = AdminUser.all.pluck(:id) || []
-      work_groups  = WorkGroup.where(invisible: false, public: true).all
-      work_groups += WorkGroup.joins(:users).where(invisible: false, public: false, not_assignable: true,
-                                                      "users.id" => admin_ids).all
-      work_groups = (work_groups + model.groups).uniq
+      admin_ids        = AdminUser.all.pluck(:id) || []
+      public_groups    = WorkGroup.where(invisible: false, public: true).all
+      nonassign_groups = WorkGroup.joins(:users).where(invisible: false, public: false,
+                                   not_assignable: true, "users.id" => admin_ids).all
+      work_groups = model.groups.select {|g| g.is_a?(WorkGroup) && ! g.invisible && ! g.public  &&
+                                                         ! nonassign_groups.include?(g)}
       invis_groups = WorkGroup.where(invisible: true).all
     elsif current_user.has_role? :site_manager
       work_groups  = current_user.site.groups.where( :type  => "WorkGroup", :invisible => false ).all | current_user.groups.where( :type => "WorkGroup", :invisible => false )
       invis_groups = current_user.site.groups.where( :type  => "WorkGroup", :invisible => true )
+      public_groups = []
     else
-      work_groups  = []
-      invis_groups = []
+      work_groups   = []
+      invis_groups  = []
+      public_groups = []
     end
-    work_groups  = work_groups.sort  { |a,b| a.name <=> b.name }
-    invis_groups = invis_groups.sort { |a,b| a.name <=> b.name }
-    class_name   = model.class.sti_root_class.to_s.underscore
+    work_groups   = work_groups.sort  { |a,b| a.name <=> b.name }
+    invis_groups  = invis_groups.sort { |a,b| a.name <=> b.name }
+    public_groups = public_groups.sort { |a,b| a.name <=> b.name }
+    class_name    = model.class.sti_root_class.to_s.underscore
 %>
 
 <%
@@ -60,14 +64,12 @@
 
 <% if work_groups.present? %>
 
-  <label>Work Projects</label>
+  <label> Work Projects </label>
   <%= array_to_table(work_groups, :cols => 4, :td_class => 'left_align no_wrap') do |group,r,c| %>
     <%= group_check_box.(group) %>
   <% end %>
 
 <% end %>
-
-
 
 <% if invis_groups.present? %>
 
@@ -79,3 +81,23 @@
 
 <% end %>
 
+<% if public_groups.present? %>
+
+  <br>
+  <label>Public Projects</label>
+  <%= array_to_table(public_groups, :cols => 4, :td_class => 'left_align no_wrap') do |group,r,c| %>
+    <%= group_check_box.(group) %>
+  <% end %>
+
+<% end %>
+
+
+<% if nonassign_groups.present? %>
+
+  <br>
+  <label>Non-Assignable Projects</label>
+  <%= array_to_table(nonassign_groups, :cols => 4, :td_class => 'left_align no_wrap') do |group,r,c| %>
+    <%= group_check_box.(group) %>
+  <% end %>
+
+<% end %>

--- a/BrainPortal/app/views/shared/_group_tables.html.erb
+++ b/BrainPortal/app/views/shared/_group_tables.html.erb
@@ -24,7 +24,8 @@
 
 <%
     if current_user.has_role? :admin_user
-      work_groups  = WorkGroup.where(invisible: false).all
+      work_groups  = WorkGroup.where(invisible: false, public: true).all
+      work_groups += WorkGroup.where(invisible: false, public: false, not_assignable: true, users: current_user.id).all
       invis_groups = WorkGroup.where(invisible: true).all
     elsif current_user.has_role? :site_manager
       work_groups  = current_user.site.groups.where( :type  => "WorkGroup", :invisible => false ).all | current_user.groups.where( :type => "WorkGroup", :invisible => false )

--- a/BrainPortal/app/views/shared/_group_tables.html.erb
+++ b/BrainPortal/app/views/shared/_group_tables.html.erb
@@ -24,16 +24,19 @@
 
 <%
     if current_user.has_role? :admin_user
-      admin_ids        = AdminUser.all.pluck(:id) || []
-      public_groups    = WorkGroup.where(invisible: false, public: true).all
-      nonassign_groups = WorkGroup.joins(:users).where(invisible: false, public: false,
-                                   not_assignable: true, "users.id" => admin_ids).all
-      work_groups = model.groups.select {|g| g.is_a?(WorkGroup) && ! g.invisible && ! g.public  &&
-                                                         ! nonassign_groups.include?(g)}
-      invis_groups = WorkGroup.where(invisible: true).all
+      admin_ids         = AdminUser.all.pluck(:id) || []
+      public_groups     = WorkGroup.where( invisible: false, public: true ).all
+      nonassign_groups  = WorkGroup.joins(:users).where( invisible: false, public: false,
+                                   not_assignable: true, "users.id" => admin_ids ).all
+      nonassign_groups |= WorkGroup.where( invisible: false, public: false,
+                                   not_assignable: true, creator_id: admin_ids ).all
+      nonassign_groups  = nonassign_groups.uniq
+      work_groups       = model.groups.select { |g| g.is_a?(WorkGroup) && ! g.invisible && ! g.public  &&
+                                                         ! nonassign_groups.include?(g) }
+      invis_groups      = WorkGroup.where( invisible: true ).all
     elsif current_user.has_role? :site_manager
-      work_groups  = current_user.site.groups.where( :type  => "WorkGroup", :invisible => false ).all | current_user.groups.where( :type => "WorkGroup", :invisible => false )
-      invis_groups = current_user.site.groups.where( :type  => "WorkGroup", :invisible => true )
+      work_groups   = current_user.site.groups.where( :type  => "WorkGroup", :invisible => false ).all | current_user.groups.where( :type => "WorkGroup", :invisible => false )
+      invis_groups  = current_user.site.groups.where( :type  => "WorkGroup", :invisible => true )
       public_groups = []
     else
       work_groups   = []
@@ -64,12 +67,14 @@
 
 <% if work_groups.present? %>
 
-  <label> Work Projects </label>
+  <label>Work Projects</label>
   <%= array_to_table(work_groups, :cols => 4, :td_class => 'left_align no_wrap') do |group,r,c| %>
     <%= group_check_box.(group) %>
   <% end %>
 
 <% end %>
+
+
 
 <% if invis_groups.present? %>
 
@@ -81,6 +86,8 @@
 
 <% end %>
 
+
+
 <% if public_groups.present? %>
 
   <br>
@@ -90,6 +97,7 @@
   <% end %>
 
 <% end %>
+
 
 
 <% if nonassign_groups.present? %>

--- a/BrainPortal/app/views/shared/_group_tables.html.erb
+++ b/BrainPortal/app/views/shared/_group_tables.html.erb
@@ -24,8 +24,11 @@
 
 <%
     if current_user.has_role? :admin_user
+      admin_ids = AdminUser.all.pluck(:id) || []
       work_groups  = WorkGroup.where(invisible: false, public: true).all
-      work_groups += WorkGroup.where(invisible: false, public: false, not_assignable: true, users: current_user.id).all
+      work_groups += WorkGroup.joins(:users).where(invisible: false, public: false, not_assignable: true,
+                                                      "users.id" => admin_ids).all
+      work_groups = (work_groups + model.groups).uniq
       invis_groups = WorkGroup.where(invisible: true).all
     elsif current_user.has_role? :site_manager
       work_groups  = current_user.site.groups.where( :type  => "WorkGroup", :invisible => false ).all | current_user.groups.where( :type => "WorkGroup", :invisible => false )


### PR DESCRIPTION
this reduces the project lists for admin, which became unwieldy.

@natacha-beck the feature complicates task of setting the prototype tools to a private group, as well as creation of private data providers. Please confirm that you ok with it or need some workaround (e.g. adding admin workgroups, perhaps prioriterization instead of removal)
