### PR TITLE
 DataProviders: restriction panels: new toggles and defaults

### DIFF
--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -2662,6 +2662,5 @@ img {
 
 .indeterminate_box_label {
    color: steelblue !important;
-
    font-weight: normal !important;
 }

--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -2655,3 +2655,13 @@ img {
 .no-close .ui-dialog-titlebar-close {
   display: none;
 }
+
+.indefinite {
+   color: steelblue !important;
+}
+
+.indefinite_checkbox_label {
+   color: steelblue !important;
+
+   font-weight: normal !important;
+}

--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -2656,11 +2656,11 @@ img {
   display: none;
 }
 
-.indefinite {
+.indeterminate {
    color: steelblue !important;
 }
 
-.indefinite_checkbox_label {
+.indeterminate_box_label {
    color: steelblue !important;
 
    font-weight: normal !important;

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -179,7 +179,7 @@ class DataProvidersController < ApplicationController
     # Fields that stay the same if the form provides a blank entry:
     new_data_provider_attr.delete :cloud_storage_client_token if new_data_provider_attr[:cloud_storage_client_token].blank?
     if @provider.update_attributes_with_logging(new_data_provider_attr, current_user, @provider.attributes.keys + [])
-      mass_flags                  = 'dp_no_copy_default|rr_no_sync_default'  # few_special flags that control other
+      mass_flags                  = 'dp_no_copy_default|rr_no_sync_default'  # default policies w.r.t new dp or server
       # todo cast params to hash for rails 5.1 as `ActionController::Parameters` no longer inherits from hash
       meta_flags_for_restrictions = (params[:meta] || {}).keys.grep(/\Adp_no_copy_\d+\z|\Arr_no_sync_\d+|#{mass_flags}\z/)
 

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -152,7 +152,7 @@ class DataProvidersController < ApplicationController
       format.json { render      :json   => @provider }
     end
   end
-
+  require 'pry'
   def update #:nodoc:
     @user     = current_user
     id        = params[:id]
@@ -178,9 +178,12 @@ class DataProvidersController < ApplicationController
 
     # Fields that stay the same if the form provides a blank entry:
     new_data_provider_attr.delete :cloud_storage_client_token if new_data_provider_attr[:cloud_storage_client_token].blank?
+    binding.pry
+    if @provider.update_attributes_with_logging(new_data_provider_attr, current_user, @provider.attributes.keys + [])
+      mass_flags                  = 'dp_no_copy_new|dp_no_copy_toggle|rr_no_sync_new|rr_no_sync_toggle'  # few_special flags that control other
+      # todo cast params to hash for rails 5.1 as `ActionController::Parameters` no longer inherits from hash
+      meta_flags_for_restrictions = (params[:meta] || {}).keys.grep(/\Adp_no_copy_\d+\z|\Arr_no_sync_\d+|#{mass_flags}\z/)
 
-    if @provider.update_attributes_with_logging(new_data_provider_attr, current_user, @provider.attributes.keys)
-      meta_flags_for_restrictions = (params[:meta] || {}).keys.grep(/\Adp_no_copy_\d+\z|\Arr_no_sync_\d+\z/)
       add_meta_data_from_form(@provider, [:must_move, :no_uploads, :no_viewers, :browse_gid] + meta_flags_for_restrictions)
       flash[:notice] = "Provider successfully updated."
       respond_to do |format|

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -152,7 +152,7 @@ class DataProvidersController < ApplicationController
       format.json { render      :json   => @provider }
     end
   end
-  require 'pry'
+
   def update #:nodoc:
     @user     = current_user
     id        = params[:id]
@@ -178,9 +178,8 @@ class DataProvidersController < ApplicationController
 
     # Fields that stay the same if the form provides a blank entry:
     new_data_provider_attr.delete :cloud_storage_client_token if new_data_provider_attr[:cloud_storage_client_token].blank?
-    binding.pry
     if @provider.update_attributes_with_logging(new_data_provider_attr, current_user, @provider.attributes.keys + [])
-      mass_flags                  = 'dp_no_copy_new|dp_no_copy_toggle|rr_no_sync_new|rr_no_sync_toggle'  # few_special flags that control other
+      mass_flags                  = 'dp_no_copy_default|rr_no_sync_default'  # few_special flags that control other
       # todo cast params to hash for rails 5.1 as `ActionController::Parameters` no longer inherits from hash
       meta_flags_for_restrictions = (params[:meta] || {}).keys.grep(/\Adp_no_copy_\d+\z|\Arr_no_sync_\d+|#{mass_flags}\z/)
 

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -197,12 +197,14 @@ module ShowTableHelper
     # As +boolean_edit_cell+ is a specialization of +edit_cell+, +field+,
     # +&block+ and +options+ are handled the same way (save for the defaults
     # outlined above).
+    # +input_options+ apply only to the checkbox itself (works only in edit mode and in absence of block)
     def boolean_edit_cell(field, cur_value, checked_value = "1", unchecked_value = "0", options = {}, &block)
       options[:content] ||= @template.disabled_checkbox(cur_value == checked_value)
+      input_options       = options.delete(:input_options) || {}
       if block_given?
         edit_cell(field, options, &block)
       else
-        edit_cell(field, options) { @template.hidden_field_tag(field, unchecked_value) + @template.check_box_tag(field, checked_value, cur_value == checked_value) }
+        edit_cell(field, options) { @template.hidden_field_tag(field, unchecked_value) + @template.check_box_tag(field, checked_value, cur_value == checked_value, input_options) }
       end
     end
 

--- a/BrainPortal/app/helpers/show_table_helper.rb
+++ b/BrainPortal/app/helpers/show_table_helper.rb
@@ -197,7 +197,7 @@ module ShowTableHelper
     # As +boolean_edit_cell+ is a specialization of +edit_cell+, +field+,
     # +&block+ and +options+ are handled the same way (save for the defaults
     # outlined above).
-    # +input_options+ apply only to the checkbox itself (works only in edit mode and in absence of block)
+    # +input_options+ are options just for the checkbox itself (at the moment apply only to the edit mode and block-free use)
     def boolean_edit_cell(field, cur_value, checked_value = "1", unchecked_value = "0", options = {}, &block)
       options[:content] ||= @template.disabled_checkbox(cur_value == checked_value)
       input_options       = options.delete(:input_options) || {}

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -809,7 +809,6 @@ class DataProvider < ApplicationRecord
     true
   end
 
-
   # Copy a +userfile+ from the current provider to +otherprovider+.
   # Returns the new userfile if data was actually copied, true if
   # no copy was necessary, and false if anything was amiss.
@@ -1362,7 +1361,7 @@ class DataProvider < ApplicationRecord
 
   # Returns true if RemoteResource +rr+ is allowed to access DataProvider +check_dp+
   # (which defaults to self). The information for this restriction is maintained
-  # as a blacklist in the meta data store.
+  # according to whitelist, blacklist and default value in the meta data store.
   def rr_allowed_syncing?(rr = RemoteResource.current_resource, check_dp = self)
     rr ||= RemoteResource.current_resource
     meta_key = "rr_no_sync_#{rr.id}"
@@ -1383,7 +1382,7 @@ class DataProvider < ApplicationRecord
   # Returns true if the DataProvider is allowed to copy or move files to the
   # other DataProvider +other_dp+ .
   # The information for this restriction is maintained by default value
-  # along with a white- and blacklist, whitelist in the meta data store.
+  # along with a white- and blacklist, all stored in the meta data store.
   def dp_allows_copy?(other_dp)
     meta_key = "dp_no_copy_#{other_dp.id}"
     # if there is no explicit flag for particular provider
@@ -1393,9 +1392,6 @@ class DataProvider < ApplicationRecord
     # hacky equivalent of
     # return true if self.meta[meta_key] == 'copy'  # yes if whitelisted
     # self.meta[meta_key].blank? && default != "disabled"  # otherwise by dafault
-
-
-
   end
 
   # Works like dp_allows_copy? but raises an exception if the

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -817,7 +817,7 @@ class DataProvider < ApplicationRecord
     # Define the conditions to select records
     conditions = {
       ar_table_name: 'data_providers',
-      meta_key:      'dp_no_copy_new',
+      meta_key:      'dp_no_copy_default',
       meta_value:    'disabled'
     }
 
@@ -1407,11 +1407,20 @@ class DataProvider < ApplicationRecord
 
   # Returns true if the DataProvider is allowed to copy or move files to the
   # other DataProvider +other_dp+ .
-  # The information for this restriction is maintained
-  # as a blacklist in the meta data store.
+  # The information for this restriction is maintained by default value
+  # along with a white- and blacklist, whitelist in the meta data store.
   def dp_allows_copy?(other_dp)
-    meta_key_disabled = "dp_no_copy_#{other_dp.id}"
-    self.meta[meta_key_disabled].blank?
+    meta_key = "dp_no_copy_#{other_dp.id}"
+    # if there is no explicit flag for particular provider
+    # fall back on the default policy
+    default  = self.meta["dp_no_copy_default"]
+    return ( self.meta[meta_key].presence || default ) != "disabled"
+    # hacky equivalent of
+    # return true if self.meta[meta_key] == 'copy'  # yes if whitelisted
+    # self.meta[meta_key].blank? && default != "disabled"  # otherwise by dafault
+
+
+
   end
 
   # Works like dp_allows_copy? but raises an exception if the

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -1365,9 +1365,9 @@ class DataProvider < ApplicationRecord
   def rr_allowed_syncing?(rr = RemoteResource.current_resource, check_dp = self)
     rr ||= RemoteResource.current_resource
     meta_key = "rr_no_sync_#{rr.id}"
-    default  = check_dp.meta["rr_no_sync_default"] || 'allowed'
+    default  = check_dp.meta["rr_no_sync_default"] || 'allowed'  # default for default is allow sync
     policy   = ( self.meta[meta_key].presence || default )
-    return policy.length > 7  # it is faster check length
+    return policy.length != 8  # shorter or longer than 'disabled' (either 'allowed' or long legacy sentence)
   end
 
   # Works like rr_allowed_syncing? but raise an exception when the

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -288,7 +288,6 @@
         <strong>Mass controls </strong>
       <% end %>
       <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Reset old to", :class => 'checkbox_label') do %>
-        <%#= select_all_checkbox("rr_box", :persistant_name => meta_key, :id => :rr_select_all) %>
         <%= select_all_checkbox("rr_box", :id => :rr_select_all) %>
       <% end %>
       <% default_key = "rr_no_sync_default" %>
@@ -304,7 +303,7 @@
         <% t.row(:class => 'subheader') { "<strong>Portals<strong>".html_safe } %>
         <% rrs_by_category[:portal].sort_by(&:name).each do |rr| %>
           <% meta_key = "rr_no_sync_#{rr.id}" %>
-          <% meta_value = "disabled" if @provider.meta[meta_key]&.length&.> 7 # to avoid migration, works old and new value %>
+          <% meta_value = "disabled" if @provider.meta[meta_key]&.length&.> 7 # to avoid migration, works with old and new value %>
           <% tribox(t, rr, meta_key, meta_value, default_value, "rr_box" ) %>
         <% end%>
       <% end%>
@@ -316,7 +315,7 @@
         <% rrs_by_category[:bourreau].sort_by(&:name).each do |rr| %>
           <% meta_key = "rr_no_sync_#{rr.id}" %>
           <% meta_value = @provider.meta[meta_key] %>
-          <% meta_value = "disable" if meta_value == "#{rr.name} cannot sync #{@provider.name}" # transitional, to avoid migration%>
+          <% meta_value = "disabled" unless meta_value # transitional, to avoid migration%>
           <% tribox(t, rr, meta_key, meta_value, default_value, "rr_box" ) %>
 
 <% end%>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -29,6 +29,16 @@
 <% is_userkey_dp    = @provider.is_a?(UserkeyFlatDirSshDataProvider) %>
 <% needs_ssh_config = @provider.is_a?(SshDataProvider) || @provider.is_a?(SmartDataProviderInterface) %>
 
+<% def tribox(t, model, meta_key, meta_value, default_value, cls) # creates tristate checkbox for table
+     if meta_value.present?
+       t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "allowed", "disabled", :header => "#{model.name}", :class => 'checkbox_label', :input_options => { class: cls } )
+     else
+       t.boolean_edit_cell("meta[#{meta_key}]", default_value, "allowed", "disabled", :header => "<em>#{model.name}</em>".html_safe, :class => 'checkbox_label indeterminate_box_label', :input_options => { class: "#{cls} indeterminate" } )
+     end
+  end
+%>
+
+
 <div class="menu_bar">
 
     <% if @provider.is_browsable?(current_user) && @provider.online? %>
@@ -235,9 +245,9 @@
         <% end %>
         <% default_key = "dp_no_copy_default" %>
         <!-- copy to new dataproviders allowed by default   -->
-        <% default_value = @provider.meta[default_key] || "copy" %>
-        <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "copy", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
-        <% t.cell("on all future providers",  :no_header => "explanations", :class => "indefinite_checkbox_label") do %>
+        <% default_value = @provider.meta[default_key] || "allowed" %>
+        <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "allowed", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
+        <% t.cell("on all future providers",  :no_header => "explanations", :class => "indeterminate_box_label") do %>
           &nbsp on all new (in <em> italic </em>) and the future providers
         <% end %>
         <% t.blank_row %>
@@ -248,31 +258,20 @@
         <% dps_by_category[:official].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
           <% meta_value = @provider.meta[meta_key] %>
-          <% if meta_value.present? %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "copy", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } )  %>
-          <% else %>
-            <%# for not yet blacklisted/whitelisted, italic header %>
-            <%# javascript will set checkbox's indeterminate state attribute %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disabled", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label  indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
-          <% end %>
+          <% tribox(t, dp, meta_key, meta_value, default_value, "dp_box" ) %>
         <% end%>
 
       <% end%>
 
       <% t.blank_row %>
 
+
       <% if dps_by_category[:user] %>
         <% t.row(:class => 'subheader') { "<strong>User or Site Storage</strong>".html_safe } %>
         <% dps_by_category[:user].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
           <% meta_value = @provider.meta[meta_key] %>
-          <% if meta_value.present? %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "copy", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } )  %>
-          <% else %>
-            <%# for not yet blacklisted/whitelisted, italic header %>
-            <%# javascript will set checkbox to indeterminate state %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disabled", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
-          <% end %>
+          <% tribox(t, dp, meta_key, meta_value, default_value, "dp_box" ) %>
         <% end%>
       <% end%>
     <% end%>
@@ -284,11 +283,29 @@
   <% if other_rrs.size > 0 %>
 
     <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'File contents can be accessed by these Servers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
+
+      <% t.row(:class => 'subheader') do %>
+        <strong>Mass controls </strong>
+      <% end %>
+      <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Reset old to", :class => 'checkbox_label') do %>
+        <%#= select_all_checkbox("rr_box", :persistant_name => meta_key, :id => :rr_select_all) %>
+        <%= select_all_checkbox("rr_box", :id => :rr_select_all) %>
+      <% end %>
+      <% default_key = "rr_no_copy_default" %>
+      <!-- sycn to new Remote Resources allowed by default   -->
+      <% default_value = @provider.meta[default_key] || "allowed" %>
+      <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "allowed", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
+      <% t.cell("on all future servers",  :no_header => "explanations", :class => "indeterminate_box_label") do %>
+        &nbsp on all new (in <em> italic </em>) and the future servers
+      <% end %>
+      <% t.blank_row %>
+
       <% if rrs_by_category[:portal] %>
         <% t.row(:class => 'subheader') { "<strong>Portals<strong>".html_safe } %>
         <% rrs_by_category[:portal].sort_by(&:name).each do |rr| %>
           <% meta_key = "rr_no_sync_#{rr.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "#{rr.name} cannot sync #{@provider.name}", :header => "#{rr.name}", :class => 'checkbox_label') %>
+          <% meta_value = "disabled" if @provider.meta[meta_key]&.length&.> 7 # to avoid migration, works old and new value %>
+          <% tribox(t, rr, meta_key, meta_value, default_value, "rr_box" ) %>
         <% end%>
       <% end%>
 
@@ -298,8 +315,11 @@
         <% t.row(:class => 'subheader') { "<strong>Execution Servers<strong>".html_safe } %>
         <% rrs_by_category[:bourreau].sort_by(&:name).each do |rr| %>
           <% meta_key = "rr_no_sync_#{rr.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "#{rr.name} cannot sync #{@provider.name}", :header => "#{rr.name}", :class => 'checkbox_label') %>
-        <% end%>
+          <% meta_value = @provider.meta[meta_key] %>
+          <% meta_value = "disable" if meta_value == "#{rr.name} cannot sync #{@provider.name}" # transitional, to avoid migration%>
+          <% tribox(t, rr, meta_key, meta_value, default_value, "rr_box" ) %>
+
+<% end%>
       <% end%>
     <% end%>
   <% end%>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -248,7 +248,7 @@
         <% default_value = @provider.meta[default_key] || "allowed" %>
         <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "allowed", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
         <% t.cell("on all future providers",  :no_header => "explanations", :class => "indeterminate_box_label") do %>
-          &nbsp on all new (in <em> italic </em>) and the future providers
+          &nbsp on new and future providers
         <% end %>
         <% t.blank_row %>
         <% t.row(:class => 'subheader') do %>
@@ -291,12 +291,12 @@
         <%#= select_all_checkbox("rr_box", :persistant_name => meta_key, :id => :rr_select_all) %>
         <%= select_all_checkbox("rr_box", :id => :rr_select_all) %>
       <% end %>
-      <% default_key = "rr_no_copy_default" %>
+      <% default_key = "rr_no_sync_default" %>
       <!-- sycn to new Remote Resources allowed by default   -->
       <% default_value = @provider.meta[default_key] || "allowed" %>
       <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "allowed", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
       <% t.cell("on all future servers",  :no_header => "explanations", :class => "indeterminate_box_label") do %>
-        &nbsp on all new (in <em> italic </em>) and the future servers
+        &nbsp on new and future servers
       <% end %>
       <% t.blank_row %>
 

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -22,6 +22,8 @@
 #
 -%>
 
+<script src="show.js"></script>
+
 <% title 'Data Provider Info' %>
 
 <% has_owner_access = (check_role(:admin_user) || @provider.user_id == current_user.id) %>
@@ -229,13 +231,15 @@
           <strong>Mass controls </strong>
         <% end %>
         <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Toggle all", :class => 'checkbox_label') do %>
-          <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :existing_select_all) %>
-          <%= select_all_checkbox("dp_box", :id => :existing_select_all) %>
+          <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :dp_select_all) %>
+          <%= select_all_checkbox("dp_box", :id => :dp_select_all) %>
         <% end %>
-        <% meta_key = "dp_no_copy_new" %>
-        <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
+        <% default_key = "dp_no_copy_default" %>
+        <!-- copy to new dataproviders allowed by default   -->
+        <% default_value = @provider.meta[default_key] || "copy" %>
+        <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "copy", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
         <% t.cell("on all future providers",  :no_header => "explanations")do %>
-          &nbsp (on all the future providers)
+          &nbsp on all new (in italic) and the future providers
         <% end %>
         <% t.blank_row %>
         <% t.row(:class => 'subheader') do %>
@@ -244,7 +248,14 @@
 
         <% dps_by_category[:official].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } ) %>
