### PR TITLE
Add task workdir shortening in Singularity containers

### DIFF
--- a/BrainPortal/app/controllers/tool_configs_controller.rb
+++ b/BrainPortal/app/controllers/tool_configs_controller.rb
@@ -238,9 +238,16 @@ class ToolConfigsController < ApplicationController
 
     respond_to do |format|
       new_record = @tool_config.new_record?
-      if @tool_config.save_with_logging(current_user, %w( env_array script_prologue script_epilogue ncpus extra_qsub_args
-                                                          container_image_userfile_id containerhub_image_name
-                                                          container_engine container_index_location ))
+      if @tool_config.save_with_logging(current_user,
+         %w( version_name env_array script_prologue script_epilogue ncpus extra_qsub_args
+             container_image_userfile_id containerhub_image_name
+             container_engine container_index_location container_exec_args
+             inputs_readonly
+             singularity_overlays_specs singularity_use_short_workdir
+             boutiques_descriptor_path
+           )
+        )
+
         if new_record
           flash[:notice] = "Tool configuration is successfully created."
         else
@@ -298,6 +305,7 @@ class ToolConfigsController < ApplicationController
       :group_id, :ncpus, :container_image_userfile_id, :containerhub_image_name, :container_index_location,
       :inputs_readonly,
       :container_engine, :extra_qsub_args, :singularity_overlays_specs, :container_exec_args,
+      :singularity_use_short_workdir,
       :boutiques_descriptor_path,
       # The configuration of a tool in a VM managed by a
       # ScirCloud Bourreau is defined by the following

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1778,27 +1778,16 @@ class ClusterTask < CbrainTask
     # Joined version of all the lines in the scientific script
     command_script = commands.join("\n")
 
-    # Add HOME switching back and forth
-    command_script = <<-HOME_SWITCHING
-# Preserve system HOME, then switch it to the task's workdir
-_cbrain_home_="$HOME"
-export HOME=#{self.full_cluster_workdir.bash_escape}
-
-#{command_script}
-
-# Restore system HOME (while preserving the latest exit code)
-_cbrain_status_="$?"
-export HOME="$_cbrain_home_"
-bash -c "exit $_cbrain_status_"
-    HOME_SWITCHING
-
     # In case of Docker or Singularity, we rewrite the scientific script inside
     # yet another wrapper script.
     if self.use_docker?
+      command_script = wrap_new_HOME(command_script, self.full_cluster_workdir)
       command_script = self.docker_commands(command_script)
     elsif self.use_singularity?
       load_singularity_image
-      command_script = self.singularity_commands(command_script)
+      command_script = self.singularity_commands(command_script) # note: invokes wrap_new_HOME itself
+    else
+      command_script = wrap_new_HOME(command_script, self.full_cluster_workdir)
     end
 
     # Create a bash science script out of the text
@@ -2312,6 +2301,10 @@ docker_image_name=#{full_image_name.bash_escape}
     return self.bourreau.singularity_executable_name.presence || "singularity"
   end
 
+  def use_singularity_rehoming?
+    self.tool_config.meta[:singularity_rehoming].present? # temporary dev
+  end
+
   # Returns the command line(s) associated with the task, wrapped in
   # a Singularity call if a Singularity image has to be used. +command_script+
   # is the raw scientific bash script.
@@ -2324,26 +2317,27 @@ docker_image_name=#{full_image_name.bash_escape}
     # Numbers in (paren) correspond to the comment
     # block in the script, well below.
 
-    # (6) The path to the task's work directory
-    task_workdir  = self.full_cluster_workdir # a string
-    short_workdir = "/cbrain_#{self.id}"
+    # (7) The path to the task's work directory
+    task_workdir   = self.full_cluster_workdir # a string
+    short_workdir  = "/cbrain_#{self.id}" # only used in rehoming mode
+    effect_workdir = use_singularity_rehoming? ? short_workdir : task_workdir
 
     # (1) additional singularity execution command options defined in ToolConfig
     container_exec_args = self.tool_config.container_exec_args.presence
 
     # (2) The root of the DataProvider cache
     cache_dir      = self.bourreau.dp_cache_dir
-    gridshare_dir  = self.bourreau.cms_shared_dir # not mounted explicitely
-    cache_dir_syml = "#{gridshare_dir}/DP_Cache"
 
