### PR TITLE
File name verifier

### DIFF
--- a/Bourreau/lib/boutiques_file_name_verifier.rb
+++ b/Bourreau/lib/boutiques_file_name_verifier.rb
@@ -1,0 +1,1 @@
+../../BrainPortal/lib/boutiques_file_name_verifier.rb

--- a/BrainPortal/lib/boutiques_file_name_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_name_verifier.rb
@@ -23,7 +23,7 @@
 # This module adds automatic verification of the
 # files (or directories ) names generated as output, which comply with CBRAIN restrictions.
 #
-# For exmaple, in the "inputs" section:
+# For example, in the "inputs" section:
 #
 #   {
 #     "description": "The name of the folder to store outputs of XCPD processing.",
@@ -35,28 +35,9 @@
 #     "default-value": "xcpd_output"
 #   }
 #
-# and in the "output-files" section:
-#
-#   {
-#     "name": "XCPD Subject Output Directory",
-#     "id":  "xcpd_output_dir",
-#     "description": "Subject level output for XCP-D",
-#     "optional":  false,
-#     "path-template": "[OUTPUT_DIR]"
-#   }
-#
-# Right before launching a task, we should validate
-# them a little bit and make sure they respect the rules that CBRAIN impose for userfiles.
-#
-#   "cbrain:integrator_modules": {
-#     "BoutiquesFileNameVerifier": [ "output_dir", "other_id", "other_id_2" ]
-#   }
-#
-# Please do not include output ids in the list. This modules does fully address more complex analyses, when output file name template includes several input string, or  prefixes or multiple path-templates like
-#
-#                    "path-template": "[SUBJECT_ID][SESSION_ID][OUTPUT_DIR]"
-#
-# You may prefer to use BoutiquesInputRegexChecker is these situations.
+# "cbrain:integrator_modules": {
+#   "BoutiquesFileNameVerifier": [ "output_dir", "other_id", "other_id_2" ]
+# }
 module BoutiquesFileNameVerifier
 
   # Note: to access the revision info of the module,
@@ -66,7 +47,7 @@ module BoutiquesFileNameVerifier
 
   def after_form #:nodoc:
     descriptor = self.descriptor_for_after_form
-    verifs     = descriptor.custom_module_info('BoutiquesFileNameVerifier')
+    verifs     = descriptor.custom_module_info('BoutiquesFileNameVerifier') || []
     verifs.each do |inputid| # 'myinput'
       found_match = Array(invoke_params[inputid])
         .map(&:presence)

--- a/BrainPortal/lib/boutiques_file_name_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_name_verifier.rb
@@ -20,10 +20,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# This module adds automatic verification of the
-# files (or directories ) names generated as output, which comply with CBRAIN restrictions.
+# This module offers automatic verification of the
+# files (or directories) names generated as tool output, and therefore have comply with CBRAIN file name conventions.
 #
-# For example, in the "inputs" section:
+# For example, in the "inputs" section we might have:
 #
 #   {
 #     "description": "The name of the folder to store outputs of XCPD processing.",
@@ -35,9 +35,14 @@
 #     "default-value": "xcpd_output"
 #   }
 #
-# "cbrain:integrator_modules": {
-#   "BoutiquesFileNameVerifier": [ "output_dir", "other_id", "other_id_2" ]
-# }
+# And the custom property is specified like
+#
+#   "cbrain:integrator_modules": {
+#     "BoutiquesFileNameVerifier": [
+#       "output_dir",
+#       "another_id"
+#     ]
+#   }
 module BoutiquesFileNameVerifier
 
   # Note: to access the revision info of the module,

