### PR TITLE
Admins can force a user to authenticate with globus

### DIFF
--- a/BrainPortal/app/controllers/neurohub_application_controller.rb
+++ b/BrainPortal/app/controllers/neurohub_application_controller.rb
@@ -103,7 +103,7 @@ class NeurohubApplicationController < ApplicationController
     @nh_new_message_count = find_nh_messages.where(:read => false).count  # differs from cbrain, as invites are shown separately
     @nh_new_invites_ack   = current_user.messages.where( :read => false, :header => 'Invitation Accepted' ).order( "last_sent DESC" ).all()
   end
-  
+
   # Check if password need to be reset.
   # This method is identical to (and overrides) the one in
   # ApplicationController excepts it uses the NeuroHub password reset form.
@@ -117,6 +117,26 @@ class NeurohubApplicationController < ApplicationController
     end
     return true
   end
+
+  # Check to see if the user HAS to link their account to
+  # a globus identity. If that's the case and not yet done,
+  # redirects to the page that provides the user with the
+  # buttons and explanations.
+  # This method is similar to (and overrides) the one in
+  # ApplicationController excepts it uses the NeuroHub information form.
+  def check_mandatory_globus_id_linkage #:nodoc:
+    return true if   params[:action].to_s == "nh_mandatory_globus"
+    return true if   params[:action].to_s == "nh_globus"
+    return true if ! user_must_link_to_globus?(current_user)
+    return true if   user_has_link_to_globus?(current_user)
+    respond_to do |format|
+      format.html { redirect_to :controller => :nh_sessions, :action => :nh_mandatory_globus }
+      format.json { render :status => 403, :json => { "error" => "This account must first be linked to a Globus identity" } }
+      format.xml  { render :status => 403, :xml  => { "error" => "This account must first be linked to a Globus identity" } }
+    end
+    return false
+  end
+
 
 end
 

--- a/BrainPortal/app/models/s3_flat_data_provider.rb
+++ b/BrainPortal/app/models/s3_flat_data_provider.rb
@@ -46,8 +46,8 @@ class S3FlatDataProvider < DataProvider
   validates_presence_of :cloud_storage_client_identifier, :cloud_storage_client_token,
                         :cloud_storage_client_bucket_name
 
