### PR TITLE
fix error message duplication for duplicate filename ( fixes #1309 )

### DIFF
--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -549,8 +549,9 @@ class UserfilesController < ApplicationController
         flash[:error]  += "It might help to rename the file.\n" if flash[:error].include? "Name is already"
         respond_to do |format|
           format.html { redirect_to redirect_path }
-          format.json { render :json => { :notice => flash[:error] }, :status => :unprocessable_entity
-                        flash.discard
+          format.json {
+                          render :json => { :notice => flash[:error] }, :status => :unprocessable_entity
+                          flash.discard # no need to repeat error message
                       }
         end
         return

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -546,9 +546,12 @@ class UserfilesController < ApplicationController
         userfile.errors.each do |field, error|
           flash[:error] += "#{field.to_s.capitalize} #{error}.\n"
         end
+        flash[:error]  += "It might help to rename the file.\n" if flash[:error].include? "Name is already"
         respond_to do |format|
           format.html { redirect_to redirect_path }
-          format.json { render :json => { :notice => flash[:error] }, :status => :unprocessable_entity }
+          format.json { render :json => { :notice => flash[:error] }, :status => :unprocessable_entity
+                        flash.discard
+                      }
         end
         return
       end

--- a/BrainPortal/app/controllers/userfiles_controller.rb
+++ b/BrainPortal/app/controllers/userfiles_controller.rb
@@ -546,7 +546,7 @@ class UserfilesController < ApplicationController
         userfile.errors.each do |field, error|
           flash[:error] += "#{field.to_s.capitalize} #{error}.\n"
         end
-        flash[:error]  += "It might help to rename the file.\n" if flash[:error].include? "Name is already"
+        flash[:error]  += "It might help to rename the file.\n" if flash[:error].include? "Name has already been taken"
         respond_to do |format|
           format.html { redirect_to redirect_path }
           format.json {

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -28,9 +28,10 @@
   /* Generic AJAX error handler */
   $(document).ajaxError(function (event, xhr, settings, error) {
     var flash = $('.flash_error'),
-        xml   = $(xhr.responseXML);
-
+        xml   = $(xhr.responseXML),
+        rjson  = xhr.responseJSON;
     if (xhr.status === 0) return true;
+    //if (rjson && rjson.notice) return true;
 
     if (!flash.length)
       flash = $('<div class="flash_error">')
@@ -44,6 +45,8 @@
           .get()
           .join('<br />')
       );
+    else if (rjson && rjson.notice)
+      flash.html(rjson.notice.replace(/\n/g, "<br />"))
     else
       flash.html(
         'Error sending background request: <br />' +

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -29,7 +29,7 @@
   $(document).ajaxError(function (event, xhr, settings, error) {
     var flash = $('.flash_error'),
         xml   = $(xhr.responseXML),
-        rjson  = xhr.responseJSON;
+        rjson = xhr.responseJSON;
     if (xhr.status === 0) return true;
     //if (rjson && rjson.notice) return true;
 


### PR DESCRIPTION
Fixes confusing error messages when trying to upload a file that already exists shows bad error message

I did not investigate messages for any other errors.

https://github.com/aces/cbrain/issues/1309