+          <% meta_value = @provider.meta[meta_key] %>
+          <% if meta_value.present? %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "copy", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } )  %>
+          <% else %>
+            <%# for not yet blacklisted/whitelisted, italic header %>
+            <%# javascript to set checkbox to indeterminate state %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+          <% end %>
         <% end%>
 
       <% end%>
@@ -255,7 +266,14 @@
         <% t.row(:class => 'subheader') { "<strong>User or Site Storage</strong>".html_safe } %>
         <% dps_by_category[:user].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" }) %>
+          <% meta_value = @provider.meta[meta_key] %>
+          <% if meta_value.present? %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "copy", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } )  %>
+          <% else %>
+            <%# for not yet blacklisted/whitelisted, italic header %>
+            <%# javascript will set checkbox to indeterminate state %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+          <% end %>
         <% end%>
       <% end%>
     <% end%>
@@ -307,5 +325,9 @@
   <p>
 
   <%= render :partial => "layouts/log_report", :locals  => { :log  => @provider.getlog, :title => "Data Provider Log" } %>
+<% end %>
+
+<% content_for :scripts do %>
+  <%= javascript_include_tag 'cbrain/data_providers/tribox' %>
 <% end %>
 

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -225,8 +225,10 @@
     <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'Files can be copied or moved to these other Data Providers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
       <% if dps_by_category[:official] %>
 
