### PR TITLE
Boutiques parameter values Fixer module

### DIFF
--- a/Bourreau/lib/boutiques_input_value_fixer.rb
+++ b/Bourreau/lib/boutiques_input_value_fixer.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_input_value_fixer.rb

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -57,10 +57,9 @@ module BoutiquesInputValueFixer
   # no input or values dependencies for fixed variables are fully supported,
   # in the presence of dependencies involving fixed params, the module
   # does its best to avoid deadlock and issues, but, probably,
-  # might fails in edge cases. It is best if fixation is "closed" in the sense that
-  # contains all the 'implied' fixation
+  # might fails in edge cases. It is recommended to supply fixation is "closed" in the sense that
+  # contains all the implied parameter fixes or deletions
   def delete_fixed_inputs(descriptor)
-
     # input parameters are marked by null values will be excluded from the command line
     # the major use case are Flags, but also may be useful to address params with 'default' (
     # or, for flags, null-like values)
@@ -89,7 +88,7 @@ module BoutiquesInputValueFixer
       if g.mutually_exclusive && members.length != g.members.length # params can be mutually exclusive e.g. --use-min-mem vs --mem-mb
         if (fixation.keys & g.members - skipped).present? # at least some group members are actually assigned vals rather than deleted
           g.mutually_exclusive = false
-          block_inputs(descriptor_dup, members)
+          block_inputs(descriptor_dup, members - fixation.keys)
           # a better solution is to delete rest of group params completely
           # a bit more complex though and might result in recursive code or nested loops
         end
@@ -158,7 +157,6 @@ module BoutiquesInputValueFixer
 
   # adjust descriptor to allow check # of supplied files
   def descriptor_for_before_form
-
     delete_fixed_inputs(super)
   end
 

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -76,7 +76,6 @@ module BoutiquesInputValueFixer
 
     end
 
-
     # generally speaking, boutiques inputs can have different dependencies,
     # here we address only group dependencies, namely mutually exclusion group
     # if not removed task UI might force user into entering invalid parameter valuation (invocation)
@@ -99,7 +98,7 @@ module BoutiquesInputValueFixer
       # removes  'one-is-required' or disables group when one or more element fixed, e.g.
       # if g.all_or_none && members.length != g.members.length
       #   # if (g.members & skipped).present?
-      #   #   # todo delete all member inputs, or disable by injecting pairwise required/disable dependencie
+      #   #   # todo delete all member inputs, or disable by injecting pairwise required/disable dependencies
       #   # end
       #   if (fixation.keys & g.members - skipped).present? # if one is set, rest should be to
       #     g.members.each do |i_id|
@@ -133,7 +132,7 @@ module BoutiquesInputValueFixer
     descriptor_dup.inputs.each do |i|
       i.requires_inputs = i.requires_inputs - fixation.keys if i.requires_inputs.present?
       i.disables_inputs = i.disables_inputs - fixation.keys if i.disables_inputs.present?
-      i.value_requires.each { |v, a| i.value_disables[v] -= fixation.keys } if i.value_requires.present?
+      i.value_requires.each { |v, a| i.value_requires[v] -= fixation.keys } if i.value_requires.present?
       i.value_disables.each { |v, a| i.value_disables[v] -= fixation.keys } if i.value_disables.present?
     end
 

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -75,7 +75,9 @@ module BoutiquesInputValueFixer
 
     end
 
-    descriptor_dup.groups.each do |g| # filter groups
+
+
+    descriptor_dup.groups.each do |g| # filter groups, relax restriction to anable form submission
       members = g.members - invocation.keys
       # disable a mutualy exclusive group if its param assigned fixed value by this modifier
       # if one simply deletes the fixed param,
@@ -83,7 +85,7 @@ module BoutiquesInputValueFixer
         if (invocation.keys & g.members - skipped).present? # at least some group members are actually assigned vals rather than deleted
            if members.length == 1
              g.mutually_exclusive = false # drop the restriction, has no point for one element
-             # (though ideally input should be suppressed)
+             # todo add pairwise requires and disables to effectively disable all
            else # when more than one member
              g.all_or_none = true # adding all-or-none will block task submission.
            end
@@ -92,30 +94,32 @@ module BoutiquesInputValueFixer
         end
       end
 
+      # presently one-is-required is checked only statically, no GUI support
       # removes one-is-required flag if one element fixed
