### PR TITLE
Add BoutiquesSaveStdOutStdErr module to save stderr and/or sdtout

### DIFF
--- a/Bourreau/lib/boutiques_save_std_out_std_err.rb
+++ b/Bourreau/lib/boutiques_save_std_out_std_err.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_save_std_out_std_err.rb

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -20,7 +20,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# Module to save stdout and stderr files
+# This module allow to save the stdout and stderr files of a Boutiques task
+#
+# To use this module, you need to add the following lines in the descriptor:
+# "custom_module_info": {
+#   "BoutiquesSaveStdOutStdErr": {
+#     "stdout_output_dir": true,
+#     "stderr_output_dir": "path/to/dir/"
+#   }
+# }
+#
+# In case of a MultilevelSshDataProvider the "path/to/dir/" will be use to save
+# the output at this specific location.
+# In case of a no MultilevelSshDataProvider the "path/to/dir/" will be ignored.
+#
+# The value of the key "stdout_output_dir" and "stderr_output_dir" can be set to true,
+# in this situation the files will be saved in directly in the root folder of the DataProvider.
 module BoutiquesSaveStdOutStdErr
 
   # Note: to access the revision info of the module,
@@ -29,19 +44,19 @@ module BoutiquesSaveStdOutStdErr
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
   # This method overrides the one in BoutiquesClusterTask
+  # Save the stdout and stderr files of the task as an output file,
+  # set it as a child of the first input file.
   def save_results
-    # Performs standard processing
     return false unless super
-    self.addlog("Saving results...")
 
     # Get the folder where to save the log files from the descriptor
     descriptor      = self.descriptor_for_save_results
     save_log_folder = descriptor.custom_module_info('BoutiquesSaveStdOutStdErr')
 
-    # Save stdout and stderr
+    # Get parent file to set stderr and stdout as children of input file
     parent_file   = Userfile.find((self.params[:invoke] ||= {})[descriptor.file_inputs.first.id])
 
-    # save stdout
+    # Save stdout
     hidden_science_stdout_basename = science_stdout_basename(self.run_number)
     science_stdout_basename        = hidden_science_stdout_basename.gsub(/^\.science./, "")
     copy_to_location               = save_log_folder["stdout_output_dir"] == true ?
@@ -50,7 +65,7 @@ module BoutiquesSaveStdOutStdErr
 
     return false if !save_log_file(hidden_science_stdout_basename, copy_to_location, parent_file)
 
-    # save stderr
+    # Save stderr
     hidden_science_stderr_basename = science_stderr_basename(self.run_number)
     science_stderr_basename        = hidden_science_stderr_basename.gsub(/^\.science./, "")
     copy_to_location               = save_log_folder["stderr_output_dir"] == true ?
@@ -62,6 +77,8 @@ module BoutiquesSaveStdOutStdErr
     true
   end
 
+  # Add the stdout and stderr files to the descriptor
+  # for the show page of the task.
   def descriptor_for_show_params  #:nodoc:
     descriptor = descriptor_for_form
 
@@ -116,7 +133,9 @@ module BoutiquesSaveStdOutStdErr
 
   private
 