-
-        <% t.boolean_edit_cell("Toggle all", 0, :header => "All", :class => 'checkbox_label') do %>
+        <% t.row(:class => 'subheader') do %>
+          <strong>Mass controls </strong>
+        <% end %>
+        <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Toggle all", :class => 'checkbox_label') do %>
           <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :existing_select_all) %>
           <%= select_all_checkbox("dp_box", :id => :existing_select_all) %>
         <% end %>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -225,8 +225,8 @@
     <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'Files can be copied or moved to these other Data Providers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
       <% if dps_by_category[:official] %>
 
-        <% meta_key = "dp_no_copy_toggle" %>
-        <% t.boolean_edit_cell("meta[_dummy_field]", @provider.meta[meta_key].to_s, "", "disabled", :header => "Toggle all", :class => 'checkbox_label') do %>
+
+        <% t.boolean_edit_cell("Toggle all", 0, :header => "All", :class => 'checkbox_label') do %>
           <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :existing_select_all) %>
           <%= select_all_checkbox("dp_box", :id => :existing_select_all) %>
         <% end %>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -22,7 +22,6 @@
 #
 -%>
 
-<script src="show.js"></script>
 
 <% title 'Data Provider Info' %>
 
@@ -230,7 +229,7 @@
         <% t.row(:class => 'subheader') do %>
           <strong>Mass controls </strong>
         <% end %>
