### PR TITLE
More BackgroundActivity integrations

### DIFF
--- a/Bourreau/lib/bourreau_system_checks.rb
+++ b/Bourreau/lib/bourreau_system_checks.rb
@@ -470,6 +470,11 @@ class BourreauSystemChecks < CbrainChecker #:nodoc:
     puts "C> Starting Background Activity Workers..."
     #----------------------------------------------------------------------------
 
+    if ENV['CBRAIN_NO_BACKGROUND_ACTIVITY_WORKER'].present?
+      puts "C> \t- NOT started as env variable CBRAIN_NO_BACKGROUND_ACTIVITY_WORKER is set."
+      return
+    end
+
     worker_name = 'BourreauActivity'
     num_workers = 1 # hardcoded, usually that's enough for a Bourreau
 

--- a/BrainPortal/app/controllers/background_activities_controller.rb
+++ b/BrainPortal/app/controllers/background_activities_controller.rb
@@ -24,7 +24,7 @@ class BackgroundActivitiesController < ApplicationController
 
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
 
-  api_available :only => [ :show ]
+  api_available :only => [ :show, :index ]
 
   before_action :login_required
   before_action :admin_role_required,  :only => [:new, :create, :destroy]

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -615,7 +615,7 @@ class DataProvidersController < ApplicationController
     # Generate a complete response matching the old API
     flash[:notice]  = ""
     flash[:notice] += "Deleting #{exist_files.count} userfile(s) in background.\n"              if exist_files.present?
-    flash[:notice] += "Deleting #{unreg_basenames.count} unregistered files in background.\n" if unreg_basenames.present?
+    flash[:notice] += "Deleting #{unreg_basenames.count} unregistered file(s) in background.\n" if unreg_basenames.present?
     flash[:error]   = "No files selected, or that can be deleted." if exist_files.empty? && unreg_basenames.empty?
     api_response = generate_register_response.merge(
       :num_erased       => exist_files.size,

--- a/BrainPortal/app/controllers/data_providers_controller.rb
+++ b/BrainPortal/app/controllers/data_providers_controller.rb
@@ -494,7 +494,7 @@ class DataProvidersController < ApplicationController
     bac_klass = BackgroundActivity::RegisterAndCopyFile if post_action == :copy
     bac = bac_klass.setup!( # all three classes have this helper
       current_user.id, items.shuffle, RemoteResource.current_resource.id,
-      @provider.id, @browse_path, group_id, @as_user.id, target_dp # target_dp is ignored and is always nil for plain register
+      @provider.id, @browse_path, group_id, @as_user.id, target_dp&.id # for plain register, target_dp is ignored and is always nil
     ) if items.size > 0
 
     # Generate a complete response matching the old API

--- a/BrainPortal/app/models/background_activity.rb
+++ b/BrainPortal/app/models/background_activity.rb
@@ -200,13 +200,14 @@ class BackgroundActivity < ApplicationRecord
 
   # Utility builder: returns an object with user_ids and items pre-filled,
   # status set to 'InProgress', and remote_resource set to current resource.
-  def self.local_new(user_id, items, remote_resource_id=CBRAIN::SelfRemoteResourceId)
+  def self.local_new(user_id, items, remote_resource_id=CBRAIN::SelfRemoteResourceId, options={})
     remote_resource_id ||= CBRAIN::SelfRemoteResourceId
     self.new(
       :status             => 'InProgress',
       :user_id            => user_id,
       :items              => Array(items),
       :remote_resource_id => remote_resource_id,
+      :options            => options,
     )
   end
 

--- a/BrainPortal/app/models/background_activity.rb
+++ b/BrainPortal/app/models/background_activity.rb
@@ -217,20 +217,23 @@ class BackgroundActivity < ApplicationRecord
 
     return false if self.status != 'InProgress'
 
-    # Find current item
+    # Find current index
     idx  = self.current_item
-    item = self.items[idx]
-    return false if item.nil?
 
     # Callback where a subclass can do some special stuff
     # before the first item.
     begin
-      self.before_first_item if idx == 0
-    rescue => ex
-      self.status = 'InternalError'
+      self.prepare_dynamic_items if idx == 0 && self.is_configured_for_dynamic_items?
+      self.before_first_item     if idx == 0
       self.save
+    rescue => ex
+      self.internal_error!
       return false
     end
+
+    # Find current item
+    item = self.items[idx]
+    return false if item.nil?
 
     # Main processing handler
     ok,message = nil,nil
@@ -264,9 +267,9 @@ class BackgroundActivity < ApplicationRecord
     # after the last item.
     begin
       self.after_last_item if self.current_item >= items.size
-    rescue => ex
-      self.status = 'InternalError'
       self.save
+    rescue => ex
+      self.internal_error!
       return false
     end
 
@@ -315,6 +318,12 @@ class BackgroundActivity < ApplicationRecord
     self.update_column(:status, 'InProgress')         if self.status == 'Suspended'
     self.update_column(:status, 'Scheduled')          if self.status == 'SuspendedScheduled'
     self.status.match(/InProgress|Scheduled/)
+  end
+
+  def internal_error!
+    self.update_column(:status, "InternalError")
+    self.update_column(:handler_lock, nil)
+    self.save
   end
 
   ###########################################
@@ -415,8 +424,7 @@ class BackgroundActivity < ApplicationRecord
     ).where(
       "updated_at < ?", older_than.ago
     ).each do |bac|
