### PR TITLE
Error codes support in boutiques

### DIFF
--- a/BrainPortal/app/models/boutiques_cluster_task.rb
+++ b/BrainPortal/app/models/boutiques_cluster_task.rb
@@ -211,6 +211,10 @@ class BoutiquesClusterTask < ClusterTask
         cb_error "Exit status file #{exit_status_filename()} has unexpected content"
       end
       status = out.strip.to_i
+      descriptor.error_codes ||= []
+      descriptor.error_codes.each do |err|  # note, 0 code is supported by boutiques
+        self.addlog err['description'] if err['code'] == status
+      end
       if exit_status_means_failure?(status)
         self.addlog "Command failed, exit status #{status}"
         return false

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -438,11 +438,6 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 %   end
       else # Check exit status value
         exit_status = status_file_content.to_i
-        # provide explanations for exit statuses (if any):
-        <% descriptor['error-codes']&.each do |err| %>
-          self.addlog(<%=err["description"].inspect %>)  if <%= err['code'].to_i %> == exit_status  # with escaping
-        <% end %>
-
         unless SystemExit.new(exit_status).success?
           self.addlog("Command failed, exit status #{exit_status}")
 %   if outputs.empty?

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -440,7 +440,7 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
         exit_status = status_file_content.to_i
         # provide explanations for exit statuses (if any):
         <% descriptor['error-codes']&.each do |err| %>
-          self.addlog '<%=err["description"].gsub("'", '"').gsub(/\R|\\/, ' ')%>'  if <%= err['code'].to_i %> == exit_status
+          self.addlog(<%=err["description"].inspect %>)  if <%= err['code'].to_i %> == exit_status  # with escaping
         <% end %>
 
         unless SystemExit.new(exit_status).success?

--- a/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
+++ b/BrainPortal/lib/cbrain_task_generators/templates/bourreau.rb.erb
@@ -438,6 +438,11 @@ class CbrainTask::<%= name %> < <%= (descriptor['custom'] || {})['cbrain:inherit
 %   end
       else # Check exit status value
         exit_status = status_file_content.to_i
+        # provide explanations for exit statuses (if any):
+        <% descriptor['error-codes']&.each do |err| %>
+          self.addlog '<%=err["description"].gsub("'", '"').gsub(/\R|\\/, ' ')%>'  if <%= err['code'].to_i %> == exit_status
+        <% end %>
+
         unless SystemExit.new(exit_status).success?
           self.addlog("Command failed, exit status #{exit_status}")
 %   if outputs.empty?


### PR DESCRIPTION
see https://github.com/aces/cbrain/issues/1432

I created few test boutiques https://github.com/MontrealSergiy/cbrain-plugins-test/tree/errorcodes. (might fail due to lack of bash in alpine docker, but just add container-free config).