-        <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Toggle all", :class => 'checkbox_label') do %>
+        <% t.boolean_edit_cell("Unsaved toggle", "", "", "", :header => "Reset old to", :class => 'checkbox_label') do %>
           <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :dp_select_all) %>
           <%= select_all_checkbox("dp_box", :id => :dp_select_all) %>
         <% end %>
@@ -238,8 +237,8 @@
         <!-- copy to new dataproviders allowed by default   -->
         <% default_value = @provider.meta[default_key] || "copy" %>
         <% t.boolean_edit_cell("meta[#{default_key}]", default_value, "copy", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
-        <% t.cell("on all future providers",  :no_header => "explanations")do %>
-          &nbsp on all new (in italic) and the future providers
+        <% t.cell("on all future providers",  :no_header => "explanations", :class => "indefinite_checkbox_label") do %>
+          &nbsp on all new (in <em> italic </em>) and the future providers
         <% end %>
         <% t.blank_row %>
         <% t.row(:class => 'subheader') do %>
@@ -253,8 +252,8 @@
             <% t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "copy", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } )  %>
           <% else %>
             <%# for not yet blacklisted/whitelisted, italic header %>
-            <%# javascript to set checkbox to indeterminate state %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+            <%# javascript will set checkbox's indeterminate state attribute %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label  indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
           <% end %>
         <% end%>
 
