### PR TITLE
Ext3 capturing of files in cbrain tasks

### DIFF
--- a/Bourreau/lib/boutiques_ext3_capturer.rb
+++ b/Bourreau/lib/boutiques_ext3_capturer.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_ext3_capturer.rb

--- a/BrainPortal/app/models/boutiques_cluster_task.rb
+++ b/BrainPortal/app/models/boutiques_cluster_task.rb
@@ -137,7 +137,7 @@ class BoutiquesClusterTask < ClusterTask
     end
 
     # Write down the file with the boutiques descriptor itself
-    boutiques_json_basename = "boutiques.#{self.run_id}.json"
+    boutiques_json_basename = ".boutiques.#{self.run_id}.json"
     File.open(boutiques_json_basename, "w") do |fh|
       cleaned_desc = descriptor.dup
       cleaned_desc.delete("groups") if cleaned_desc.groups.size == 0 # bosh is picky
@@ -393,7 +393,7 @@ class BoutiquesClusterTask < ClusterTask
   # Returns the basename of the JSON file
   # that holds the 'invoke' structure for bosh.
   def invoke_json_basename
-    "invoke.#{self.run_id}.json"
+    ".invoke.#{self.run_id}.json"
   end
 
   # Return true or false depending on if

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -689,7 +689,7 @@ class ClusterTask < CbrainTask
       self.make_cluster_workdir
       self.apply_tool_config_environment do
         Dir.chdir(self.full_cluster_workdir) do
-          setup_success   = self.meta[:submit_without_setup] || self.setup
+          setup_success = self.meta[:submit_without_setup] || self.setup
           if ! setup_success  # as defined by subclass
             self.addlog("Failed to setup: 'false' returned by setup().")
             self.status_transition(self.status, "Failed To Setup")
@@ -2477,7 +2477,10 @@ chmod o+x . .. ../.. ../../..
   # and then formats it with a ext3 filesystem. If the filename already exists,
   # nothing is done.
   def install_ext3fs_filesystem(filename,size) #:nodoc:
-    return true if File.file?(filename) # already exists, all ok
+    if File.file?(filename) # already exists, all ok
+      self.addlog("EXT3 filesystem file '#{filename}' already exists")
+      return true
+    end
 
     self.addlog("Creating EXT3 filesystem in '#{filename}' with size=#{size}")
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -689,7 +689,7 @@ class ClusterTask < CbrainTask
       self.make_cluster_workdir
       self.apply_tool_config_environment do
         Dir.chdir(self.full_cluster_workdir) do
-          setup_success = self.meta[:submit_without_setup] || self.setup
+          setup_success   = self.meta[:submit_without_setup] || self.setup
           if ! setup_success  # as defined by subclass
             self.addlog("Failed to setup: 'false' returned by setup().")
             self.status_transition(self.status, "Failed To Setup")
@@ -779,11 +779,11 @@ class ClusterTask < CbrainTask
           saveok = saveok && self.save_results
           self.meta[:no_end_keyword_check] = nil
         end
-        self.update_size_of_cluster_workdir
         if ! saveok
           self.status_transition(self.status, "Failed On Cluster")
           self.addlog("Data processing failed on the cluster.")
         else
+          self.update_size_of_cluster_workdir # callbacks and modules might have cleaned up the files by now
           self.addlog("Post processing completed.")
           self.status_transition(self.status, "Completed")
         end
@@ -1868,7 +1868,7 @@ bash #{Rails.root.to_s.bash_escape}/vendor/cbrain/bin/runtime_info.sh > #{runtim
 
 # stdout and stderr captured below will be re-substituted in
 # the output and error of this script.
-bash '#{sciencefile}' > #{science_stdout_basename} 2> #{science_stderr_basename} </dev/null
+bash '#{sciencefile}' >> #{science_stdout_basename} 2> #{science_stderr_basename} </dev/null
 status="$?"
 
 echo '__CBRAIN_CAPTURE_PLACEHOLDER__'      # where stdout captured below will be substituted
@@ -2330,17 +2330,27 @@ docker_image_name=#{full_image_name.bash_escape}
     # Numbers in (paren) correspond to the comment
     # block in the script, well below.
 