-    # (3) Ext3 capture mounts, if any.
+    # (3) The root of the GridShare area (all tasks workdirs)
+    gridshare_dir  = self.bourreau.cms_shared_dir # not mounted explicitely
+
+    # (6) Ext3 capture mounts, if any.
     # These will look like "-B .capt_abcd.ext3:/path/workdir/abcd:image-src=/"
     # While we are building these options, we're also creating
     # the ext3 filesystems at the same time, if needed.
     esc_capture_mounts = ext3capture_basenames().inject("") do |sing_opts,(basename,size)|
       fs_name    = ".capt_#{basename}.ext3"      # e.g. .capt_work.ext3
-      #mountpoint = "#{task_workdir}/#{basename}" # e.g. /path/to/workdir/work
-      mountpoint = "#{short_workdir}/#{basename}" # e.g. /cbrain_123/work
+      mountpoint = "#{effect_workdir}/#{basename}" # e.g. /path/to/workdir/work or /cbrain_123/work
       install_ext3fs_filesystem(fs_name,size)
       "#{sing_opts} -B #{fs_name.bash_escape}:#{mountpoint.bash_escape}:image-src=/"
     end
@@ -2366,6 +2360,9 @@ docker_image_name=#{full_image_name.bash_escape}
     overlay_mounts = overlay_paths.inject("") do |sing_opts,path|
       "#{sing_opts} --overlay=#{path.bash_escape}:ro"
     end
+
+    # Wrap new HOME environment
+    command_script = wrap_new_HOME(command_script, effect_workdir)
 
     # Set singularity command
     singularity_commands = <<-SINGULARITY_COMMANDS
@@ -2404,6 +2401,17 @@ if test ! -d #{gridshare_dir.bash_escape} ; then
   exit 2
 fi
 
+# CBRAIN internal consistenct test 5: short task workdir rehoming (optional)
+# It's possible the path below will be the same as the task workdir if no rehoming
+# is configured, so the test becomes trivially like test 2.
+if test ! -d #{effect_workdir.bash_escape} ; then
+  echo "Container missing rehomed task work directory:" #{effect_workdir.bash_escape}
+  exit 2
+fi
+
+# Make sure we are in the task's workdir now.
+cd #{effect_workdir.bash_escape} || exit 2
+
 # Scientific commands start here
 
 #{command_script}
@@ -2411,29 +2419,29 @@ SINGULARITYJOB
 
 # Make sure it is executable
 chmod 755 #{singularity_wrapper_basename.bash_escape}
-# Other should have executable right on all components
-# of the path in order to be mounted by singularity.
-chmod o+x . .. ../.. ../../..
 
 # Invoke Singularity with our wrapper script above.
 # Tricks used here:
 # 1) we supply (if any) additional options for the exec command
 # 2) we mount the local data provider cache root directory
-# 3) we mount (if any) capture ext3 filesystems
+#   a) at its original cluster full path
+#   b) at /DP_Cache (used only during rehoming)
+# 3) we mount the root of the gridshare area (for all tasks)
 # 4) we mount each (if any) of the root directories for local data providers
 # 5) we mount (if any) other fixed file system overlays
-# 6) with -H we set the task's work directory as the singularity $HOME directory
+# 6) we mount (if any) capture ext3 filesystems
+# 7) with -H we set the task's work directory as the singularity $HOME directory
 #{singularity_executable_name}                  \\
     exec                                        \\
     #{container_exec_args}                      \\
     -B #{cache_dir.bash_escape}                 \\
-    -B #{cache_dir_syml.bash_escape}:/DP_Cache  \\
-    -B #{cache_dir_syml.bash_escape}            \\
+    -B #{cache_dir.bash_escape}:/DP_Cache       \\
+    -B #{gridshare.bash_escape}                 \\
     #{esc_local_dp_mountpoints}                 \\
     #{overlay_mounts}                           \\
-    -B #{task_workdir.bash_escape}:#{short_workdir.bash_escape} \\
+    -B #{task_workdir.bash_escape}:#{effect_workdir.bash_escape} \\
     #{esc_capture_mounts}                       \\
-    -H #{short_workdir.bash_escape}              \\
+    -H #{effect_workdir.bash_escape}            \\
     #{container_image_name.bash_escape}         \\
     ./#{singularity_wrapper_basename.bash_escape}
 
@@ -2449,6 +2457,24 @@ chmod o+x . .. ../.. ../../..
   ##################################################################
 
   private