-  def save_log_file(original_filename, copy_to_location, parent_file)
+  # Save the log with original_filename to copy_to_location ast
+  # a child of parent_file to the results data provider.
+  def save_log_file(original_filename, copy_to_location, parent_file) #:nodoc:
     file = safe_userfile_find_or_new(LogFile,
       :name             => copy_to_location,
       :data_provider_id => self.results_data_provider_id
@@ -128,12 +147,11 @@ module BoutiquesSaveStdOutStdErr
       self.addlog("Saved output file #{original_filename}")
       self.params["_cbrain_output_stdout"] = file.id if original_filename == science_stdout_basename(self.run_number)
       self.params["_cbrain_output_stderr"] = file.id if original_filename == science_stderr_basename(self.run_number)
+      self.save
     else
       self.addlog("Could not save back result file #{original_filename}")
       return false
     end
-
-    self.save
 
     true
   end

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -1,0 +1,103 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2023
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Module to save stdout and stderr files
+module BoutiquesSaveStdOutStdErr
+
+  # Note: to access the revision info of the module,
+  # you need to access the constant directly, the
+  # object method revision_info() won't work.
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  # This method overrides the one in BoutiquesClusterTask
+  def save_results
+    # Performs standard processing
+    return false unless super
+
+    everything_ok = true
+
+    # Get the folder where to save the log files from the descriptor
+    descriptor      = self.descriptor_for_save_results
+    save_log_folder = descriptor.custom_module_info('BoutiquesSaveStdOutStdErr')
+    self.addlog("BoutiquesSaveStdOutStdErr: save_log_folder is '#{save_log_folder.inspect}'")
+
+    # Save stdout and stderr
+    parent_file   = Userfile.find((self.params[:invoke] ||= {})[descriptor.file_inputs.first.id])
+    everything_ok = save_log_file(science_stdout_basename(self.run_number), parent_file)
+    everything_ok = save_log_file(science_stderr_basename(self.run_number), parent_file)
+
+    everything_ok
+  end
+
+
+  # This method overrides the method in BoutiquesClusterTask.
+  # If the name for the file contains a relative path such
+  # as "a/b/c/hello.txt", it will extract the "a/b/c" and
+  # provide it in the browse_path attribute to the Userfile
+  # constructor in super().
+  def safe_userfile_find_or_new(klass, attlist)
+    name = attlist[:name]
+    return super(klass, attlist) if ! (name.include? "/") # if there is no relative path, just do normal stuff
+
+    # Find all the info we need
+    attlist = attlist.dup
+    dp_id   = attlist[:data_provider_id] || self.results_data_provider_id
+    dp      = DataProvider.find(dp_id)
+    pn      = Pathname.new(name)  # "a/b/c/hello.txt"
+
+    # Make adjustements to name and browse_path
+    attlist[:name] = pn.basename.to_s  # "hello.txt"
+    if dp.has_browse_path_capabilities?
+      attlist[:browse_path] = pn.dirname.to_s   # "a/b/c"
+      self.addlog "BoutiquesSaveStdErrOut: result DataProvider browse_path for Stderr and Stdout will be '#{pn.dirname}'"
+    else
+      attlist[:browse_path] = nil # ignore the browse_path
+      self.addlog "BoutiquesSaveStdErrOut: result DataProvider doesn't have multi-level capabilities, ignoring forced browse_path for Stderr and Stdout '#{pn.dirname}'."
+    end
+
+    # Invoke the standard code
+    return super(klass, attlist)
+  end
+
+  private
+
+  def save_log_file(filename, parent_file)
+    save_filename = filename.gsub(/^./, '')
+
+    file = safe_userfile_find_or_new(LogFile,
+      :name             => save_filename,
+      :data_provider_id => self.results_data_provider_id
+    )
+
+    file.cache_copy_from_local_file(filename)
+    if file.save
+      file.move_to_child_of(parent_file)
+      self.addlog("Saved output file #{save_filename}")
+    else
+      self.addlog("Could not save back result file #{save_filename}")
+      return false
+    end
+
+    true
+  end
+end
+

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -23,7 +23,7 @@
 # This module allow to save the stdout and stderr files of a Boutiques task
 #
 # To use this module, you need to add the following lines in the descriptor:
-#   "custom_module_info": {
+#   "cbrain:integrator_modules": {
 #     "BoutiquesSaveStdOutStdErr": {
 #       "stdout_output_dir": "",
 #       "stderr_output_dir": "path/to/dir"
@@ -50,7 +50,7 @@ module BoutiquesSaveStdOutStdErr
   # The files will be saved as a child of the first input file.
   def save_results
     # Get the folder where to save the log files from the descriptor
-    descriptor      = self.descriptor_for_save_results
+    descriptor  = self.descriptor_for_save_results
     module_info = descriptor.custom_module_info('BoutiquesSaveStdOutStdErr')
 
     # Get parent file to set stderr and stdout as children of first input file
@@ -84,14 +84,14 @@ module BoutiquesSaveStdOutStdErr
 
     stdout_file = BoutiquesSupport::OutputFile.new({
       "id"   => "cbrain_stdout",
-      "name" => "stdout",
+      "name" => "Standard output",
       "description" => "Standard output of the tool",
       "optional" => true
     })
 
     stderr_file = BoutiquesSupport::OutputFile.new({
       "id"   => "cbrain_stderr",
-      "name" => "stderr",
+      "name" => "Standard error",
       "description" => "Standard error of the tool",
       "optional" => true
     })
@@ -104,16 +104,9 @@ module BoutiquesSaveStdOutStdErr
 
   private
 
-  # If the name for the file doesn't contain a relative path
-  # it will just call safe_userfile_find_or_new().
-  #
-  # If the name for the file contains a relative path such
-  # as "a/b/c/hello.txt", it will extract the "a/b/c" and
-  # provide it in the browse_path attribute.
-  # The modified attlist will be passed to safe_userfile_find_or_new().
-  #
-  # This method will returns a file object for a logfile,
-  # prepared with a browse_path if necessary.
+  # Returns a Userfile object, prepared with a browse_path if necessary.
+  # To do that it can override the attlist to add a browse_path and then
+  # call the standard safe_userfile_find_or_new() method.
   def safe_logfile_find_or_new(klass, attlist)
     name = attlist[:name]
     return safe_userfile_find_or_new(klass, attlist) if ! (name.include? "/") # if there is no relative path, just do normal stuff

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -23,12 +23,12 @@
 # This module allow to save the stdout and stderr files of a Boutiques task
 #
 # To use this module, you need to add the following lines in the descriptor:
-# "custom_module_info": {
-#   "BoutiquesSaveStdOutStdErr": {
-#     "stdout_output_dir": "",
-#     "stderr_output_dir": "path/to/dir"
+#   "custom_module_info": {
+#     "BoutiquesSaveStdOutStdErr": {
+#       "stdout_output_dir": "",
+#       "stderr_output_dir": "path/to/dir"
+#     }
 #   }
-# }
 #
 # In case of a MultilevelSshDataProvider the "path/to/dir" will be use to save the output.
 # In case of a no MultilevelSshDataProvider the "path/to/dir" will be ignored.
@@ -96,22 +96,21 @@ module BoutiquesSaveStdOutStdErr
       "optional" => true
     })
 
