### PR TITLE
Updating the list of users in a workgroup (Bug1+Bug2)

### DIFF
--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -49,9 +49,12 @@ module DynamicFormHelper
   # Create a checkbox that will select or deselect all checkboxes on the page
   # of class +checkbox_class+.
   # Most +options+ are just treated as HTML attributes.
-  # Except +options[:persistant_name]+; if provided,
-  # an additional hidden input will be added to track
-  # the state of the select_all checkbox.
+  #
+  # Except:
+  #   - +options[:persistant_name]+: if provided, an additional hidden
+  # input will be added to track the state of the select_all checkbox.
+  #   - +options["data-noload"]+: if true, the select_all checkbox will
+  # not be updated when the page is loaded.
   def select_all_checkbox(checkbox_class, options = {})
     options[:class] ||= ""
     options[:class]  +=  " select_all"

--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -58,7 +58,6 @@ module DynamicFormHelper
 
     options["data-checkbox-class"] = checkbox_class
 
-
     options["data-noload"] = "true" if options["data-noload"]
     atts  = options.reject{|x| x.to_s === "persistant_name"}.to_html_attributes
 

--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -49,7 +49,7 @@ module DynamicFormHelper
   # Create a checkbox that will select or deselect all checkboxes on the page
   # of class +checkbox_class+.
   # Most +options+ are just treated as HTML attributes.
-  # Except +options[:persistant_name]+; if provided, 
+  # Except +options[:persistant_name]+; if provided,
   # an additional hidden input will be added to track
   # the state of the select_all checkbox.
   def select_all_checkbox(checkbox_class, options = {})
@@ -57,6 +57,7 @@ module DynamicFormHelper
     options[:class]  +=  " select_all"
 
     options["data-checkbox-class"] = checkbox_class
+    options["data-onload"]         = options["data-onload"] ? "true" : "false"
     atts  = options.reject{|x| x.to_s === "persistant_name"}.to_html_attributes
 
     # Most common case just the select_all input
@@ -66,11 +67,11 @@ module DynamicFormHelper
     # Add the hidden input; javascript code will update
     # its value as needed.
     hidden_options = {
-                      :name                 => options[:persistant_name], 
+                      :name                 => options[:persistant_name],
                       "data-checkbox-class" => checkbox_class,
                       :class                => "select_all_hidden"
-                     } 
-    
+                     }
+
     hidden_atts  = hidden_options.to_html_attributes
     hidden_input = "<input type='hidden' #{hidden_atts}>".html_safe
     inputs       = "#{input} #{hidden_input}".html_safe

--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -57,7 +57,9 @@ module DynamicFormHelper
     options[:class]  +=  " select_all"
 
     options["data-checkbox-class"] = checkbox_class
-    options["data-onload"]         = options["data-onload"] ? "true" : "false"
+
+
+    options["data-noload"] = "true" if options["data-noload"]
     atts  = options.reject{|x| x.to_s === "persistant_name"}.to_html_attributes
 
     # Most common case just the select_all input

--- a/BrainPortal/app/helpers/dynamic_form_helper.rb
+++ b/BrainPortal/app/helpers/dynamic_form_helper.rb
@@ -53,15 +53,12 @@ module DynamicFormHelper
   # Except:
   #   - +options[:persistant_name]+: if provided, an additional hidden
   # input will be added to track the state of the select_all checkbox.
-  #   - +options["data-noload"]+: if true, the select_all checkbox will
-  # not be updated when the page is loaded.
   def select_all_checkbox(checkbox_class, options = {})
     options[:class] ||= ""
     options[:class]  +=  " select_all"
 
     options["data-checkbox-class"] = checkbox_class
 
-    options["data-noload"] = "true" if options["data-noload"]
     atts  = options.reject{|x| x.to_s === "persistant_name"}.to_html_attributes
 
     # Most common case just the select_all input