+    # (6) The path to the task's work directory
+    task_workdir  = self.full_cluster_workdir # a string
+
     # (1) additional singularity execution command options defined in ToolConfig
     container_exec_args = self.tool_config.container_exec_args.presence
 
-    # (2) The root of the shared area for all CBRAIN tasks
-    gridshare_dir = self.bourreau.cms_shared_dir
+    # (2) The root of the DataProvider cache
+    cache_dir      = self.bourreau.dp_cache_dir
+    gridshare_dir  = self.bourreau.cms_shared_dir # not mounted explicitely
+    cache_dir_syml = "#{gridshare_dir}/DP_Cache"
 
-    # (3) The root of the DataProvider cache
-    cache_dir     = self.bourreau.dp_cache_dir
-
-    # (6) The path to the task's work directory
-    task_workdir  = self.full_cluster_workdir
+    # (3) Ext3 capture mounts, if any.
+    # These will look like "-B .capt_abcd.ext2:/path/workdir/abcd:image-src=/"
+    # While we are building these options, we're also creating
+    # the ext3 filesystems at the same time, if needed.
+    esc_capture_mounts = self.tool_config.ext3capture_basenames.inject("") do |sing_opts,(basename,size)|
+      fs_name    = ".capt_#{basename}.ext3"      # e.g. .capt_work.ext3
+      mountpoint = "#{task_workdir}/#{basename}" # e.g. /path/to/workdir/work
+      install_ext3fs_filesystem(fs_name,size)
+      "#{sing_opts} -B #{fs_name.bash_escape}:#{mountpoint.bash_escape}:image-src=/"
+    end
 
     # (4) More -B (bind mounts) for all the local data providers.
     # This will be a string "-B path1 -B path2 -B path3" etc.
@@ -2392,7 +2402,6 @@ if test ! -d #{cache_dir.bash_escape} ; then
   exit 2
 fi
 
-
 # CBRAIN internal consistency test 4: must have the gridshare_dir mounted inside the container
 if test ! -d #{gridshare_dir.bash_escape} ; then
   echo "Container missing mount point for gridshare directory:" #{gridshare_dir.bash_escape}
@@ -2413,16 +2422,17 @@ chmod o+x . .. ../.. ../../..
 # Invoke Singularity with our wrapper script above.
 # Tricks used here:
 # 1) we supply (if any) additional options for the exec command
-# 2) we mount the gridshare root directory
-# 3) we mount the local data provider cache root directory
-# 4) we mount each (if any) of the root directory for local data providers
-# 5) we mount (if any) file system overlays
+# 2) we mount the local data provider cache root directory
+# 3) we mount (if any) capture ext3 filesystems
+# 4) we mount each (if any) of the root directories for local data providers
+# 5) we mount (if any) other fixed file system overlays
 # 6) with -H we set the task's work directory as the singularity $HOME directory
 #{singularity_executable_name}                  \\
     exec                                        \\
     #{container_exec_args}                      \\
-    -B #{gridshare_dir.bash_escape}             \\
     -B #{cache_dir.bash_escape}                 \\
+    -B #{cache_dir_syml.bash_escape}            \\
+    #{esc_capture_mounts}                       \\
     #{esc_local_dp_mountpoints}                 \\
     #{overlay_mounts}                           \\
     -H #{task_workdir.bash_escape}              \\
@@ -2455,6 +2465,33 @@ chmod o+x . .. ../.. ../../..
       .select { |dir| File.directory?(dir) }
       .sort { |a,b| a <=> b } # ordered so deeper paths are last
     dirs
