### PR TITLE
CBRAIN should not change data provider type arbitrary (in presence of missed or incorrect fields)

### DIFF
--- a/BrainPortal/app/views/data_providers/new.html.erb
+++ b/BrainPortal/app/views/data_providers/new.html.erb
@@ -56,7 +56,7 @@
     <span title="Type of data provider.">
 
       <p><%= f.label :type, "Type" %><br/>
-      <%= f.select :type, grouped_options_for_select(@typelist, selected_key=@provider.type), { :prompt => "Select Provider Type" }, { :disabled => (params[:action].to_sym == :edit) } %><br/>
+      <%= f.select :type, grouped_options_for_select(@typelist, @provider.type), { :prompt => "Select Provider Type" }, { :disabled => (params[:action].to_sym == :edit) } %><br/>
       <div class="field_explanation"><%= show_hide_toggle "(Data Provider Type Information)", "#data_provider_classes", :class  => 'action_link' %></div>
       </p>
 

--- a/BrainPortal/app/views/data_providers/new.html.erb
+++ b/BrainPortal/app/views/data_providers/new.html.erb
@@ -56,7 +56,7 @@
     <span title="Type of data provider.">
 
       <p><%= f.label :type, "Type" %><br/>
-      <%= f.select :type, grouped_options_for_select(@typelist), { :prompt => "Select Provider Type" }, { :disabled => (params[:action].to_sym == :edit) } %><br/>
+      <%= f.select :type, grouped_options_for_select(@typelist, selected_key=@provider.type), { :prompt => "Select Provider Type" }, { :disabled => (params[:action].to_sym == :edit) } %><br/>
       <div class="field_explanation"><%= show_hide_toggle "(Data Provider Type Information)", "#data_provider_classes", :class  => 'action_link' %></div>
       </p>
 


### PR DESCRIPTION
Makes sure that CBRAIN does not change new data provider type arbitrary due validation errors, such as supplying already existing name, missing it completely etc fixes #1406