### PR TITLE
Added support for subset copying

### DIFF
--- a/BrainPortal/app/models/background_activity/copy_file.rb
+++ b/BrainPortal/app/models/background_activity/copy_file.rb
@@ -40,6 +40,15 @@ class BackgroundActivity::CopyFile < BackgroundActivity
     userfile     = Userfile.find(item)
     dest_dp_id   = self.options[:dest_data_provider_id]
     dest_dp      = DataProvider.find(dest_dp_id)
+
+    # This option is rarely used. The CBRAIN main interface
+    # doesn't provide any means of setting this. It is used
+    # by special external API calls that require copying of only a
+    # subset of a FileCollection. Also, only some specific
+    # types of destination DPs support the option.
+    userfile.sync_select_patterns = self.options[:sync_select_patterns] # can be nil
+
+    # Main operation and return status
     new_userfile = userfile.provider_copy_to_otherprovider(dest_dp, self.options || {})
     return [ true, new_userfile.id ] if new_userfile.is_a?(Userfile)
     return [ true, "Skipped"      ]  if new_userfile == true

--- a/BrainPortal/app/models/background_activity/copy_file_and_unregister.rb
+++ b/BrainPortal/app/models/background_activity/copy_file_and_unregister.rb
@@ -1,0 +1,37 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Copy a file, but the new copy is not left registered in the DB
+class BackgroundActivity::CopyFileAndUnregister < BackgroundActivity::CopyFile
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def process(item)
+    ok, userfile_id = super # CopyFile can return the ID or a string message
+    return [ ok, userfile_id ] if userfile_id.is_a?(String) # a message
+    userfile = Userfile.find(userfile_id)
+    userfile.unregister
+    [ true, "Copied" ]
+  end
+
+end
+

--- a/BrainPortal/app/models/data_provider.rb
+++ b/BrainPortal/app/models/data_provider.rb
@@ -392,11 +392,11 @@ class DataProvider < ApplicationRecord
     cb_error "Error: provider #{self.name} is not syncable."   if     self.not_syncable?
     cb_error "Error: file #{userfile.name} is immutable."      if     userfile.immutable?
     rr_allowed_syncing!("synchronize content to")
-    if alternate_source_path.present? && ! self.can_upload_directly_from_path?
+    if alternate_source_path.to_s.present? && ! self.can_upload_directly_from_path?
       cb_error "Provider #{self.name} does not support direct uploads."
     end
     final_status = 'InSync'
-    final_status = 'ProvNewer' if alternate_source_path.present? && self.can_upload_directly_from_path?
+    final_status = 'ProvNewer' if alternate_source_path.to_s.present? && self.can_upload_directly_from_path?
     SyncStatus.ready_to_copy_to_dp(userfile, final_status) do
       final_status == 'ProvNewer' ? # same test as the 'if' two lines above
         impl_sync_to_provider(userfile, alternate_source_path) :
@@ -635,6 +635,7 @@ class DataProvider < ApplicationRecord
       if userfile.is_a? FileCollection
         if directory == :all
           entries = Dir.glob(userfile.name + "/**/*")
+          #entries = Dir.glob(userfile.name + "/**/*", File::FNM_DOTMATCH).reject { |p| p.ends_with?("/.") || p.ends_with?("/..")}
         else
           directory = "." if directory == :top
           base_dir = Pathname.new(userfile.name) + directory

--- a/BrainPortal/app/models/userfile.rb
+++ b/BrainPortal/app/models/userfile.rb
@@ -99,6 +99,12 @@ class Userfile < ApplicationRecord
   # this flag is checked by a callback before_destroy()
   attr_accessor           :keep_dp_content_on_destroy
 
+  # Special array of file patterns when performing syncing of
+  # only a subset of the files in a FileCollection. Not a
+  # commonly used feature of the model, and this is used only
+  # by certain DataProvider types which understand these patterns.
+  attr_accessor           :sync_select_patterns
+
   # Utility named scopes
   scope :name_like,     -> (n) { where("userfiles.name LIKE ?", "%#{n.strip}%") }
 

--- a/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
+++ b/BrainPortal/config/console_rc/lib/wirble_hirb_looksee.rb
@@ -110,6 +110,13 @@ def htable(thingie, options={})
   table thingie, options.merge(:unicode => true, :headers => false)
 end
 
+def sql(command)
+  res = ApplicationRecord.connection.execute command
+  f   = res.fields
+  tab = res.to_a.unshift f
+  htable tab
+end
+
 (CbrainConsoleFeatures ||= []) << <<FEATURES
 ========================================================
 Feature: Hirb pretty model tables, and table helpers

--- a/BrainPortal/spec/models/ssh_data_provider_spec.rb
+++ b/BrainPortal/spec/models/ssh_data_provider_spec.rb
@@ -71,6 +71,7 @@ describe SshDataProvider do
       allow(Dir).to receive(:mkdir)
       allow(File).to receive(:directory?).and_return(true)
       allow(File).to receive(:exist?).and_return(true)
+      allow(provider).to receive(:rsync_select_pattern_options).and_return(nil)
     end
     context "for a FileCollection" do
       it "should check if the cache directory already exists" do


### PR DESCRIPTION
Includes a new BAC for copying with unregister at the end.
Subset copying works only for two DP types, SSH and S3,
and is only available through the dispatcher API.

Just read the code, point out any problem that is visible by reading it.