--- a/BrainPortal/app/views/groups/_users_form.html.erb
+++ b/BrainPortal/app/views/groups/_users_form.html.erb
@@ -130,7 +130,7 @@
     :td_class    => 'left_align no_wrap',
     :fill_by_columns => true
   ) do |group,r,c| %>
-    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}", "data-noload" => true %>
+    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}" %>
     <label for="workgroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 

--- a/BrainPortal/app/views/groups/_users_form.html.erb
+++ b/BrainPortal/app/views/groups/_users_form.html.erb
@@ -130,7 +130,7 @@
     :td_class    => 'left_align no_wrap',
     :fill_by_columns => true
   ) do |group,r,c| %>
-    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}" %>
+    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}", "data-onload" => false %>
     <label for="workgroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 
@@ -154,7 +154,7 @@
       :td_class    => 'left_align no_wrap',
       :fill_by_columns => true
       ) do |group,r,c| %>
-        <%= select_all_checkbox "sitegroup_#{group.id}", :id => "sitegroup_#{group.id}" %>
+        <%= select_all_checkbox "sitegroup_#{group.id}", :id => "sitegroup_#{group.id}", "data-onload" => false %>
         <label for="sitegroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 

--- a/BrainPortal/app/views/groups/_users_form.html.erb
+++ b/BrainPortal/app/views/groups/_users_form.html.erb
@@ -154,7 +154,7 @@
       :td_class    => 'left_align no_wrap',
       :fill_by_columns => true
       ) do |group,r,c| %>
-        <%= select_all_checkbox "sitegroup_#{group.id}", {:id => "sitegroup_#{group.id}", "data-noload" => true } %>
+        <%= select_all_checkbox "sitegroup_#{group.id}", :id => "sitegroup_#{group.id}" %>
         <label for="sitegroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 

--- a/BrainPortal/app/views/groups/_users_form.html.erb
+++ b/BrainPortal/app/views/groups/_users_form.html.erb
@@ -130,7 +130,7 @@
     :td_class    => 'left_align no_wrap',
     :fill_by_columns => true
   ) do |group,r,c| %>
-    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}", "data-onload" => false %>
+    <%= select_all_checkbox "workgroup_#{group.id}", :id => "workgroup_#{group.id}", "data-noload" => true %>
     <label for="workgroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 
@@ -154,7 +154,7 @@
       :td_class    => 'left_align no_wrap',
       :fill_by_columns => true
       ) do |group,r,c| %>