+
+  # Add HOME switching back and forth to a bash script;
+  # preserve the status returned by the script too.
+  def wrap_new_HOME(script, new_home)
+    new_home_script = <<-HOME_SWITCHING
+# Preserve system HOME, then switch it
+_cbrain_home_="$HOME"
+export HOME=#{new_home.bash_escape}
+
+#{command_script}
+
+# Restore system HOME (while preserving the latest exit code)
+_cbrain_status_="$?"
+export HOME="$_cbrain_home_"
+bash -c "exit $_cbrain_status_"
+    HOME_SWITCHING
+    new_home_script
+  end
 
   # Returns an array of directory paths for all
   # online data providers that are local to the current

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2466,7 +2466,7 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
 _cbrain_home_="$HOME"
 export HOME=#{new_home.bash_escape}
 
-#{command_script}
+#{script}
 
 # Restore system HOME (while preserving the latest exit code)
 _cbrain_status_="$?"

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2339,6 +2339,7 @@ docker_image_name=#{full_image_name.bash_escape}
       fs_name    = ".capt_#{basename}.ext3"      # e.g. .capt_work.ext3
       mountpoint = "#{effect_workdir}/#{basename}" # e.g. /path/to/workdir/work or /cbrain_123/work
       install_ext3fs_filesystem(fs_name,size)
+      safe_mkdir(basename)
       "#{sing_opts} -B #{fs_name.bash_escape}:#{mountpoint.bash_escape}:image-src=/"
     end
 

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2301,6 +2301,8 @@ docker_image_name=#{full_image_name.bash_escape}
     return self.bourreau.singularity_executable_name.presence || "singularity"
   end
 
+  # Returns true if the admin has configured this option in the
+  # task's ToolConfig attributes.
   def use_singularity_short_workdir?
     self.tool_config.singularity_use_short_workdir
   end

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2436,7 +2436,7 @@ chmod 755 #{singularity_wrapper_basename.bash_escape}
     #{container_exec_args}                      \\
     -B #{cache_dir.bash_escape}                 \\
     -B #{cache_dir.bash_escape}:/DP_Cache       \\
-    -B #{gridshare.bash_escape}                 \\
+    -B #{gridshare_dir.bash_escape}             \\
     #{esc_local_dp_mountpoints}                 \\
     #{overlay_mounts}                           \\
     -B #{task_workdir.bash_escape}:#{effect_workdir.bash_escape} \\

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -245,6 +245,12 @@
       </div>
     <% end %>
 
+    <% t.boolean_edit_cell('tool_config[singularity_use_short_workdir]',
+         (@tool_config.singularity_use_short_workdir ? "1" : "0"),
+         "1", "0",
+         :header => "Use short workdirs inside Singularity")
+    %>
+
   <% end %>
 
 

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/bourreau/diagnostics.rb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/diagnostics/bourreau/diagnostics.rb
@@ -168,11 +168,11 @@ class CbrainTask::Diagnostics < ClusterTask
       echo ""
 
       echo "==== Host Info ===="
-      uname -a
-      uptime
+      uname -a 2>/dev/null
+      uptime   2>/dev/null
       echo ""
 
-      if test -n "$(type lsb_release)" ; then
+      if test -n "$(type -p lsb_release)" ; then
         echo "==== LSB Release ===="
         lsb_release -a
         echo ""
@@ -185,8 +185,8 @@ class CbrainTask::Diagnostics < ClusterTask
       fi
 
       if test -e /proc/cpuinfo ; then
-        echo "==== Last CPU Info ===="
-        cat /proc/cpuinfo | perl -ne '@x=grep(/./,<>);unshift(@y,pop(@x)) while @x > 0 && $y[0] !~ /^processor/; END { print @y }'
+        echo "==== Compacted CPU Info ===="
+        cat /proc/cpuinfo | sort | uniq | grep -v -E 'apicid|^processor|core id'
         echo ""
       fi
 
@@ -204,6 +204,10 @@ class CbrainTask::Diagnostics < ClusterTask
 
       echo "==== Listing Content of Work Directory ===="
       ls -la
+      echo ""
+
+      echo "==== Listing Content of Work Directory With Dereferencing ===="
+      ls -laL
       echo ""
 
     _DIAGNOSTIC_COMMANDS_