+  end
+
+  # This method creates an empty +filename+ with +size+ bytes
+  # (where size is specified like what the unix 'truncate' command accepts)
+  # and then formats it with a ext3 filesystem. If the filename already exists,
+  # nothing is done.
+  def install_ext3fs_filesystem(filename,size) #:nodoc:
+    return true if File.file?(filename) # already exists, all ok
+
+    # Create an empty file of the proper size
+    system("truncate -s #{size.bash_escape} #{filename.bash_escape}")
+    status  = $? # A Process::Status object
+    if ! status.success?
+      cb_error "Cannot create EXT3 filesystem file '#{filename}': #{status.to_s}"
+    end
+
+    # Format it. Only works on linux obviously
+    system("echo y | mkfs.ext3 -t ext3 -q -E root_owner  #{filename.bash_escape}")
+    status  = $? # A Process::Status object
+    if ! status.success?
+      cb_error "Cannot format EXT3 filesystem file '#{filename}': #{status.to_s}"
+    end
+
+    true
+  rescue => ex
+    File.unlink(filename) rescue nil # keep directory clean of broken ext3 file
+    raise ex
   end
 
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2479,6 +2479,8 @@ chmod o+x . .. ../.. ../../..
   def install_ext3fs_filesystem(filename,size) #:nodoc:
     return true if File.file?(filename) # already exists, all ok
 
+    self.addlog("Creating EXT3 filesystem in '#{filename}' with size=#{size}")
+
     # Create an empty file of the proper size
     system("truncate -s #{size.bash_escape} #{filename.bash_escape}")
     status  = $? # A Process::Status object

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2345,7 +2345,7 @@ docker_image_name=#{full_image_name.bash_escape}
     # These will look like "-B .capt_abcd.ext2:/path/workdir/abcd:image-src=/"
     # While we are building these options, we're also creating
     # the ext3 filesystems at the same time, if needed.
-    esc_capture_mounts = self.tool_config.ext3capture_basenames.inject("") do |sing_opts,(basename,size)|
+    esc_capture_mounts = ext3capture_basenames().inject("") do |sing_opts,(basename,size)|
       fs_name    = ".capt_#{basename}.ext3"      # e.g. .capt_work.ext3
       mountpoint = "#{task_workdir}/#{basename}" # e.g. /path/to/workdir/work
       install_ext3fs_filesystem(fs_name,size)
@@ -2465,6 +2465,11 @@ chmod o+x . .. ../.. ../../..
       .select { |dir| File.directory?(dir) }
       .sort { |a,b| a <=> b } # ordered so deeper paths are last
     dirs
+  end
+
+  # Just invokes the same method on the task's ToolConfig.
+  def ext3capture_basenames
+    self.tool_config.ext3capture_basenames
   end
 
   # This method creates an empty +filename+ with +size+ bytes

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2342,7 +2342,7 @@ docker_image_name=#{full_image_name.bash_escape}
     cache_dir_syml = "#{gridshare_dir}/DP_Cache"
 
     # (3) Ext3 capture mounts, if any.
-    # These will look like "-B .capt_abcd.ext2:/path/workdir/abcd:image-src=/"
+    # These will look like "-B .capt_abcd.ext3:/path/workdir/abcd:image-src=/"
     # While we are building these options, we're also creating
     # the ext3 filesystems at the same time, if needed.
     esc_capture_mounts = ext3capture_basenames().inject("") do |sing_opts,(basename,size)|

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -526,7 +526,7 @@ class ToolConfig < ApplicationRecord
 
       when 'ext3capture' # ext3 filesystem as a basename with an initial size
         # The basename is limited to letters, digits, numbers and dashes; the =SIZE suffix must end with G or M
-        if id_or_name !~ /\w[\w\.-]+=([1-9]\d*)[mg]/i
+        if id_or_name !~ /\A\w[\w\.-]+=([1-9]\d*)[mg]\z/i
           self.errors.add(:singularity_overlays_specs, "contains invalid ext3capture specification (must be like ext3capture:basename=1g or 2m etc)")
         end
 

--- a/BrainPortal/app/models/tool_config.rb
+++ b/BrainPortal/app/models/tool_config.rb
@@ -365,6 +365,8 @@ class ToolConfig < ApplicationRecord
   #         dp:1234
   #      # CBRAIN db registered file
   #         userfile:1234
+  #      # A ext3 capture filesystem, will NOT be returned here as an overlay
+  #         ext3capture:basename=12G
   def singularity_overlays_full_paths
     specs = parsed_overlay_specs
     specs.map do |knd, id_or_name|