-        <%= select_all_checkbox "sitegroup_#{group.id}", :id => "sitegroup_#{group.id}", "data-onload" => false %>
+        <%= select_all_checkbox "sitegroup_#{group.id}", {:id => "sitegroup_#{group.id}", "data-noload" => true } %>
         <label for="sitegroup_<%= group.id %>"><%= group.name -%></label>
   <% end %>
 

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -650,28 +650,26 @@
 
     // Define on click event for each child of a `select_all` element.
     $(".select_all").each( (index,input) => {
-      var checkbox_class = $(input).data("checkbox-class");
-
-      if ($(input).data("persistant_name")) {
+      if ($(input).data("persistant_name") !== undefined) {
+        var checkbox_class = $(input).data("checkbox-class");
         $(input).load(click_select_all($(input)));
-      }
-
-      var checkbox_class_elements = $('.' + checkbox_class);
-      checkbox_class_elements.each(function(index, element) {
-        $(element).on("click", () => {
-          var number_of_checkbox = checkbox_class_elements.filter((i,e) => e.checked).length;
-          if (number_of_checkbox === 0) {
-            set_hidden_select_all($(input), "none");
-            input.checked = false;
-          } else if (checkbox_class_elements.length === number_of_checkbox) {
-            set_hidden_select_all($(input), "all");
-            input.checked = true;
-          } else {
-            set_hidden_select_all($(input), "some");
-            input.checked = false;
-          }
+        var checkbox_class_elements = $('.' + checkbox_class);
+        checkbox_class_elements.each(function(index, element) {
+          $(element).on("click", () => {
+            var number_of_checkbox = checkbox_class_elements.filter((i,e) => e.checked).length;
+            if (number_of_checkbox === 0) {
+              set_hidden_select_all($(input), "none");
+              input.checked = false;
+            } else if (checkbox_class_elements.length === number_of_checkbox) {
+              set_hidden_select_all($(input), "all");
+              input.checked = true;
+            } else {
+              set_hidden_select_all($(input), "some");
+              input.checked = false;
+            }
+          });
         });
-      });
+      };
     });
 
     $(document).delegate(".select_master", "change", function() {

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -651,9 +651,9 @@
     // Define on click event for each child of a `select_all` element.
     $(".select_all").each( (index,input) => {
       var checkbox_class = $(input).data("checkbox-class");
-      var onload         = $(input).data("onload");
+      var noload         = $(input).data("noload");
 
-      if (onload === "true") {
+      if (!noload) {
         $(input).load(click_select_all($(input)));
       }
 

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -117,7 +117,7 @@
 
     loaded_element.find("select").each(function(){
       var select = $(this);
-  
+
       var defined_width = (select.context.style.width);
       if ( defined_width !== '' ){
         select.chosen({ width: defined_width });
@@ -125,7 +125,7 @@
         select.chosen({ width: '25em' });
       }
     });
-		  
+
     /////////////////////////////////////////////////////////////////////
     //
     // UI Helper Methods see application_helper.rb for corresponding
@@ -631,8 +631,8 @@
       $(hidden_box).val( value );
     };
 
-    // Value of the header box is used to set 
-    // the checked status of child boxes 
+    // Value of the header box is used to set
+    // the checked status of child boxes
     var click_select_all = (header_box) => {
       var checkbox_class = header_box.data("checkbox-class");
 
@@ -649,24 +649,27 @@
     });
 
     // Define on click event for each child of a `select_all` element.
-    $(".select_all").each( (index,input) => { 
+    $(".select_all").each( (index,input) => {
       var checkbox_class = $(input).data("checkbox-class");
+      var onload         = $(input).data("onload");
 
-      $(input).load(click_select_all($(input)));
+      if (onload === "true") {
+        $(input).load(click_select_all($(input)));
+      }
 
       var checkbox_class_elements = $('.' + checkbox_class);
-      checkbox_class_elements.each(function(index, element) {        
+      checkbox_class_elements.each(function(index, element) {
         $(element).on("click", () => {
           var number_of_checkbox = checkbox_class_elements.filter((i,e) => e.checked).length;
           if (number_of_checkbox === 0) {
             set_hidden_select_all($(input), "none");
-            input.checked = false; 
+            input.checked = false;
           } else if (checkbox_class_elements.length === number_of_checkbox) {
             set_hidden_select_all($(input), "all");
             input.checked = true;
-          } else { 
+          } else {
             set_hidden_select_all($(input), "some");
-            input.checked = false; 
+            input.checked = false;
           }
         });
       });

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -651,9 +651,8 @@
     // Define on click event for each child of a `select_all` element.
     $(".select_all").each( (index,input) => {
       var checkbox_class = $(input).data("checkbox-class");
-      var noload         = $(input).data("noload");
 
-      if (!noload) {
+      if ($(input).data("persistant_name")) {
         $(input).load(click_select_all($(input)));
       }
 


### PR DESCRIPTION
I was annoyed by this issue and couldn't ignore it.

The fix concerns bug 1 for the moment:

> the users already members of the project don't have their checkboxes pre-selected in table A

**Note**: the `select_all_box` is also used in `bourreaux/rr_disk_usage`. 
Seems to be a little bit buggy too in rr_disk_usage when you: 
- select_all a row then select_all a column (see screenshot 1)
- then unselect the row did not unable the all column (see screenshot 2).

![image](https://user-images.githubusercontent.com/777590/218419582-30a9a1e1-e7cb-48ef-9293-77689e82ccac.png)

Then

![image](https://user-images.githubusercontent.com/777590/218419654-43b35ad1-c2df-4a8a-9437-b24a36b84c43.png)