-      bac.update_column(:status,       'InternalError')
-      bac.update_column(:handler_lock, nil)
+      bac.internal_error!
     end
   end
 
@@ -484,7 +492,7 @@ class BackgroundActivity < ApplicationRecord
     end
 
     # The repeat attribute has a value we don't understand
-    self.update_column(:status, 'InternalError')
+    self.internal_error!
 
   end
 

--- a/BrainPortal/app/models/background_activity/copy_file.rb
+++ b/BrainPortal/app/models/background_activity/copy_file.rb
@@ -50,6 +50,9 @@ class BackgroundActivity::CopyFile < BackgroundActivity
 
     # Main operation and return status
     new_userfile = userfile.provider_copy_to_otherprovider(dest_dp, self.options || {})
+
+    DataUsage.increase_copies(self.user, userfile) if new_userfile.is_a?(Userfile)
+
     return [ true, new_userfile.id ] if new_userfile.is_a?(Userfile)
     return [ true, "Skipped"      ]  if new_userfile == true
     return [ false, "Failed to copy '#{userfile.name}'" ]

--- a/BrainPortal/app/models/background_activity/destroy_file.rb
+++ b/BrainPortal/app/models/background_activity/destroy_file.rb
@@ -27,6 +27,13 @@ class BackgroundActivity::DestroyFile < BackgroundActivity
 
   validates_dynamic_bac_presence_of_option :userfile_custom_filter_id
 
+  # Helper for scheduling a destroy of files immediately.
+  def self.setup!(user_id, userfile_ids, remote_resource_id=nil)
+    ba         = self.local_new(user_id, userfile_ids, remote_resource_id)
+    ba.save!
+    ba
+  end
+
   def process(item)
     userfile     = Userfile.find(item)
     ok           = userfile.destroy