--- a/BrainPortal/db/migrate/20230304184206_add_short_task_workdir_to_tool_configs.rb
+++ b/BrainPortal/db/migrate/20230304184206_add_short_task_workdir_to_tool_configs.rb
@@ -1,3 +1,4 @@
+
 #
 # CBRAIN Project
 #
@@ -18,3 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+class AddShortTaskWorkdirToToolConfigs < ActiveRecord::Migration[5.0]
+  def change
+    add_column :tool_configs, :singularity_use_short_workdir, :boolean,
+      :default => false, :null => false, :after => :singularity_overlays_specs
+  end
+end

--- a/BrainPortal/db/schema.rb
+++ b/BrainPortal/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20221007094232) do
+ActiveRecord::Schema.define(version: 20230304184206) do
 
   create_table "access_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name",        null: false
@@ -438,12 +438,12 @@ ActiveRecord::Schema.define(version: 20221007094232) do
 
   create_table "tool_configs", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "version_name"
-    t.text     "description",                 limit: 65535
+    t.text     "description",                   limit: 65535
     t.integer  "tool_id"
     t.integer  "bourreau_id"
-    t.text     "env_array",                   limit: 65535
-    t.text     "script_prologue",             limit: 65535
-    t.text     "script_epilogue",             limit: 65535
+    t.text     "env_array",                     limit: 65535
+    t.text     "script_prologue",               limit: 65535
+    t.text     "script_epilogue",               limit: 65535
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "group_id"
@@ -460,9 +460,10 @@ ActiveRecord::Schema.define(version: 20221007094232) do
     t.string   "containerhub_image_name"
     t.string   "container_engine"
     t.string   "container_index_location"
-    t.text     "singularity_overlays_specs",  limit: 65535
+    t.text     "singularity_overlays_specs",    limit: 65535
+    t.boolean  "singularity_use_short_workdir",               default: false, null: false
     t.string   "container_exec_args"
-    t.boolean  "inputs_readonly",                           default: false
+    t.boolean  "inputs_readonly",                             default: false
     t.string   "boutiques_descriptor_path"
     t.index ["bourreau_id"], name: "index_tool_configs_on_bourreau_id", using: :btree
     t.index ["tool_id"], name: "index_tool_configs_on_tool_id", using: :btree

--- a/BrainPortal/lib/boutiques_post_processing_cleaner.rb
+++ b/BrainPortal/lib/boutiques_post_processing_cleaner.rb
@@ -41,6 +41,13 @@
 #       }
 #   }
 #
+# This module will also erase EXT3 capture filesystems created by CBRAIN
+# if the basename of the filesystem, as configured in the ToolConfig, matches
+# one of the entries in this module's configuration. So in the code above,
+# the content of the file ".capt_work.ext3" would also be erased if a capture
+# filesystem was configured for "work". Patterns are not supported for
+# this feature.
+#
 module BoutiquesPostProcessingCleaner
 
   # Note: to access the revision info of the module,
@@ -79,6 +86,15 @@ module BoutiquesPostProcessingCleaner
         self.addlog("Cleaning up '#{path}' in work directory")
         system("/bin/rm","-rf",path)
       end
+    end
+
+    # Also erase ext3 catpure files IF they match one of the patterns
+    ext3capture_basenames.each do |basename, _|
+      next unless patterns.include?(basename) # must be exact match, e.g. 'work' == 'work'
+      fs_name = ".capt_#{basename}.ext3"      # e.g. .capt_work.ext3, see also in cluster_task.rb
+      next unless File.file?(fs_name)
+      self.addlog("Cleaning up EXT3 capture filesystem '#{fs_name}' in work directory")
+      File.delete(fs_name) rescue nil
     end
 
     true


### PR DESCRIPTION
This PR allows an admin to turn on a new feature. In all ToolConfigs, there is a new flag `Use short workdirs inside Singularity`. Default is off.

When turned on, a task run in a Singularity container will see its workdir remapped to a much shorter path such as "/T12345/" (where 12345 is the task's ID).

The system should normally make sure all data files are properly accessible from that new location. This was needed because some stupid C tools crash when a path provided in argument is too long (e.g. some of the internal programs invoked by FMRIPrep).

As an added feature, an admin can go to the work directory of any Singularity-based task and start a Singularity shell simply by invoking:

```
bash .science.TOOLNAME.1234-1.sh shell
```

Basically, the scripts named `.science.TOOLNAME*` can take the single argument `shell` to bypass the execution of the tool and boot an interactive shell instead.