### PR TITLE
Changed the main SSH key from RSA to ed25519

### DIFF
--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -524,8 +524,8 @@ class RemoteResource < ApplicationRecord
     cb_error "SSH public key only accessible for the current resource." unless self.id == self.class.current_resource.id
     return @ssh_public_key if @ssh_public_key
     home = CBRAIN::Rails_UserHome
-    if File.exists?("#{home}/.ssh/id_cbrain_portal.pub")
-      @ssh_public_key = File.read("#{home}/.ssh/id_cbrain_portal.pub") rescue ""
+    if File.exists?("#{home}/.ssh/id_cbrain_ed25519.pub")
+      @ssh_public_key = File.read("#{home}/.ssh/id_cbrain_ed25519.pub") rescue ""
     else
       @ssh_public_key = ""
     end


### PR DESCRIPTION
Backwards compatibility is kept by adding the old RSA key to the agent, if it's found. Eventually, operators will want to only use the ed25519 key, they can do so by removing the files.