@@ -388,6 +390,8 @@ class ToolConfig < ApplicationRecord
         cb_error "Userfile with id '#{id_or_name}' for overlay fetching not found." if ! userfile
         userfile.sync_to_cache() rescue cb_error "Userfile with id '#{id_or_name}' for fetching overlay failed to synchronize."
         userfile.cache_full_path()
+      when 'ext3capture'
+        [] # flatten will remove all that
       else
         cb_error "Invalid '#{knd}:#{id_or_name}' overlay."
       end
@@ -404,6 +408,16 @@ class ToolConfig < ApplicationRecord
     @_data_providers_with_overlays_ = specs.map do |kind, id_or_name|
       DataProvider.where_id_or_name(id_or_name).first if kind == 'dp'
     end.compact
+  end
+
+  # Returns pairs [ [ basename, size], ...] as in [ [ 'work', '28g' ]
+  def ext3capture_basenames
+    specs = parsed_overlay_specs
+    return [] if specs.empty?
+    specs
+      .map { |pair| pair[1] if pair[0] == 'ext3capture' }
+      .compact
+      .map { |basename_and_size| basename_and_size.split("=") }
   end
 
   #################################################################
@@ -461,6 +475,9 @@ class ToolConfig < ApplicationRecord
   #    userfile:333
   #    dp:123
   #    dp:dp_name
+  #    ext3capture:basename=SIZE
+  #    ext3capture:work=30G
+  #    ext3capture:tool_1.1.2=15M
   #
   def validate_overlays_specs #:nodoc:
     specs = parsed_overlay_specs
@@ -505,6 +522,12 @@ class ToolConfig < ApplicationRecord
           self.errors.add(:singularity_overlays_specs, "contains invalid DP '#{id_or_name}' (no such DP)")
         elsif ! dp.is_a?(SingSquashfsDataProvider)
           self.errors.add(:singularity_overlays_specs, "DataProvider '#{id_or_name}' is not a SingSquashfsDataProvider")
+        end
+
+      when 'ext3capture' # ext3 filesystem as a basename with an initial size
+        # The basename is limited to letters, digits, numbers and dashes; the =SIZE suffix must end with G or M
+        if id_or_name !~ /\w[\w\.-]+=([1-9]\d*)[mg]/i
+          self.errors.add(:singularity_overlays_specs, "contains invalid ext3capture specification (must be like ext3capture:basename=1g or 2m etc)")
         end
 
       else

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -210,7 +210,7 @@
         for now.
         </div>
     <% end %>
-      
+
     <% t.edit_cell :containerhub_image_name, :content => link_to_userfile_if_accessible(@tool_config.container_image), :header => "ID of the container image" do |f| %>
       <%= f.text_field :container_image_userfile_id %>
       <div class="field_explanation">
@@ -227,8 +227,9 @@
         A specification can be either
         a full path (e.g. <em>file:/a/b/data.squashfs</em>),
         a path with a pattern (e.g. <em>file:/a/b/data*.squashfs</em>),
-        a registered file identified by ID (e.g. <em>userfile:123</em>)
-        or a SquashFS Data Provider identified by its ID or name (e.g. <em>dp:123</em>, <em>dp:DpNameHere</em>).
+        a registered file identified by ID (e.g. <em>userfile:123</em>),
+        a SquashFS Data Provider identified by its ID or name (e.g. <em>dp:123</em>, <em>dp:DpNameHere</em>)
+        or an ext3 capture overlay basename (e.g. <em>ext3capture:basename=SIZE</em> where size is <em>12G</em> or <em>12M</em>).
         In the case of a Data Provider, the overlays will be the files that the provider uses.
         Each overlay specification should be on a separate line.
         You can add comments, indicated with hash symbol <em>#</em>.