@@ -272,7 +271,7 @@
           <% else %>
             <%# for not yet blacklisted/whitelisted, italic header %>
             <%# javascript will set checkbox to indeterminate state %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
           <% end %>
         <% end%>
       <% end%>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -253,7 +253,7 @@
           <% else %>
             <%# for not yet blacklisted/whitelisted, italic header %>
             <%# javascript will set checkbox's indeterminate state attribute %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label  indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disabled", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label  indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
           <% end %>
         <% end%>
 
@@ -271,7 +271,7 @@
           <% else %>
             <%# for not yet blacklisted/whitelisted, italic header %>
             <%# javascript will set checkbox to indeterminate state %>
-            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disable", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
+            <% t.boolean_edit_cell("meta[#{meta_key}]", default_value, "copy", "disabled", :header => "<em>#{dp.name}</em>".html_safe, :class => 'checkbox_label indefinite_checkbox_label', :input_options => { class: "dp_box indeterminate" } )  %>
           <% end %>
         <% end%>
       <% end%>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -29,7 +29,10 @@
 <% is_userkey_dp    = @provider.is_a?(UserkeyFlatDirSshDataProvider) %>
 <% needs_ssh_config = @provider.is_a?(SshDataProvider) || @provider.is_a?(SmartDataProviderInterface) %>
 