-      if g.one_is_required && members.length != g.members.length
-        if (invocation.keys & g.members - skipped).present?
-          g.one_is_required == false
-        end
-      end
+      # if g.one_is_required && members.length != g.members.length
+      #   if (invocation.keys & g.members - skipped).present?
+      #     g.one_is_required == false
+      #   end
+      # end
 
-      # removes one is required flag if one element fixed, e.g.
-      if g.all_or_none && members.length != g.members.length
-        if (g.members & skipped).present?
-          #g.all_or_none == false
-          g.mutually_exclusive = true # if more than 1 params remains remaining
-          # todo delete all member inputs
-        elsif (invocation.keys & g.members - skipped).present? # if one is set, rest should be to
-          g.members.each do |i_id|
-            begin
-              input = descriptor.input_by_id(i_id)
-            rescue CbrainError  # if descriptor was already processed
-              next
-            end
-            input.optional = false
-          end
-        end
-      end
+      # all-or-none is not reflected in dynamic gui, uncomment once fixed
+      #
+      # removes  'one-is-required' or disables group when one or more element fixed, e.g.
+      # if g.all_or_none && members.length != g.members.length
+      #   # if (g.members & skipped).present?
+      #   #   # todo delete all member inputs, or disable by injecting pairwise required/disable dependencie
+      #   # end
+      #   if (invocation.keys & g.members - skipped).present? # if one is set, rest should be to
+      #     g.members.each do |i_id|
+      #       begin
+      #         input = descriptor.input_by_id(i_id)
+      #       rescue CbrainError  # if descriptor was already processed
+      #         next
+      #       end
+      #       input.optional = false
+      #     end
+      #   end
+      # end
 
       # I suspect that at the moment CBRAIN only fully comfortable
       # with at most one quantifier flag per group

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -1,0 +1,181 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module allows one to fix some of input parameters to specific values
+# The fixed input(s) would no longer be shown to the user in the form.
+#
+# In the descriptor, the spec would look like:
+#
+#    "custom": {
+#     "cbrain:integrator_modules": {
+#         "BoutiquesInputValueFixer": {
+#             "n_cpus": 1,
+#             "mem_": "4G",
+#             "customquery": nil,
+#             "level": "group"
+#         }
+#     }
+# }
+# COULD BE TRICKY, PRESENTLY PARAMETER DEPENDENCY are not supported
+# disables-inputs, requires-inputs,
+# the parameters assigned null will be disabled without assignment
+# string 'null' is considered string for String params
+module BoutiquesInputValueFixer
+
+  # Note: to access the revision info of the module,
+  # you need to access the constant directly, the
+  # object method revision_info() won't work.
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # deletes fixed inputs listed in the custom 'integrator_modules'
+  # no input or values dependencies for fixed variables are supported
+  def delete_fixed_inputs(descriptor)
+    old_descriptor = descriptor.dup
+    #skipped parameters that's unset
+
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+
+    # inputs which are deleted by assign null (or, for flags, null-like values)
+    skipped = invocation.keys.select do |i_id|
+
+      input = descriptor.input_by_id(i_id)
+      value = invocation[i_id]
+      value.nil? || input.type == 'Flag' && (value               == 0       || # flag inputs
+                                             value.to_s.downcase == 'no'    || # can be skipped by null-like values
+                                             value               == [nil]   || # but for other types
+                                             value               == '0'     || # to skip a parameter from command line
+                                             value.to_s.downcase == 'null'  || # only use
+                                             value.to_s.downcase == 'false' || # null
+                                             value.blank?
+                                             )
+    end
+
+    descriptor.inputs = descriptor.inputs.select { |i| ! invocation.key?(i.id)} # filter inputs
+
+    descriptor.groups.each do |g| # filter groups
+
+      members = g.members - invocation.keys
+      # deletes a mutualy exclusive group if one element fixed
+      if g.mutually_exclusive && members.length != g.members.length
+        if (invocation.keys & g.members - skipped).present?
+           g.mutually_exclusive == false
+           members = nil
+        end
+      end
+
+      # removes one is required flag if one element fixed
+      if g.one_is_required && members.length != g.members.length
+        if (invocation.keys & g.members - skipped).present?
+          g.one_is_required == false
+        end
+      end
+
+      # removes one is required flag if one element fixed
+      if g.all_or_none && members.length != g.members.length
+        if (g.members & skipped).present?
+          g.all_or_none == false
+        elsif (invocation.keys & g.members - skipped).present? # if one is set, rest should be to
+          g.members.each do |iid|
+            input = descriptor.input_by_id(iid)
+            input.optional = false
+          end
+
+        end
+      end
+
+      # I suspect that at the moment CBRAIN only fully comfortable
+      # with at most one quantifier flag per group
+      # and in mutually exclusive
+      # (non-overlapping groups), if not more can be done
+
+      g.members = members.presence
+
+      # todo propagate dependencies (it's easier to add internal 'hidden' attribute to inputs)
+      # or maybe just delete dependencies
+
+    end
+    descriptor.groups = descriptor.groups.compact
+    descriptor
+  end
+
+  # adjust descriptor to allow check # of supplied files
+  def descriptor_before_form #:nodoc:
+    descriptor = self.super.dup
+    delete_fixed_inputs(descriptor)
+  end
+
+  # not show user fixed inputs
+  def descriptor_for_form
+    descriptor = super.dup
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+    self.invoke_params.merge!(invocation)
+    delete_fixed_inputs(descriptor)
+  end
+
+  def descriptor_for_show_params
+    descriptor = super.dup
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+    self.invoke_params.merge!(invocation)
+    delete_fixed_inputs(descriptor)
+  end
+
+  require 'pry'
+  # validation
+  # todo descriptor trimming might needed to hide from executed
+  def after_form #:nodoc:
+    #binding.pry
+    descriptor = self.descriptor_for_after_form
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+
+    self.invoke_params.merge!(invocation)
+    # delete_fixed(descriptor) no idea is needed
+    super
+  end
+
+  # prepare fixed userfiles
+  def setup
+    descriptor = self.descriptor_for_setup
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+    self.invoke_params.merge!(invocation)
+    super
+  end
+
+  # todo delete, is it really needed? maybe to restart on cluster
+  # This method overrides the one in BoutiquesClusterTask
+  # It adjusts task's invocation
+  def cluster_commands
+    descriptor = self.descriptor_for_cluster_commands
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+    self.invoke_params.merge!(invocation) # todo, maybe not needed, already done at setup
+    super
+  end
+
+  # restart postprocessing
+  def save_results
+    descriptor = self.descriptor_for_save_results
+    invocation = descriptor.custom_module_info('BoutiquesInputValueFixer')
+    self.invoke_params.merge!(invocation) # todo, maybe not needed, already done at setup
+    # Performs standard processing
+    super
+  end
+
+end

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -85,14 +85,14 @@ module BoutiquesInputValueFixer
         end
       end
 