--- a/BrainPortal/lib/boutiques_ext3_capturer.rb
+++ b/BrainPortal/lib/boutiques_ext3_capturer.rb
@@ -1,0 +1,65 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2023
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module adds automatic setting up of mounted
+# ext3 filesystem as subdirectories of a task, provided
+# the tool works in Singularity/Apptainer.
+# It is the exact equivalent of adding an ext3 overlay
+# configuration entry in the task's tool config.
+#
+# To include the module automatically at boot time
+# in a task integrated by Boutiques, add a new entry
+# in the 'custom' section of the descriptor, like this:
+#
+#   "custom": {
+#       "cbrain:integrator_modules": {
+#           "BoutiquesExt3Capturer": {
+#             "work":   "50g",
+#             "tmpdir": "20m"
+#           }
+#       }
+#   }
+#
+module BoutiquesExt3Capturer
+
+  # Note: to access the revision info of the module,
+  # you need to access the constant directly, the
+  # object method revision_info() won't work.
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # Override the default behavior by adding new entries directly
+  # from the descriptor.
+  def ext3capture_basenames
+    # Get standard list as described in tool config
+    initial_list = super.dup # [ [ basename, size], [basename, size], ... ]
+
+    # Get values in descriptos, as a hash
+    descriptor = self.descriptor_for_cluster_commands
+    ext3_specs = descriptor.custom_module_info('BoutiquesExt3Capturer')
+
+    # Append our own entries; note that duplications of basenames
+    # will mean only the first entry is used!
+    initial_list + ext3_specs.to_a  # the .to_a transforms the hash into an array of pairs.
+  end
+
+end
+

--- a/BrainPortal/lib/boutiques_ext3_capturer.rb
+++ b/BrainPortal/lib/boutiques_ext3_capturer.rb
@@ -52,7 +52,7 @@ module BoutiquesExt3Capturer
     # Get standard list as described in tool config
     initial_list = super.dup # [ [ basename, size], [basename, size], ... ]
 
-    # Get values in descriptos, as a hash
+    # Get values in descriptor, as a hash
     descriptor = self.descriptor_for_cluster_commands
     ext3_specs = descriptor.custom_module_info('BoutiquesExt3Capturer')
 

--- a/BrainPortal/lib/boutiques_support.rb
+++ b/BrainPortal/lib/boutiques_support.rb
@@ -60,6 +60,14 @@ module BoutiquesSupport
     Group          = Class.new(RestrictedHash) { allowed_keys group_prop_names  }
     ContainerImage = Class.new(RestrictedHash) { allowed_keys cont_prop_names   }
 
+    # Adds a comparison operator to these subobjects so that
+    # they can be sorted
+    [ Input, OutputFile, Group ].each do |klass|
+      klass.define_method(:'<=>') do |other|
+        self['id'] <=> other['id']
+      end
+    end
+
     def initialize(hash={})
       super(hash)
       # The following re-assignment transforms hashed into subobjects (like OutputFile etc)

--- a/BrainPortal/lib/cbrain_extensions/hash_extensions/conversions.rb
+++ b/BrainPortal/lib/cbrain_extensions/hash_extensions/conversions.rb
@@ -81,6 +81,25 @@ module CBRAINExtensions #:nodoc:
         to_xml({ :dasherize => false, :root => root_tag }.merge(options))
       end
 
+      # Returns a dup of the hash, where the keys are sorted, and
+      # any values that are arrays are also sorted. Applies these
+      # rules recursively. Assumes that all keys and all array values
+      # are things that can be compared, otherwise this will crash.
+      def resorted
+        res = self.class.new
+        self.keys.sort.each do |key|
+          val = self[key]
+          if val.is_a?(Hash)
+            res[key] = val.resorted
+          elsif val.is_a?(Array)
+            res[key] = val.sort.map { |x| x.respond_to?(:resorted) ? x.resorted : x }
+          else
+            res[key] = val
+          end
+        end
+        res
+      end
+
     end
   end
 end


### PR DESCRIPTION
Adds a new feature. Admins can configure that a subdirectory in a task's work directory will be bound to a mounted ext3 filesystem-in-a-file. In the ToolConfig object, in the "overlays" section, this is done with directives like:

ext3capture:work=40G

which will create an empty 40 Gb file `.capt_work.ext3` in the work directory, format it as ext3, and then when the singularity container is started, the directory `{WORKDIR}/work` will be used as a mountpoint.

As an additional feature, without modifying the ToolConfig, a designer of a boutiques descriptor can add a similar specification in the 'custom' section (see BoutiquesExt3Capturer in this PR).