### PR TITLE
the tool tag list in alphabetic order, resolves #1383

### DIFF
--- a/BrainPortal/app/views/userfiles/_tools_interface.html.erb
+++ b/BrainPortal/app/views/userfiles/_tools_interface.html.erb
@@ -24,7 +24,7 @@
 <%
   types    = @my_tools.map { |t| t.application_type         :array  }.flatten.uniq
   packages = @my_tools.map { |t| t.application_package_name :array  }.flatten.uniq
-  tags     = @my_tools.map { |t| t.application_tags         :array  }.flatten.sort_by{|tag| tag.downcase}.uniq
+  tags     = @my_tools.map { |t| t.application_tags         :array  }.flatten.sort_by{ |tag| tag.downcase }.uniq
 %>
 
 <div id="toolsDialog" title="Select Tool" >

--- a/BrainPortal/app/views/userfiles/_tools_interface.html.erb
+++ b/BrainPortal/app/views/userfiles/_tools_interface.html.erb
@@ -24,7 +24,7 @@
 <%
   types    = @my_tools.map { |t| t.application_type         :array  }.flatten.uniq
   packages = @my_tools.map { |t| t.application_package_name :array  }.flatten.uniq
-  tags     = @my_tools.map { |t| t.application_tags         :array  }.flatten.uniq
+  tags     = @my_tools.map { |t| t.application_tags         :array  }.flatten.sort_by{|tag| tag.downcase}.uniq
 %>
 
 <div id="toolsDialog" title="Select Tool" >


### PR DESCRIPTION
sorting tags alphabetically in task launch form, see #1383 for details

sort is case insensitive, so capitalisation does not affect the ordering, as in [the reference tag sheet ](https://docs.google.com/spreadsheets/d/1Be-MrFDJrGbCrvbvDGITUl0OiVC5uR90CTsAfG1eu1A/)