### PR TITLE
Prefetch tasks git file revision info resolves #1248

### DIFF
--- a/Bourreau/lib/bourreau_system_checks.rb
+++ b/Bourreau/lib/bourreau_system_checks.rb
@@ -460,23 +460,6 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
 
 
 
-  def self.a110_ensure_task_class_git_commits_cached
-
-    #----------------------------------------------------------------------------
-    puts "C> Ensuring git commits for tasks classes are pre-cached..."
-    #----------------------------------------------------------------------------
-
-    myself = RemoteResource.current_resource
-
-    ToolConfig.where(:bourreau_id => myself.id)
-        .map {|tc| tc.cbrain_task_class rescue nil}
-        .uniq
-        .compact  # to remove the nil
-        .each { |klass| klass.revision_info.self_update }
-  end
-
-
-
   def self.a100_ensure_dp_cache_symlink_exists #:nodoc:
 
     myself        = RemoteResource.current_resource
@@ -501,6 +484,23 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
 
 
 
+  def self.a110_ensure_task_class_git_commits_cached
+
+    #----------------------------------------------------------------------------
+    puts "C> Ensuring git commits for tasks classes are pre-cached..."
+    #----------------------------------------------------------------------------
+
+    myself = RemoteResource.current_resource
+
+    ToolConfig.where(:bourreau_id => myself.id)
+        .map {|tc| tc.cbrain_task_class rescue nil}
+        .uniq
+        .compact  # to remove the nil
+        .each { |klass| klass.revision_info.self_update }
+  end
+  
+  
+  
   def self.z000_ensure_we_have_a_forwarded_ssh_agent #:nodoc:
 
     #----------------------------------------------------------------------------
@@ -518,4 +518,3 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
   end
 
 end
-

--- a/Bourreau/lib/bourreau_system_checks.rb
+++ b/Bourreau/lib/bourreau_system_checks.rb
@@ -460,6 +460,23 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
 
 
 
+  def self.a110_ensure_task_class_git_commits_cached
+
+    #----------------------------------------------------------------------------
+    puts "C> Ensuring git commits for tasks classes are pre-cached..."
+    #----------------------------------------------------------------------------
+
+    myself = RemoteResource.current_resource
+
+    ToolConfig.where(:bourreau_id => myself.id)
+        .map {|tc| tc.cbrain_task_class rescue nil}
+        .uniq
+        .compact  # to remove the nil
+        .each { |klass| klass.revision_info.self_update }
+  end
+
+
+
   def self.a100_ensure_dp_cache_symlink_exists #:nodoc:
 
     myself        = RemoteResource.current_resource


### PR DESCRIPTION
Prefetches tasks git file revision info #1248

Note, this will fail e.g. if there are ghost tools (configs) from deleted boutiques. 

I can add some rescues if that's an issue, or just clean up the db from outdated configs