--- a/BrainPortal/app/models/background_activity/destroy_unregistered_file.rb
+++ b/BrainPortal/app/models/background_activity/destroy_unregistered_file.rb
@@ -1,0 +1,66 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Destroy files that are not even registered.
+# Basenames are provided as an items list.
+class BackgroundActivity::DestroyUnregisteredFile < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def pretty_name
+    cnt         = self.items.size
+    source_name = DataProvider.where(:id => self.options[:src_data_provider_id]).first&.name || "Unknown"
+    "Destroy #{cnt} unregistered file#{cnt > 1 ? 's' : ''} on #{source_name}"
+  end
+
+  # Helper for scheduling a destruction of unregistered files immediately.
+  def self.setup!(user_id, basenames, remote_resource_id, src_data_provider_id, browse_path)
+    ba         = self.local_new(user_id, basenames, remote_resource_id)
+    ba.options = {
+      :src_data_provider_id => src_data_provider_id,
+      :browse_path          => browse_path,
+    }
+    ba.save!
+    ba
+  end
+
+  def process(item)  # item is a basename like "abcd.xyz"
+    src_dp_id   = self.options[:src_data_provider_id]
+    browse_path = self.options[:browse_path].presence
+    dp          = DataProvider.find(src_dp_id)
+    user        = User.admin
+    group       = user.own_group
+
+    temporary   = FileCollection.new(
+      :name             => item,
+      :user_id          => user.id,
+      :group_id         => group.id,
+      :data_provider_id => dp.id,
+      :browse_path      => browse_path,
+    ).fake_record!
+
+    result = dp.provider_erase(temporary)
+    [ result, nil ] # no messages ever
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/duplicate_task.rb
+++ b/BrainPortal/app/models/background_activity/duplicate_task.rb
@@ -1,0 +1,41 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Duplicate a CBRAIN task.
+# The options hash should contain dup_bourreau_id,
+# otherwise duplication will occur on the same Bourreau
+# as the tasks.
+class BackgroundActivity::DuplicateTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def process(item)
+    task         = CbrainTask.real_tasks.find(item)
+    new_bid      = options[:dup_bourreau_id].presence || task.bourreau_id
+    new_bourreau = Bourreau.find(new_bid)
+    ok           = task.duplicate!(new_bourreau)
+    return [ true,  "Duplicated" ] if   ok
+    return [ false, "Skipped"    ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/file_on_provider_is_newer.rb
+++ b/BrainPortal/app/models/background_activity/file_on_provider_is_newer.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Flag that files are potentionally newer on
+# the DataProvider than whatever is currently in the
+# cache. The cached data is not affected.
+class BackgroundActivity::FileOnProviderIsNewer < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  validates_dynamic_bac_presence_of_option :userfile_custom_filter_id
+
+  # Helper for scheduling a batch mark-as-newer operation immediately
+  def self.setup!(user_id, userfile_ids, remote_resource_id=nil)
+    ba         = self.local_new(user_id, userfile_ids, remote_resource_id)
+    ba.save!
+    ba
+  end
+
+  def process(item)
+    Userfile.find(item).provider_is_newer
+    [ true,  "Ok" ]
+  end
+
+  def prepare_dynamic_items
+    populate_items_from_userfile_custom_filter
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/hold_task.rb
+++ b/BrainPortal/app/models/background_activity/hold_task.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Holds a CBRAIN task. This is the cluster operation of
+# holding a job currently Queued
+#
+# This is part of a set of four cluster operations
+# that, within CBRAIN, have no supporting interface elements
+# or API calls:
+#
+#   suspend, resume, hold, release
+#
+# This is implemented for the sake of completing the official
+# CBRAIN low-level job control features.
+class BackgroundActivity::HoldTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task  = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    ok    = task.hold
+    task.addlog("New status: #{task.status}") if ok
+    return [ true,  "Resumed" ] if   ok
+    return [ false, "Skipped" ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/recover_task.rb
+++ b/BrainPortal/app/models/background_activity/recover_task.rb
@@ -1,0 +1,50 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Recover a CBRAIN task. This is the CBRAIN operation
+# that trigger error recovery code and salvages
+# a failed task, if possible.
+class BackgroundActivity::RecoverTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task       = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    old_status = task.status
+    ok         = task.recover
+    task.addlog("New status: #{task.status}") if ok && (old_status != task.status)
+    return [ true,  "Retrying" ] if   ok
+    return [ false, "Skipped"  ] if ! ok
+  end
+
+  def after_last_item
+    pool = WorkerPool.find_pool(BourreauWorker)
+    pool.wake_up_workers
+    true
+  rescue => ex
+    Rails.log.debug "AfterLastItem of #{self.class} raised #{ex.class}: #{ex.message}"
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/register_and_copy_file.rb
+++ b/BrainPortal/app/models/background_activity/register_and_copy_file.rb
@@ -51,8 +51,7 @@ class BackgroundActivity::RegisterAndCopyFile < BackgroundActivity::RegisterFile
     userfile    = Userfile.find(userfile_id)
     dest_dp     = DataProvider.find(dest_dp_id)
     newfile     = userfile.provider_copy_to_otherprovider(dest_dp)
-    userfile.keep_dp_content_on_destroy = true
-    userfile.destroy
+    userfile.unregister # we leave the original content on the DP, but not registered.
     [ true, newfile.id ]
   end
 

--- a/BrainPortal/app/models/background_activity/register_file.rb
+++ b/BrainPortal/app/models/background_activity/register_file.rb
@@ -32,13 +32,16 @@ class BackgroundActivity::RegisterFile < BackgroundActivity
   end
 
   # Helper for scheduling a registration of the files immediately.
-  def self.setup!(user_id, type_dash_names, remote_resource_id, src_data_provider_id, browse_path, group_id, as_user_id)
+  # Note that the argument +dest_data_provider_id+ is always ignored
+  # but it is declared to make this method's signature identical to
+  # the setup!() method defined in subclasses.
+  def self.setup!(user_id, type_dash_names, remote_resource_id, src_data_provider_id, browse_path, group_id, as_user_id, dest_data_provider_id=nil)
     ba         = self.local_new(user_id, type_dash_names, remote_resource_id)
     ba.options = {
       :src_data_provider_id => src_data_provider_id,
-      :browse_path             => browse_path,
-      :as_user_id              => (as_user_id || user_id),
-      :group_id                => group_id,
+      :browse_path          => browse_path,
+      :as_user_id           => (as_user_id || user_id),
+      :group_id             => group_id,
     }
     ba.save!
     ba

--- a/BrainPortal/app/models/background_activity/release_task.rb
+++ b/BrainPortal/app/models/background_activity/release_task.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Releases a CBRAIN task. This is the cluster operation of
+# releasing a job currently On Hold
+#
+# This is part of a set of four cluster operations
+# that, within CBRAIN, have no supporting interface elements
+# or API calls:
+#
+#   suspend, resume, hold, release
+#
+# This is implemented for the sake of completing the official
+# CBRAIN low-level job control features.
+class BackgroundActivity::ReleaseTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task  = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    ok    = task.release
+    task.addlog("New status: #{task.status}") if ok
+    return [ true,  "Resumed" ] if   ok
+    return [ false, "Skipped" ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/restart_task.rb
+++ b/BrainPortal/app/models/background_activity/restart_task.rb
@@ -1,0 +1,53 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Restart a CBRAIN task. This is the CBRAIN operation
+# that trigger restarting code at three possible
+# stages of an already Completed task. The
+# value of options[:atwhat] must be one of
+# 'Setup', 'Cluster' or 'PostProcess'
+class BackgroundActivity::RestartTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task       = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    atwhat     = options[:atwhat]
+    old_status = task.status
+    ok         = task.restart(atwhat)
+    task.addlog("New status: #{task.status}") if ok && (old_status != task.status)
+    return [ true,  "Restarting" ] if   ok
+    return [ false, "Skipped"    ] if ! ok
+  end
+
+  def after_last_item
+    pool = WorkerPool.find_pool(BourreauWorker)
+    pool.wake_up_workers
+    true
+  rescue => ex
+    Rails.log.debug "AfterLastItem of #{self.class} raised #{ex.class}: #{ex.message}"
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/resume_task.rb
+++ b/BrainPortal/app/models/background_activity/resume_task.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Resume a CBRAIN task. This is the cluster operation of
+# resuming a job currently Suspended
+#
+# This is part of a set of four cluster operations
+# that, within CBRAIN, have no supporting interface elements
+# or API calls:
+#
+#   suspend, resume, hold, release
+#
+# This is implemented for the sake of completing the official
+# CBRAIN low-level job control features.
+class BackgroundActivity::ResumeTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task  = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    ok    = task.resume
+    task.addlog("New status: #{task.status}") if ok
+    return [ true,  "Resumed" ] if   ok
+    return [ false, "Skipped" ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/save_task_workdir.rb
+++ b/BrainPortal/app/models/background_activity/save_task_workdir.rb
@@ -1,0 +1,36 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Saves the workdir of a CBRAIN task as a userfile.
+class BackgroundActivity::SaveTaskWorkdir < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def process(item)
+    task  = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    ok    = task.send(:save_cluster_workdir, self.user_id) # it's a protected method
+    return [ true,  "Saved"   ] if   ok
+    return [ false, "Skipped" ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/suspend_task.rb
+++ b/BrainPortal/app/models/background_activity/suspend_task.rb
@@ -1,0 +1,49 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Suspend a CBRAIN task. This is the cluster operation of
+# suspending a job currently On CPU.
+#
+# This is part of a set of four cluster operations
+# that, within CBRAIN, have no supporting interface elements
+# or API calls:
+#
+#   suspend, resume, hold, release
+#
+# This is implemented for the sake of completing the official
+# CBRAIN low-level job control features.
+class BackgroundActivity::SuspendTask < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  before_save :must_be_on_bourreau!
+
+  def process(item)
+    task  = CbrainTask.where(:bourreau_id => CBRAIN::SelfRemoteResourceId).find(item)
+    ok    = task.suspend
+    task.addlog("New status: #{task.status}") if ok
+    return [ true,  "Suspended" ] if   ok
+    return [ false, "Skipped"   ] if ! ok
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/sync_file.rb
+++ b/BrainPortal/app/models/background_activity/sync_file.rb
@@ -1,0 +1,47 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2024
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# Sync files to the local cache
+class BackgroundActivity::SyncFile < BackgroundActivity
+
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  validates_dynamic_bac_presence_of_option :userfile_custom_filter_id
+
+  # Helper for scheduling a mass sync_to_cache immediately.
+  def self.setup!(user_id, userfile_ids, remote_resource_id=nil)
+    ba         = self.local_new(user_id, userfile_ids, remote_resource_id)
+    ba.save!
+    ba
+  end
+
+  def process(item)
+    Userfile.find(item).sync_to_cache
+    [ true,  "Ok" ]
+  end
+
+  def prepare_dynamic_items
+    populate_items_from_userfile_custom_filter
+  end
+
+end
+

--- a/BrainPortal/app/models/background_activity/uncompress_file.rb
+++ b/BrainPortal/app/models/background_activity/uncompress_file.rb
@@ -41,10 +41,22 @@ class BackgroundActivity::UncompressFile < BackgroundActivity
   end
 
   def process_single_file(userfile)
+
     return [ false, "File is under transfer" ] if
       userfile.sync_status.to_a.any? { |ss| ss.status =~ /^To/ }
+
     return [ false, "File is not compressed" ] if
       userfile.name !~ /\.gz\z/i
+
+    collision = userfile.class.where(
+        :name             => userfile.name.sub(/\.gz\z/i,""),
+        :data_provider_id => userfile.data_provider_id,
+        :browse_path      => userfile.browse_path,
+      )
+    collision = collision.where(:user_id => userfile.user_id) if                                                                    ! userfile.data_provider.content_storage_shared_between_users?
+    return [ false, "Another GZ file already exists" ] if
+      collision.exists?
+
     userfile.gzip_content(:uncompress)
     [ true, "Uncompressed" ]
   end

--- a/BrainPortal/app/models/background_activity/unregister_file.rb
+++ b/BrainPortal/app/models/background_activity/unregister_file.rb
@@ -40,8 +40,7 @@ class BackgroundActivity::UnregisterFile < BackgroundActivity
       userfile.sync_status.to_a.any? { |ss| ss.status =~ /^To/ }
     return [ false, "File is not on a browsable DataProvider" ] if
       ! userfile.data_provider.is_browsable?
-    userfile.keep_dp_content_on_destroy = true
-    ok = userfile.destroy # only remove entries from DB, does not affect file content
+    ok = userfile.unregister # only remove entries from DB, does not affect file content
     [ ok, "Unregistered" ]
   end
 

--- a/BrainPortal/app/models/background_activity_worker.rb
+++ b/BrainPortal/app/models/background_activity_worker.rb
@@ -28,6 +28,10 @@ class BackgroundActivityWorker < Worker
   # Currently hardcoded, maybe one day it will be configurable.
   BAC_SLICE_TIME=5.seconds
 
+  # Any BAC that had a lock on it and has not been updated in
+  # this amount of time is considered 'dead' (process died?)
+  BAC_IS_DEAD_TIME=12.hours
+
   def setup
     @myself    = RemoteResource.current_resource
     @myself_id = @myself.id
@@ -62,6 +66,7 @@ class BackgroundActivityWorker < Worker
     return unless main_process_is_alive?
 
     BackgroundActivity.activate_scheduled(@myself_id)
+    BackgroundActivity.cancel_crashed(@myself_id, BAC_IS_DEAD_TIME)
 
     # All the activity ready on this CBRAIN component
     todo = BackgroundActivity.where(

--- a/BrainPortal/app/models/bourreau.rb
+++ b/BrainPortal/app/models/bourreau.rb
@@ -442,6 +442,14 @@ class Bourreau < RemoteResource
     cb_error "Got control command #{command.command} but I'm not a Bourreau!" unless
       myself.is_a?(Bourreau)
 
+Message.send_message(:admin,
+   :message_type => :system,
+   :header => "Bourreau #{myself.name} got AlterTask",
+   :description => "This is to track a deprecated piece of code, we should not get this.",
+   :critical => true,
+   :variable_text => command.inspect,
+)
+
     # 'taskids' is an array of tasks to process.
     # 'newstatus', as received in the command object, is not
     # necessarily an official legal task status name, it can be a

--- a/BrainPortal/app/models/boutiques_cluster_task.rb
+++ b/BrainPortal/app/models/boutiques_cluster_task.rb
@@ -74,7 +74,9 @@ class BoutiquesClusterTask < ClusterTask
 
   def setup #:nodoc:
     descriptor = self.descriptor_for_setup
-    self.addlog(descriptor.file_revision_info.format("%f rev. %s %a %d"))
+
+    self.addlog(Revision_info.format("%f rev. %s %a %d"))
+    self.addlog(self.boutiques_descriptor.file_revision_info.format("%f rev. %s %a %d"))
 
     descriptor.file_inputs.each do |input|
       userfile_id = invoke_params[input.id]
@@ -188,6 +190,9 @@ class BoutiquesClusterTask < ClusterTask
 
   def save_results #:nodoc:
     descriptor = self.descriptor_for_save_results
+
+    self.addlog(Revision_info.format("%f rev. %s %a %d"))
+
     custom     = descriptor.custom || {} # 'custom' is not packaged as an object, just a hash
 
     # Verifications of proper exit status

--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -264,8 +264,9 @@ class BoutiquesPortalTask < PortalTask
   # Final set of tasks to be launched based on this task's parameters.
   def final_task_list #:nodoc:
     descriptor = self.descriptor_for_final_task_list
-    self.addlog(descriptor.file_revision_info.format("%f rev. %s %a %d"))
-    valid_input_keys = descriptor.inputs.map(&:id)
+
+    self.addlog(Revision_info.format("%f rev. %s %a %d"))
+    self.addlog(self.boutiques_descriptor.file_revision_info.format("%f rev. %s %a %d"))
 
     # Add author(s) information
     authors = Array(descriptor.custom['cbrain:author'])
@@ -277,6 +278,8 @@ class BoutiquesPortalTask < PortalTask
     boutiques_module_information().each do |log_info|
        self.addlog(log_info)
     end
+
+    valid_input_keys = descriptor.inputs.map(&:id)
 
     # --------------------------------------
     # Special case where there is a single file input

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -2059,7 +2059,7 @@ exit $status
 
   # Save the directory created to run the job.
   # The directory will be saved as a FileCollection
-  # only if the task have a results Data Provider.
+  # only if the task has a results Data Provider.
   def save_cluster_workdir(user_id)
     full_cluster_workdir = self.full_cluster_workdir
     user                 = User.find(user_id)

--- a/BrainPortal/app/views/background_activities/_background_activity_table.html.erb
+++ b/BrainPortal/app/views/background_activities/_background_activity_table.html.erb
@@ -24,7 +24,6 @@
 
 <div class="menu_bar">
   <%= show_hide_toggle "About", ".bac_explanations", :class => 'button', :slide_effect => true, :slide_duration => 'fast'  %>
-  <%= link_to "Refresh This List", background_activities_path, :class => "button" %>
   <%= external_submit_button "Cancel Activities", "bac_form", :class  => "button", :confirm  => "Are you sure you want to cancel the selected background activities?" %>
   <% if current_user.has_role? :admin_user %>
     <%= external_submit_button "Suspend Activities", "bac_form", :class  => "button", :confirm  => "Are you sure you want to suspend the selected background activities?" %>
@@ -39,6 +38,7 @@
         )
     %>
   <% end %>
+  <%= link_to "Refresh This List", background_activities_path, :class => "button" %>
 </div>
 
 <fieldset class="bac_explanations" style="display: none">

--- a/BrainPortal/app/views/background_activities/_background_activity_table.html.erb
+++ b/BrainPortal/app/views/background_activities/_background_activity_table.html.erb
@@ -41,7 +41,7 @@
   <%= link_to "Refresh This List", background_activities_path, :class => "button" %>
 </div>
 
-<fieldset class="bac_explanations" style="display: none">
+<fieldset class="bac_explanations" style="display: <%= @bacs.count == 0 ? 'block' : 'none' %>">
   <legend>About Background Activities</legend>
   <p class="long_paragraphs">
   This page shows "background activities" as progress bars. Each

--- a/BrainPortal/app/views/layouts/_section_menu.html.erb
+++ b/BrainPortal/app/views/layouts/_section_menu.html.erb
@@ -129,8 +129,7 @@
            </li>
          <% end %>
 
-         <% # if !current_user.has_role?(:normal_user) || (cbrain_session[:active_group_id] && !(params[:controller] == "groups" && params[:action] == "index")) %>
-         <% if current_user.has_role?(:admin_user) %>
+         <% if !current_user.has_role?(:normal_user) || (cbrain_session[:active_group_id] && !(params[:controller] == "groups" && params[:action] == "index")) %>
            <li <%= set_selected(params[:controller], :background_activities) %>>
              <%=
                label = 'Ongoing'; label_class = ""

--- a/BrainPortal/spec/controllers/userfiles_controller_spec.rb
+++ b/BrainPortal/spec/controllers/userfiles_controller_spec.rb
@@ -247,19 +247,13 @@ RSpec.describe UserfilesController, :type => :controller do
         allow(controller).to    receive(:current_user).and_return(admin)
         allow(mock_userfile).to receive(:local_sync_status).and_return(mock_status)
         allow(Userfile).to      receive(:find_accessible_by_user).and_return([mock_userfile])
-        allow(CBRAIN).to        receive(:spawn_with_active_records).and_yield
       end
 
       it "should sync the file to the cache if it is in a valid state" do
-        expect(mock_userfile).to receive(:sync_to_cache)
+        expect(BackgroundActivity::SyncFile).to receive(:setup!)
         get :sync_multiple, params: {file_ids: [1]}
       end
 
-      it "should not sync the file to the cache if it is not in a valid state" do
-        allow(mock_status).to receive_message_chain(:status).and_return("InSync")
-        expect(mock_userfile).not_to receive(:sync_to_cache)
-        get :sync_multiple, params: {file_ids: [1]}
-      end
     end
 
 
@@ -702,13 +696,12 @@ RSpec.describe UserfilesController, :type => :controller do
         allow(admin).to         receive(:license_agreement_set).and_return([])
         allow(admin).to         receive(:unsigned_license_agreements).and_return([])
         allow(DataProvider).to  receive_message_chain(:find_all_accessible_by_user, :where, :first).and_return(mock_model(DataProvider).as_null_object)
-        allow(CBRAIN).to        receive(:spawn_with_active_records).and_yield
         allow(Userfile).to      receive(:find_accessible_by_user).and_return(mock_userfile)
-        allow(mock_userfile).to receive(:provider_move_to_otherprovider)
-        allow(mock_userfile).to receive(:provider_copy_to_otherprovider)
+        allow(BackgroundActivity::CopyFile).to receive(:setup!).and_return(nil)
+        allow(BackgroundActivity::MoveFile).to receive(:setup!).and_return(nil)
       end
 
-      context "when the other data povider is not found" do
+      context "when the other data provider is not found" do
         before(:each) do
           allow(DataProvider).to receive_message_chain(:find_all_accessible_by_user, :where, :first).and_return(nil)
         end
@@ -724,45 +717,32 @@ RSpec.describe UserfilesController, :type => :controller do
         end
       end
 
+
       context "when moving a file" do
 
         it "should check if the user has owner access" do
-          expect(mock_userfile).to receive(:has_owner_access?)
+          expect(Userfile).to receive_message_chain(:find, :has_owner_access?)
           post :change_provider, params: {:file_ids => [1], :move => true, :data_provider_id_for_mv_cp => data_provider.id}
         end
 
         it "should attempt to move the file if the user has owner access" do
-          allow(mock_userfile).to receive(:has_owner_access?).and_return(true)
-          expect(mock_userfile).to receive(:provider_move_to_otherprovider)
+          allow(Userfile).to receive_message_chain(:find, :has_owner_access?).and_return(true)
+          expect(BackgroundActivity::MoveFile).to receive(:setup!)
           post :change_provider, params: {:file_ids => [1], :move => true, :data_provider_id_for_mv_cp => data_provider.id}
         end
 
-        it "should not attempt to move the file if the user does not have owner access" do
-          allow(mock_userfile).to receive(:has_owner_access?).and_return(false)
-          expect(mock_userfile).not_to receive(:provider_move_to_otherprovider)
-          post :change_provider, params: {:file_ids => [1], :move => true, :data_provider_id_for_mv_cp => data_provider.id}
+      end
+
+      context "when copying a file" do
+        it "should attempt to copy the file when requested" do
+          expect(BackgroundActivity::CopyFile).to receive(:setup!)
+          post :change_provider, params: {:file_ids => [1], :copy => true, :data_provider_id_for_mv_cp => data_provider.id}
         end
-      end
-
-      it "should attempt to copy the file when requested" do
-        expect(mock_userfile).to receive(:provider_copy_to_otherprovider)
-        post :change_provider, params: {:file_ids => [1], :copy => true, :data_provider_id_for_mv_cp => data_provider.id}
-      end
-
-      it "should send message about successes" do
-        allow(mock_userfile).to receive(:provider_copy_to_otherprovider).and_return(true)
-        expect(Message).to receive(:send_message).with(anything, hash_including(:message_type  => :notice))
-        post :change_provider, params: {:file_ids => [1], :copy => true, :data_provider_id_for_mv_cp => data_provider.id}
-      end
-
-      it "should send message about failures" do
-        allow(mock_userfile).to receive(:provider_copy_to_otherprovider).and_return(false)
-        expect(Message).to receive(:send_message).with(anything, hash_including(:message_type  => :error))
-        post :change_provider, params: {:file_ids => [1], :copy => true, :data_provider_id_for_mv_cp => data_provider.id}
       end
 
       it "should display a flash message" do
-        post :change_provider, params: {:file_ids => [1], :data_provider_id_for_mv_cp => data_provider.id}
+        allow(Userfile).to receive_message_chain(:find, :has_owner_access?).and_return(true)
+        post :change_provider, params: {:file_ids => [1], :move => true, :data_provider_id_for_mv_cp => data_provider.id}
         expect(flash[:notice]).to match(/Your files are being .+ in the background/)
       end
 
@@ -777,25 +757,25 @@ RSpec.describe UserfilesController, :type => :controller do
       before(:each) do
         session[:session_id] = 'session_id'
         allow(controller).to    receive(:current_user).and_return(admin)
-        allow(CBRAIN).to        receive(:spawn_with_active_records).and_yield
       end
 
       it "should display error message if userfiles is not accessible by user" do
         allow(controller).to    receive(:current_user).and_return(user)
-        delete :delete_files, params: {:file_ids => [admin_userfile.id]}
+        delete :delete_files, params: {:file_ids => [user_userfile.id, admin_userfile.id]}
         expect(flash[:error]).to match("not have acces")
       end
 
       it "should destroy the userfiles" do
         allow(Userfile).to receive(:find).and_return(admin_userfile)
-        expect(admin_userfile).to receive(:destroy)
+        expect(BackgroundActivity::DestroyFile).to receive(:setup!)
         delete :delete_files, params: {:file_ids => [admin_userfile.id]}
       end
 
       it "should announce that files are being deleted in the background" do
         allow(mock_userfile).to receive_message_chain(:data_provider, :is_browsable?).and_return(false)
         allow(mock_userfile).to receive_message_chain(:data_provider, :meta, :[], :blank?).and_return(false)
-        delete :delete_files, params: {:file_ids => [1]}
+        allow(BackgroundActivity::DestroyFile).to receive(:setup!).and_return(nil)
+        delete :delete_files, params: {:file_ids => [admin_userfile.id]}
         expect(flash[:notice]).to match("deleted in background")
       end
 
@@ -938,15 +918,12 @@ RSpec.describe UserfilesController, :type => :controller do
 
 
       context "when compressing" do
-        before(:each) do
-          allow(CBRAIN).to     receive(:spawn_with_active_records).and_yield
-        end
 
         it "should call gzip_content method" do
           data_provider           = DataProvider.find(user_userfile.data_provider_id)
           data_provider.read_only = false
           data_provider.save
-          expect(Process).to receive(:setproctitle).with(/GzipFile ID=#{user_userfile.id}/) # Ah! what a test!
+          expect(BackgroundActivity::CompressFile).to receive(:setup!)
           post :compress, params: {:file_ids => [user_userfile.id]}
         end
 

--- a/BrainPortal/test_api/req_files/userfiles/11-dp-delete_files.out
+++ b/BrainPortal/test_api/req_files/userfiles/11-dp-delete_files.out
@@ -1,2 +1,2 @@
 200 application/json we_will_delete_all_after_first_comma ,.*
-{"notice":"Deleting 2 userfile(s) in background.\n","error":null,"newly_registered_userfiles":[],"previously_registered_userfiles":[],"userfiles_in_transit":[],"num_unregistered":0,"num_erased":2}
+{"notice":"Deleting 2 unregistered file(s) in background.\n","error":null,"newly_registered_userfiles":[],"previously_registered_userfiles":[],"userfiles_in_transit":[],"num_unregistered":0,"num_erased":2}


### PR DESCRIPTION
This PR provides BackgroundActivity replacements for the following user-initiated operations:

1. Register files
2. Register files and copy
3. Register files and move
4. Unregister files
5. Erase unregistered files (*)
6. Erase registered files
7. Terminate tasks
8. Archive task workdirs
9. Unarchive task workdirs
10. Remove task workdirs
11. Save task workdirs (*)
12. Hold/Release tasks (*)
13. Suspend/Resume tasks
14. Duplicate tasks (*)
15. Recover tasks from failure (*)
16. Restart tasks (at three stages) (*)
17. Mass sync files (*)
18. Mass mark_as_newer on files (*)
19. Copy files to other provider
20. Move files to other provider
21. Compress files
22. Uncompress files

These features were originally performed with `spawn_with_active_records()`.

The activities labelled with (*) indicate a new BackgroundActivity model was added by the PR.

The background activity framework itself is also enhanced a little. Workers detect 'dead' BACs if they have not been updated in 12 hours.

