### PR TITLE
Added API endpoint to get a TC's descriptor

### DIFF
--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -286,7 +286,7 @@ class ToolConfigsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.json { render :json => (@descriptor || {}) }
+      format.json { render :json => JSON.pretty_generate(@descriptor || {}) }
     end
   end
 

--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -25,10 +25,10 @@ class ToolConfigsController < ApplicationController
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  api_available :only => [ :index, :show ]
+  api_available :only => [ :index, :show, :boutiques_descriptor ]
 
   before_action :login_required
-  before_action :admin_role_required, :except => [ :index ]
+  before_action :admin_role_required, :except => [ :index, :boutiques_descriptor ]
 
   def index #:nodoc:
     @scope = scope_from_session
@@ -275,6 +275,18 @@ class ToolConfigsController < ApplicationController
                     end
                   }
       format.xml  { head :ok }
+    end
+  end
+
+  # GET /tool_configs/:id/boutiques_descriptor[.json]
+  def boutiques_descriptor
+    id           = params[:id]
+    @tool_config = base_scope.find(id)
+    @descriptor  = @tool_config.boutiques_descriptor
+
+    respond_to do |format|
+      format.html
+      format.json { render :json => (@descriptor || {}) }
     end
   end
 

--- a/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
+++ b/BrainPortal/app/views/tool_configs/_tool_configs_table.html.erb
@@ -109,12 +109,22 @@
     ) {|tc|
       rev_info = tc.tool.cbrain_task_class.revision_info rescue nil
 
+      link_show = ""
       if rev_info
         rev_info_basename = rev_info.basename
         rev_info_commit   = rev_info.short_commit
 
         # rev_info_basename match *.json if cbrain use a Boutiques descriptor
-        "#{rev_info_commit} -- #{rev_info_basename}" if rev_info_basename =~ /\.json$/
+        link_show = "#{rev_info_commit} -- #{rev_info_basename}" if rev_info_basename =~ /\.json$/
+      end
+
+      descriptor = tc.boutiques_descriptor rescue nil # some TCs have no tools
+      link_show  = "(Descriptor)" if link_show.blank? && descriptor.present?
+
+      if descriptor
+        link_to link_show, boutiques_descriptor_tool_config_path(tc)
+      else
+        link_show
       end
     }
 

--- a/BrainPortal/app/views/tool_configs/boutiques_descriptor.html.erb
+++ b/BrainPortal/app/views/tool_configs/boutiques_descriptor.html.erb
@@ -1,0 +1,44 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Boutiques Descriptor' %>
+
+<% if @descriptor.present? %>
+
+This is the Boutiques Descriptor for tool
+<strong><%= @tool_config.tool.name %></strong>
+on Execution Server
+<strong><%= @tool_config.bourreau.name %></strong>.
+<p>
+
+<pre><%= JSON.pretty_generate(@descriptor) %></pre>
+
+<% else %>
+
+There is no Boutiques Descriptor for tool
+<strong><%= @tool_config.tool.name %></strong>
+on Execution Server
+<strong><%= @tool_config.bourreau.name %></strong>.
+
+<% end %>

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -49,6 +49,9 @@ Rails.application.routes.draw do
     collection do
       get  'report'
     end
+    member do
+      get  'boutiques_descriptor'
+    end
   end
 
   resources :messages,        :except => [ :edit, :show ] do


### PR DESCRIPTION
The 'Boutiques' column in the ToolConfig index page has hotlinks to a page that shows the descriptor.

For the API side, issue things like:

```shell
curl -H 'Accept: application/json' http://localhost:3000/tool_configs/5/boutiques_descriptor.json?cbrain_api_token=e262c225510aab9260301f604e2cf8ae
```