-  validates :cloud_storage_client_identifier,  length: { is: 20 }
-  validates :cloud_storage_client_token,       length: { is: 40 }
+  validates :cloud_storage_client_identifier,  length: { in: 16..128 }
+  validates :cloud_storage_client_token,       length: { in: 20..100 }
 
   validates :cloud_storage_client_bucket_name, format: {
     with: /\A[A-Za-z0-9][A-Za-z0-9\-.]{1,61}[A-Za-z0-9]\z/, # this is good enough; DP will just crash on bad names

--- a/BrainPortal/app/views/nh_sessions/nh_mandatory_globus.html.erb
+++ b/BrainPortal/app/views/nh_sessions/nh_mandatory_globus.html.erb
@@ -1,0 +1,86 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Mandatory Globus Link', "" %>
+
+<div class="nh_content">
+
+  <div class="card">
+
+    <div class="card-item heading">
+      <div class="card-heading">
+        <p class="text-lg">Mandatory Globus Link</p>
+        <p class="text-md">Before continuing, your account must be linked to a Globus identity provider.</p>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div class="card-item">
+        <div>
+          <p class="card-label">Explanations</p>
+          <p class="card-text">
+            When you click on the button below, your browser will be redirected
+            to a Globus login page; from there you can choose one of the
+            globus-supported identity providers. This will in turn redirect you
+            to the provider's own login page. Once you've successfully authenticated
+            there, your browser will be redirected back here to finalize
+            the link with your NeuroHub account.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div class="card-item">
+        <div>
+          <p class="card-label">The identity providers that are allowed for your NeuroHub account are:</p>
+          <% @allowed_provs.each do |provname| %>
+            <% provname = '(Any Globus identity provider)' if provname == '*' %>
+            <p class="card-text">&bull; <%= provname %></p>
+          <% end %>
+          <p class="btn-solid globus bg-warning-bg">
+            <%= link_to 'Link your NeuroHub account to Globus', @globus_uri, :class => '' %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="card-row">
+      <div class="card-item">
+        <div>
+          <p class="card-text">
+            If you already are logged in on Globus using a different identity provider, your
+            might want to log out first. This can be accomplished by the button below:
+          </p>
+          <p class="btn-solid globus bg-warning-bg">
+            <%= link_to 'Logout from all Globus identities', @globus_logout, :class => '' %>
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div> <!-- card -->
+
+</div> <!-- nh_content -->
+

--- a/BrainPortal/app/views/nh_storages/index.html.erb
+++ b/BrainPortal/app/views/nh_storages/index.html.erb
@@ -38,7 +38,6 @@
           <%= link_to "Create new storage configuration", new_nh_storage_path, :class => "btn-solid primary" %>
         </div>
       </div>
-      </div>
     </div>
 
   <% else %>

--- a/BrainPortal/app/views/sessions/mandatory_globus.html.erb
+++ b/BrainPortal/app/views/sessions/mandatory_globus.html.erb
@@ -1,0 +1,55 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2022
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Mandatory Globus Link' %>
+
+<h2>Before you can continue, your CBRAIN account <em>must</em> be linked to a Globus identity provider.</h2>
+
+<h5>Explanations</h5>
+
+<p class="short_paragraphs">
+When you click on the button below, your browser will be redirected
+to a Globus login page; from there you can choose one of the
+globus-support identity providers. This will in turn redirect you
+to the provider's own login page. Once you've successfully authenticated
+there, your browser will be redirected back here to finalize
+the link with your CBRAIN account.
+</p>
+
+<h5>The identity providers that are allowed for your account are:</h5>
+
+<ul>
+  <% @allowed_provs.each do |provname| %>
+    <% provname = '(Any Globus identity provider)' if provname == '*' %>
+    <li><%= provname %></li>
+  <% end %>
+</ul>
+
+<%= link_to 'Link your CBRAIN account to Globus', @globus_uri, :class => 'button globus_button' %>
+
+<p class="short_paragraphs">
+If you already are logged in on Globus using a different identity provider, your
+might want to log out first. This can be accomplished by the button below:
+<p>
+<%= link_to 'Logout from all Globus identities', @globus_logout, :class => 'button globus_button' %>

--- a/BrainPortal/app/views/sessions/new.html.erb
+++ b/BrainPortal/app/views/sessions/new.html.erb
@@ -80,6 +80,10 @@
       </td>
       <td class="field">
         <%= link_to 'Sign In With Globus', @globus_uri, :class => 'button globus_button' %>
+        <div class="field_explanation">
+          (Only available if you have already linked your<br>
+          CBRAIN account to a Globus identity)
+        </div>
       </td>
     </tr>
 

--- a/BrainPortal/app/views/users/new.html.erb
+++ b/BrainPortal/app/views/users/new.html.erb
@@ -91,6 +91,15 @@
     <span class="field_explanation">If set, make sure it is a Data Provider that will be accessible to the user</span>
 
     <p>
+    <%= label_tag 'meta_allowed_globus_provider_names', "Forced Globus Identity Providers" %>
+    <%= text_field_tag("meta[allowed_globus_provider_names]", (params[:meta] || {})[:allowed_globus_provider_names], :size => 30) %>
+    <br>
+    <span class="field_explanation">
+      If set, must be exact Globus identity provider names separated by commas
+      A single '*' is also allowed to mean any provider name.
+    </span>
+
+    <p>
     <%= f.label :password, "Password" %><br/>
     <%= f.password_field :password, :value => @random_pass, :autocomplete => "new-password" %>
 

--- a/BrainPortal/app/views/users/show.html.erb
+++ b/BrainPortal/app/views/users/show.html.erb
@@ -117,6 +117,14 @@
           Comma-separated list of allowed source IPs (X.X.X.X/XX) for the user to connect from.
         </div>
       <% end %>
+
+      <% t.edit_cell('meta[allowed_globus_provider_names]', :header => 'Forced Globus Identity Providers', :content => @user.meta['allowed_globus_provider_names'] || '') do %>
+        <%= text_field_tag "meta[allowed_globus_provider_names]", @user.meta['allowed_globus_provider_names'], :size => 40 %><br />
+        <div class="field_explanation">
+          If set, must be a list of Globus identity provider names separated by commas. A single '*' is
+          also allowed to mean any provider name.
+        </div>
+      <% end %>
     <% end %>
 
   <% end %>

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -203,6 +203,7 @@ Rails.application.routes.draw do
   # Globus authentication
   get   '/globus'                 => 'sessions#globus'
   post  '/unlink_globus'          => 'sessions#unlink_globus'
+  get   '/mandatory_globus'       => 'sessions#mandatory_globus'
 
   # Report Maker
   get   "/report",                :controller => :portal, :action => :report
@@ -292,6 +293,7 @@ Rails.application.routes.draw do
     # Globus authentication
     get   '/nh_globus'              => 'nh_sessions#nh_globus'
     post  '/nh_unlink_globus'       => 'nh_sessions#nh_unlink_globus'
+    get   '/nh_mandatory_globus'    => 'nh_sessions#nh_mandatory_globus'
 
     # ORCID authentication
     get   '/orcid'                  => 'nh_sessions#orcid'

--- a/BrainPortal/lib/globus_helpers.rb
+++ b/BrainPortal/lib/globus_helpers.rb
@@ -243,7 +243,7 @@ module GlobusHelpers
   def find_users_with_specific_identity(identity)
     provider_id   = identity['identity_provider']              || cb_error("Globus: No identity provider")
     provider_name = identity['identity_provider_display_name'] || cb_error("Globus: No identity provider name")
-    pref_username = identity['preferred_username']
+    pref_username = identity['preferred_username'] ||
                     identity['username']                       || cb_error("Globus: No preferred username")
 
     # Special case for ORCID, because we already have fields for that provider


### PR DESCRIPTION
When creating an account or editing an account, an admin can configure
it such that the user must link it to a Globus identity provider.

The admins does so by entering the name of the identity provider(s) in user's
account form, something like:

```
Sydney Opera House, Hogwarts School of Witchcraft and Wizardry, University of Minnesota
```

(These names are case sensitive by the way).