-<% def tribox(t, model, meta_key, meta_value, default_value, cls) # creates tristate checkbox for table
+<%
+    # tribox method creates tristate checkbox for table, to be used with meta data store
+    # meta_value can have values allowed, disabled and empty (=indetermiate state)
+    def tribox(t, model, meta_key, meta_value, default_value, cls)
      if meta_value.present?
        t.boolean_edit_cell("meta[#{meta_key}]", meta_value, "allowed", "disabled", :header => "#{model.name}", :class => 'checkbox_label', :input_options => { class: cls } )
      else
@@ -315,10 +318,9 @@
         <% rrs_by_category[:bourreau].sort_by(&:name).each do |rr| %>
           <% meta_key = "rr_no_sync_#{rr.id}" %>
           <% meta_value = @provider.meta[meta_key] %>
-          <% meta_value = "disabled" unless meta_value # transitional, to avoid migration%>
+          <% meta_value = "disabled" if @provider.meta[meta_key]&.length&.> 7 # to avoid migration%>
           <% tribox(t, rr, meta_key, meta_value, default_value, "rr_box" ) %>
-
-<% end%>
+        <% end%>
       <% end%>
     <% end%>
   <% end%>

--- a/BrainPortal/app/views/data_providers/show.html.erb
+++ b/BrainPortal/app/views/data_providers/show.html.erb
@@ -224,11 +224,27 @@
 
     <%= show_table(@provider, :as => :data_provider, :width => 5, :header => 'Files can be copied or moved to these other Data Providers', :edit_condition => (check_role(:admin_user) || @provider.user_id == current_user.id)) do |t| %>
       <% if dps_by_category[:official] %>
-        <% t.row(:class => 'subheader') { "<strong>Official Storage</strong>".html_safe } %>
+
+        <% meta_key = "dp_no_copy_toggle" %>
+        <% t.boolean_edit_cell("meta[_dummy_field]", @provider.meta[meta_key].to_s, "", "disabled", :header => "Toggle all", :class => 'checkbox_label') do %>
+          <%#= select_all_checkbox("dp_box", :persistant_name => meta_key, :id => :existing_select_all) %>
+          <%= select_all_checkbox("dp_box", :id => :existing_select_all) %>
+        <% end %>
+        <% meta_key = "dp_no_copy_new" %>
+        <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled",  :header => "Default to", :class => 'checkbox_label')  %>
+        <% t.cell("on all future providers",  :no_header => "explanations")do %>
+          &nbsp (on all the future providers)
+        <% end %>
+        <% t.blank_row %>
+        <% t.row(:class => 'subheader') do %>
+           <strong>Official Storage </strong>
+        <% end %>
+
         <% dps_by_category[:official].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label') %>
