### PR TITLE
improving log_params_changes() for boutiques tasks #1465

### DIFF
--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -399,8 +399,8 @@ class BoutiquesPortalTask < PortalTask
   # differences. It makes up for a difference The task object itself is not changed.
   # Overrides the parent class method
   def log_params_changes(old_params = {}, new_params = {})
-    # in this class all non-file parameters are moved inside invoke key
-    super(old_params['invoke'], new_params['invoke']) if new_params.key?('invoke') || old_params.key?('invoke')
+    # in this class all non-file parameters are inside the invoke sub-hash
+    super(old_params['invoke'] || {}, new_params['invoke'] || {})
 
     # just a precation, perhaps, not used now
     super(old_params.except('invoke'), new_params.except('invoke'))

--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -403,7 +403,7 @@ class BoutiquesPortalTask < PortalTask
     super(old_params['invoke'], new_params['invoke']) if new_params.key?('invoke') || old_params.key?('invoke')
 
     # just a precation, perhaps, not used now
-    super(old_params.except('invoke'), new_params.except('invoke')) if new_params.except('invoke') != old_params.except('invoke')
+    super(old_params.except('invoke'), new_params.except('invoke'))
 
   end
 

--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -396,10 +396,15 @@ class BoutiquesPortalTask < PortalTask
 
   # This method compares a params hash table +old_params+ with
   # a +new_params+ hash provided, and log all the
-  # differences. The task object itself is not changed.
+  # differences. It makes up for a difference The task object itself is not changed.
   # Overrides the parent class method
   def log_params_changes(old_params = {}, new_params = {})
-    super(old_params['invoke'], new_params['invoke'])
+    # in this class all non-file parameters are moved inside invoke key
+    super(old_params['invoke'], new_params['invoke']) if new_params.key?('invoke') || old_params['invoke'].key?('inovoke')
+
+    # just a precation, perhaps, not used now
+    super(old_params.except('invoke'), new_params.except('invoke')) if new_params.except('invoke') != old_params.except('invoke')
+
   end
 
   ################################

--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -400,7 +400,7 @@ class BoutiquesPortalTask < PortalTask
   # Overrides the parent class method
   def log_params_changes(old_params = {}, new_params = {})
     # in this class all non-file parameters are moved inside invoke key
-    super(old_params['invoke'], new_params['invoke']) if new_params.key?('invoke') || old_params['invoke'].key?('inovoke')
+    super(old_params['invoke'], new_params['invoke']) if new_params.key?('invoke') || old_params.key?('invoke')
 
     # just a precation, perhaps, not used now
     super(old_params.except('invoke'), new_params.except('invoke')) if new_params.except('invoke') != old_params.except('invoke')

--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -394,7 +394,13 @@ class BoutiquesPortalTask < PortalTask
     )
   end
 
-
+  # This method compares a params hash table +old_params+ with
+  # a +new_params+ hash provided, and log all the
+  # differences. The task object itself is not changed.
+  # Overrides the parent class method
+  def log_params_changes(old_params = {}, new_params = {})
+    super(old_params['invoke'], new_params['invoke'])
+  end
 
   ################################
   # Portal-side utilities

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -580,6 +580,7 @@ class CbrainTask < ApplicationRecord
   # This method compares a params hash table +old_params+ with
   # a +new_params+ hash provided, and log all the
   # differences. The task object itself is not changed.
+  # The method is overriden in BoutiquesTask subclass
   def log_params_changes(old_params = {}, new_params = {})
     numchanges = 0
     old_params.each do |ck,cv|

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -580,7 +580,6 @@ class CbrainTask < ApplicationRecord
   # This method compares a params hash table +old_params+ with
   # a +new_params+ hash provided, and log all the
   # differences. The task object itself is not changed.
-  # The method is overriden in BoutiquesTask subclass
   def log_params_changes(old_params = {}, new_params = {})
     numchanges = 0
     old_params.each do |ck,cv|

--- a/BrainPortal/app/models/cbrain_task.rb
+++ b/BrainPortal/app/models/cbrain_task.rb
@@ -606,8 +606,6 @@ class CbrainTask < ApplicationRecord
     end
     if numchanges > 0
       self.addlog("Total of #{numchanges} changes observed.")
-    else
-      self.addlog("No changes to params observed.")
     end
   end
 

--- a/BrainPortal/spec/models/cbrain_task_spec.rb
+++ b/BrainPortal/spec/models/cbrain_task_spec.rb
@@ -335,11 +335,6 @@ describe CbrainTask do
       expect(cb_diagnostic.getlog).to match(/Total of 1 changes observed./)
     end
 
-    it "should add 'No changes' if !(numchange > 0)  " do
-      cb_diagnostic.log_params_changes({:key1 => "val1"},{:key1 => "val1"})
-      expect(cb_diagnostic.getlog).to match(/No changes to params observed./)
-    end
-
   end
 
 


### PR DESCRIPTION
IMHO [overriding this method](https://github.com/aces/cbrain/compare/master...MontrealSergiy:cbrain:log-params-override?expand=1) in the `BoutiquesPortalTask` sub-class is more OOP. But submit what was requested literally 'intelligent, invoke-aware' method.

More the current 'intelligent' version allows for mixed parameters (perhaps unnecessary)