-      # removes one is required flag if one element fixed
+      # removes one is required flag if one element fixed  --use-min-mem vs --mem-mb
       if g.one_is_required && members.length != g.members.length
         if (invocation.keys & g.members - skipped).present?
           g.one_is_required == false
         end
       end
 
-      # removes one is required flag if one element fixed
+      # removes one is required flag if one element fixed, e.g.
       if g.all_or_none && members.length != g.members.length
         if (g.members & skipped).present?
           g.all_or_none == false
@@ -101,7 +101,7 @@ module BoutiquesInputValueFixer
           g.members.each do |i_id|
             begin
               input = descriptor.input_by_id(i_id)
-            rescue CbrainError
+            rescue CbrainError  # if descriptor was already processed
               next
             end
             input.optional = false
@@ -131,53 +131,46 @@ module BoutiquesInputValueFixer
   end
 
   # adjust descriptor to allow check # of supplied files
-  def descriptor_for_before_form #:nodoc:
-    
+  def descriptor_for_before_form
     delete_fixed_inputs(super)
   end
 
   # not show user fixed inputs
   def descriptor_for_form
-    
     self.invoke_params.merge!(invocation)
     delete_fixed_inputs(super)
   end
 
   def descriptor_for_show_params
-    
     self.invoke_params.merge!(invocation)
-    super
+    super    # standard values
   end
-
 
   # validation
-  # todo descriptor trimming might needed to hide from executed
-  def after_form #:nodoc:
-    
+  def after_form
     self.invoke_params.merge!(invocation)
     # delete_fixed(descriptor) no idea is needed
-    super
+    super    # Performs standard processing
   end
 
-  # prepare fixed userfiles
+  # prepare userfiles
   def setup
     self.invoke_params.merge!(invocation)
-    super
+    super    # Performs standard processing
   end
 
-  # todo delete, is it really needed? maybe to restart on cluster
+  # re-start on cluster
   # This method overrides the one in BoutiquesClusterTask
   # It adjusts task's invocation
   def cluster_commands
-    self.invoke_params.merge!(invocation) # todo, maybe not needed, already done at setup
-    super
+    self.invoke_params.merge!(invocation)
+    super    # Performs standard processing
   end
 