-    descriptor["output-files"] << stdout_file if !descriptor.output_files.find { |f| f["id"] == "cbrain_stdout" }
-    descriptor["output-files"] << stderr_file if !descriptor.output_files.find { |f| f["id"] == "cbrain_stderr" }
+    descriptor["output-files"] << stdout_file if !descriptor.output_files.any? { |f| f.id == "cbrain_stdout" }
+    descriptor["output-files"] << stderr_file if !descriptor.output_files.any? { |f| f.id == "cbrain_stderr" }
 
     descriptor
   end
 
   private
 
-  # This method overrides the method in BoutiquesClusterTask.
   # If the name for the file contains a relative path such
   # as "a/b/c/hello.txt", it will extract the "a/b/c" and
   # provide it in the browse_path attribute to the Userfile
   # constructor in super().
   def safe_logfile_find_or_new(klass, attlist)
     name = attlist[:name]
-    return super(klass, attlist) if ! (name.include? "/") # if there is no relative path, just do normal stuff
+    return safe_userfile_find_or_new(klass, attlist) if ! (name.include? "/") # if there is no relative path, just do normal stuff
 
     # Find all the info we need
     attlist = attlist.dup

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -104,10 +104,16 @@ module BoutiquesSaveStdOutStdErr
 
   private
 
+  # If the name for the file doesn't contain a relative path
+  # it will just call safe_userfile_find_or_new().
+  #
   # If the name for the file contains a relative path such
   # as "a/b/c/hello.txt", it will extract the "a/b/c" and
-  # provide it in the browse_path attribute to the Userfile
-  # constructor in super().
+  # provide it in the browse_path attribute.
+  # The modified attlist will be passed to safe_userfile_find_or_new().
+  #
+  # This method will returns a file object for a logfile,
+  # prepared with a browse_path if necessary.
   def safe_logfile_find_or_new(klass, attlist)
     name = attlist[:name]
     return safe_userfile_find_or_new(klass, attlist) if ! (name.include? "/") # if there is no relative path, just do normal stuff


### PR DESCRIPTION
This module allow to save the stdout and stderr files of a Boutiques task

To use this module, you need to add the following lines in the descriptor:

```
"custom_module_info": {
  "BoutiquesSaveStdOutStdErr": {
    "stdout_output_dir": "",
    "stderr_output_dir": "path/to/dir"
  }
}
```

In case of a MultilevelSshDataProvider the "path/to/dir" will be use to save the output.
In case of a no MultilevelSshDataProvider the "path/to/dir" will be ignored.

The value of the key "stdout_output_dir" and "stderr_output_dir" can be set to an empty string,
in this situation the files will be saved directly in the root folder of the DataProvider.