+          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" } ) %>
         <% end%>
+
       <% end%>
 
       <% t.blank_row %>
@@ -237,7 +253,7 @@
         <% t.row(:class => 'subheader') { "<strong>User or Site Storage</strong>".html_safe } %>
         <% dps_by_category[:user].sort_by(&:name).each do |dp| %>
           <% meta_key = "dp_no_copy_#{dp.id}" %>
-          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label') %>
+          <% t.boolean_edit_cell("meta[#{meta_key}]", @provider.meta[meta_key].to_s, "", "disabled", :header => "#{dp.name}", :class => 'checkbox_label', :input_options => { class: "dp_box" }) %>
         <% end%>
       <% end%>
     <% end%>

--- a/BrainPortal/public/javascripts/cbrain.js
+++ b/BrainPortal/public/javascripts/cbrain.js
@@ -640,6 +640,8 @@
 
       $('.' + checkbox_class).each(function(index, element) {
         element.checked = header_box.prop('checked');
+        // todo add artificial event, e.g. to propagage changes with tri-state checkboxes
+        // smth like element.trigger("code-change")
       });
     };
 

--- a/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
+++ b/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
@@ -26,7 +26,7 @@
 // all elements with empty value are set as indeterminate
 $(".show_table_edit_link").click(
     function () {
-        $(".dp_box.indeterminate").each(
+        $(".indeterminate").each(
             function () {
                 $(this).prop("indeterminate", true);
                 $(this).val("");

--- a/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
+++ b/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
@@ -1,28 +1,26 @@
 //
-// <%-
-// #
-// # CBRAIN Project
-// #
-// # Copyright (C) 2008-2012
-// # The Royal Institution for the Advancement of Learning
-// # McGill University
-// #
-// # This program is free software: you can redistribute it and/or modify
-// # it under the terms of the GNU General Public License as published by
-// # the Free Software Foundation, either version 3 of the License, or
-// # (at your option) any later version.
-// #
-// # This program is distributed in the hope that it will be useful,
-// # but WITHOUT ANY WARRANTY; without even the implied warranty of
-// # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// # GNU General Public License for more details.
-// #
-// # You should have received a copy of the GNU General Public License
-// # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-// #
-// -%>
+//  CBRAIN Project
+//
+//  Copyright (C) 2008-2012
+//  The Royal Institution for the Advancement of Learning
+//  McGill University
+//
+//  This program is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  This program is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
 
-// JS to add indetermitate state to certanain checkboxes
+// JS to add indetermitate state to checkboxes with indeterninate style
 
 // indeterminate state on can be set with JS
 // all elements with empty value are set as indeterminate
@@ -31,9 +29,10 @@ jQuery(".show_table_edit_link").on("click",
         $(".dp_box.indeterminate").each(
             function () {
                 $(this).prop("indeterminate", true);
+                $(this).val("");
                 let prev = $(this).prev();
                 let val = prev.val();
-                if ( val != '' ) {
+                if ( val != "" ) {
                     prev.val("");
                 }
             }

--- a/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
+++ b/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
@@ -1,0 +1,78 @@
+//
+// <%-
+// #
+// # CBRAIN Project
+// #
+// # Copyright (C) 2008-2012
+// # The Royal Institution for the Advancement of Learning
+// # McGill University
+// #
+// # This program is free software: you can redistribute it and/or modify
+// # it under the terms of the GNU General Public License as published by
+// # the Free Software Foundation, either version 3 of the License, or
+// # (at your option) any later version.
+// #
+// # This program is distributed in the hope that it will be useful,
+// # but WITHOUT ANY WARRANTY; without even the implied warranty of
+// # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// # GNU General Public License for more details.
+// #
+// # You should have received a copy of the GNU General Public License
+// # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// #
+// -%>
+
+// JS to add indetermitate state to certanain checkboxes
+
+// indeterminate state on can be set with JS
+// all elements with empty value are set as indeterminate
+jQuery(".show_table_edit_link").on("click",
+    function() {
+        $(".dp_box.indeterminate").each(
+            function () {
+                $(this).prop("indeterminate", true);
+                let prev = $(this).prev();
+                let val = prev.val();
+                if ( val != '' ) {
+                    prev.val("");
+                }
+            }
+        );
+        $(".dp_box.indeterminate").click(
+            function () {
+                $(this).val('copy');
+                let prev = $(this).prev();
+                prev.val("disable");                            }
+        )
+
+
+
+
+    }
+);
+
+// make indeterminate elements determinate again
+jQuery(".show_table").on("click code-change", ".dp_box.indeterminate", function() {
+    $(this).each(function() {
+        // $(this).prop("indeterminate", false); // usually happens automatically
+        $(this).val('copy')
+        // change value of hidden element back to disabled
+        $(this).prev().val("disabled")
+    });
+});
+
+
+// makes indetermintate checkbox determinate
+// function determinize(el)  {
+//     el.prop("indeterminate", false);
+//     // change value of hidden element
+//     el.prev().val('copy');
+// }
+
+// all elements with empty value are set as indeterminate
+
+
+
+
+
+

--- a/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
+++ b/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
@@ -24,35 +24,35 @@
 
 // indeterminate state on can be set with JS
 // all elements with empty value are set as indeterminate
-jQuery(".show_table_edit_link").on("click",
-    function() {
+$(".show_table_edit_link").click(
+    function () {
         $(".dp_box.indeterminate").each(
             function () {
                 $(this).prop("indeterminate", true);
                 $(this).val("");
                 let prev = $(this).prev();
                 let val = prev.val();
-                if ( val != "" ) {
+                if (val == "disabled") {
                     prev.val("");
                 }
             }
-        );
+        )
+    }
+    );
+
+
         $(".dp_box.indeterminate").click(
             function () {
                 $(this).val('copy');
                 let prev = $(this).prev();
-                prev.val("disable");                            }
+                prev.val("disable");
+            }
         )
 
 
-
-
-    }
-);
-
 // make indeterminate elements determinate again
-jQuery(".show_table").on("click code-change", ".dp_box.indeterminate", function() {
-    $(this).each(function() {
+jQuery(".show_table").on("click code-change", ".dp_box.indeterminate", function () {
+    $(this).each(function () {
         // $(this).prop("indeterminate", false); // usually happens automatically
         $(this).val('copy')
         // change value of hidden element back to disabled

--- a/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
+++ b/BrainPortal/public/javascripts/cbrain/data_providers/tribox.js
@@ -29,7 +29,7 @@ $(".show_table_edit_link").click(
         $(".indeterminate").each(
             function () {
                 $(this).prop("indeterminate", true);
-                $(this).val("");
+                $(this).val(""); // checked indeterminate can still passes value
                 let prev = $(this).prev();
                 let val = prev.val();
                 if (val == "disabled") {
@@ -38,37 +38,17 @@ $(".show_table_edit_link").click(
             }
         )
     }
-    );
+);
 
 
-        $(".dp_box.indeterminate").click(
-            function () {
-                $(this).val('copy');
-                let prev = $(this).prev();
-                prev.val("disable");
-            }
-        )
+$(".indeterminate").click(
+    function () {
+        $(this).val('allowed');
+        let prev = $(this).prev();
+        prev.val("disabled");
+    }
+)
 
-
-// make indeterminate elements determinate again
-jQuery(".show_table").on("click code-change", ".dp_box.indeterminate", function () {
-    $(this).each(function () {
-        // $(this).prop("indeterminate", false); // usually happens automatically
-        $(this).val('copy')
-        // change value of hidden element back to disabled
-        $(this).prev().val("disabled")
-    });
-});
-
-
-// makes indetermintate checkbox determinate
-// function determinize(el)  {
-//     el.prop("indeterminate", false);
-//     // change value of hidden element
-//     el.prev().val('copy');
-// }
-
-// all elements with empty value are set as indeterminate
 
 
 


### PR DESCRIPTION
This aims to enhance the data provider restriction panel with toggles, default buttons, and a ternary checkbox (indeterminate, checked, unchecked states). Unlike the current logic, both whitelisting and blacklisting are employed for greater flexibility. See issue 
#1352, #1004

Note: The previous, more basic attempt (without whitelisting/tristate and default only applying to future data providers and servers) is located in dppolicy. Perhaps, somehow, it can be optimized by incorporating more convoluted logic (keeping default exclusion list rather than black or white list). However, tristate/black-and-white lists seem more efficient in terms of storage space. Additionally, maintaining the exclusion list in a meaningful and robust fashion might require more precautions for exceptions/failures, etc. (which would need further discussion). In particular when policy reversal takes place, in my opinion the exclusion list be replaced with it's compliment.  I am concerned that the resulting exclusion logic and code would be even more confusing than the presently suggested ternary approach.