-  # restart postprocessing
+  # for restart postprocessing
   def save_results
-    self.invoke_params.merge!(invocation) # todo, maybe not needed, already done at setup
-    # Performs standard processing
-    super
+    self.invoke_params.merge!(invocation)
+    super     # Performs standard processing
   end
 
 end

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -125,7 +125,7 @@ module BoutiquesInputValueFixer
       #input.disables_if input.disables_inputs.present?
       input.disables_inputs ||= []
       input.disables_inputs |= [input_id]
-      input.name += " --- disabled by admin ---"
+      input.name += " ( unavailable )"
     end
   end
 

--- a/BrainPortal/lib/boutiques_input_value_fixer.rb
+++ b/BrainPortal/lib/boutiques_input_value_fixer.rb
@@ -2,7 +2,7 @@
 #
 # CBRAIN Project
 #
-# Copyright (C) 2008-2023
+# Copyright (C) 2008-2024
 # The Royal Institution for the Advancement of Learning
 # McGill University
 #
@@ -20,9 +20,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# This module allows one to fix some of input parameters to specific values
+# This module allows one to fix some of input parameters to specific constand values
 # The fixed input(s) would no longer be shown to the user in the form.
-# The inputs assigned null value will be removed (do not use with mandatory input parameters)
+# The optional inputs assigned null value will be removed 
+# (do not use with mandatory input parameters)
 #
 # In the descriptor, the spec would look like:
 #
@@ -51,7 +52,7 @@ module BoutiquesInputValueFixer
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
 
-  # the hash of param values to be fixed or be omited ()  #
+  # the hash of input parameter values to be fixed or, if value is null, to be omited  
   def fixed_values
     self.boutiques_descriptor.custom_module_info('BoutiquesInputValueFixer')
   end
@@ -59,7 +60,7 @@ module BoutiquesInputValueFixer
   # deletes fixed inputs listed in the custom 'integrator_modules'
   def descriptor_without_fixed_inputs(descriptor)
     # input parameters are marked by null values will be excluded from the command line
-    # the major use case are Flags, but also may be useful to address params with 'default'
+    # other will be given fixed falues during execution; neither is shown in form UI
 
     fixed_input_ids = fixed_values.keys
     descriptor_dup  = descriptor.dup
@@ -71,8 +72,9 @@ module BoutiquesInputValueFixer
     end
 
     # generally speaking, boutiques input groups can have three different constraints,
-    # here we address mutually exclusion group only, which is the only one present in dynamic GUI (rest are evaluated
-    # after submission of parameter).
+    # here we address mutually exclusive constraint, which is the only one present in GUI javascript (rest are evaluated
+    # after submission of parameter), and 'one is required' which might affect the initial rendering of the form
+    # ( though IMHO red stars or other indicators to draw user attention should eventually implemented )
 
     descriptor_dup.groups.each do |g| # filter groups, relax restriction to ensure that form can still be submitted
       members = g.members - fixed_input_ids
@@ -90,9 +92,10 @@ module BoutiquesInputValueFixer
         block_inputs(descriptor_dup, members) if g.mutually_exclusive
         g.mutually_exclusive = false  # will make form's javascript smaller/faster
 
-        # all-or-none constraint is seldom used, does not affect form until validation,
+        # all-or-none constraint is seldom used, does not affect form itself,
+        # and only validated after the form submission
         # and generally presents less pitfalls
-        # Therefor, at the moment all-or-none is not addressed here
+        # Therefore, at the moment, 'all or none' constraint is not addressed here
 
       end
       g.members = members
@@ -141,7 +144,7 @@ module BoutiquesInputValueFixer
 
   # show all the params
   def descriptor_for_show_params
-    self.invoke_params.merge!(fixed_values) # shows 'fixed' parameters, used would not be able to edit them, so should be save
+    self.invoke_params.merge!(fixed_values) # shows 'fixed' parameters, user would not be able to edit them
     super    # standard values
   end
 


### PR DESCRIPTION
addresses issue #1188
It did not fit in 20 lines due to some basic handling of constraints/dependencies.

If must I can do stripped down version, yet I feel there could be constraints/dependencies among preset params
even in case of the resource control, for example options to use min memory possibly and memory below threshold could be mutually exclusive.

test file with dependencies could be

https://github.com/MontrealSergiy/cbrain-plugins-test/blob/fixer/boutiques_descriptors/dependencyhell.json