--- a/BrainPortal/lib/boutiques_file_name_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_name_verifier.rb
@@ -1,0 +1,81 @@
+
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2021
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+# This module adds automatic verification of the
+# files (or directories ) names generated as output to prevent injection.
+#
+# For exmaple, in the "inputs" section:
+#
+#   {
+#     "description": "The name of the folder to store outputs of XCPD processing.",
+#     "id": "output_dir",
+#     "name": "output_dir",
+#     "optional": false,
+#     "type": "String",
+#     "value-key": "[OUTPUT_DIR]",
+#     "default-value": "xcpd_output"
+#   }
+# and in the "output-files" section:
+#
+#   {
+#     "name": "XCPD Subject Output Directory",
+#     "id":  "xcpd_output_dir",
+#     "description": "Subject level output for XCP-D",
+#     "optional":  false,
+#     "path-template": "[OUTPUT_DIR]"
+#   }
+# The prevent problems, right from the start before launching a task, we should validate
+# them a little bit and make sure they respect the rules that CBRAIN impose for userfiles.
+#
+# "cbrain:integrator_modules": {
+#   "BoutiquesOutputNameValidator": [ "output_dir", "other_id", "other_id_2" ]
+# }
+module BoutiquesFileTypeVerifier
+
+  # Note: to access the revision info of the module,
+  # you need to access the constant directly, the
+  # object method revision_info() won't work.
+  Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
+
+  def after_form #:nodoc:
+    descriptor = self.descriptor_for_after_form
+    verifs     = descriptor.custom_module_info('BoutiquesFileNameVerifier')
+
+    verifs.each do |inputid| # 'myinput'
+      input = descriptor.input_by_id(inputid)
+      found_match = Array(invoke_params[inputid])
+        .map(&:presence)
+        .compact
+        .all? do |fname|
+          Userfile.is_legal_filename?(fname)
+        end
+      if ! found_match
+        # "file names should us printable characters only, with no slashes ASCII nulls,
+        # and they must start with a letter or digit"
+        params_errors.add(input.cb_invoke_name, "is not of the proper name for file (or directory), avoid hyphens or other special symbols")
+      end
+    end
+
+    super # call all the normal code
+  end
+
+end

--- a/BrainPortal/lib/boutiques_file_name_verifier.rb
+++ b/BrainPortal/lib/boutiques_file_name_verifier.rb
@@ -21,7 +21,7 @@
 #
 
 # This module adds automatic verification of the
-# files (or directories ) names generated as output to prevent injection.
+# files (or directories ) names generated as output, which comply with CBRAIN restrictions.
 #
 # For exmaple, in the "inputs" section:
 #
@@ -34,6 +34,7 @@
 #     "value-key": "[OUTPUT_DIR]",
 #     "default-value": "xcpd_output"
 #   }
+#
 # and in the "output-files" section:
 #
 #   {
@@ -43,16 +44,19 @@
 #     "optional":  false,
 #     "path-template": "[OUTPUT_DIR]"
 #   }
+#
 # Right before launching a task, we should validate
 # them a little bit and make sure they respect the rules that CBRAIN impose for userfiles.
 #
-# "cbrain:integrator_modules": {
-#   "BoutiquesFileNameVerifier": [ "output_dir", "other_id", "other_id_2" ]
-# }
+#   "cbrain:integrator_modules": {
+#     "BoutiquesFileNameVerifier": [ "output_dir", "other_id", "other_id_2" ]
+#   }
 #
-# Please do not include output ids in the list. This modules we does fully address complex analyses eg in presence of prefixes or multiple path-templates like
+# Please do not include output ids in the list. This modules does fully address more complex analyses, when output file name template includes several input string, or  prefixes or multiple path-templates like
+#
 #                    "path-template": "[SUBJECT_ID][SESSION_ID][OUTPUT_DIR]"
-# You still can resort to BoutiquesFileNameMatcher for complex cases
+#
+# You may prefer to use BoutiquesInputRegexChecker is these situations.
 module BoutiquesFileNameVerifier
 
   # Note: to access the revision info of the module,


### PR DESCRIPTION
To reduce integration experts confusion, module is recalled File Name Verifier in same vein with the File Name Matcher . See #1447 for details