### PR TITLE
Signups now must to click button to confirm email, fixes #1468

### DIFF
--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -130,11 +130,21 @@ class SignupsController < ApplicationController
 
   # Confirms that a signup person's email address actually belongs to them
   def confirm #:nodoc:
-    @signup = Signup.find(params[:id]) rescue nil
+    @signup  = Signup.find(params[:id]) rescue nil
     token    = params[:token] || ""
+    is_valid = @signup.present? && token.present? && @signup.confirm_token == token
+    token    = "" if ! is_valid # that will just skip over everything and redirect at the end
+    req_method = request.method.to_s.upcase # GET or POST
 
-    # Params properly confirms the request? Then record that and show a nice message to user.
-    if @signup.present? && token.present? && @signup.confirm_token == token
+    # Params properly confirms the GET request? Show a simple page with button
+    if is_valid && req_method == 'GET'
+      @token = token # for the button
+      render 'confirm_button.html'
+      return
+    end
+
+    # Params properly confirms the POST request? Then record that and show a nice message to user.
+    if is_valid && req_method == 'POST'
       @signup.confirmed = true
       @signup.save
       @propose_view = can_edit?(@signup)

--- a/BrainPortal/app/controllers/signups_controller.rb
+++ b/BrainPortal/app/controllers/signups_controller.rb
@@ -139,7 +139,7 @@ class SignupsController < ApplicationController
     # Params properly confirms the GET request? Show a simple page with button
     if is_valid && req_method == 'GET'
       @token = token # for the button
-      render 'confirm_button.html'
+      render 'confirm_button.html.erb'
       return
     end
 

--- a/BrainPortal/app/views/signups/confirm_button.html.erb
+++ b/BrainPortal/app/views/signups/confirm_button.html.erb
@@ -26,10 +26,14 @@
 
 <h1>Please confirm your new account request.</h1>
 
-Thank you for following that link in your mailbox. It is needed to make sure you are indeed the owner of that email account.
+Thank you for following the link from CBRAIN in your mailbox.
 <p>
-There is only one final step required: Click the button below! This will tell the CBRAIN administrators that your request is now official.
+To ensure you are indeed the owner of the email address that has
+requested the creation of an account on CBRAIN, please complete the
+final required step by clicking the button below. This will tell
+the CBRAIN administrators that your request is legitimate and
+official.
 <p>
 
-<%= link_to('Confirm request', confirm_signup_path(@signup, :token => @token), :class => "button", :method => :post ) %>
+<%= link_to( 'Confirm request', confirm_signup_path(@signup, :token => @token), :class => "button", :method => :post ) %>
 

--- a/BrainPortal/app/views/signups/confirm_button.html.erb
+++ b/BrainPortal/app/views/signups/confirm_button.html.erb
@@ -1,0 +1,35 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2025
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<% title 'Confirm Your Request' %>
+
+<h1>Please confirm your new account request.</h1>
+
+Thank you for following that link in your mailbox. It is needed to make sure you are indeed the owner of that email account.
+<p>
+There is only one final step required: Click the button below! This will tell the CBRAIN administrators that your request is now official.
+<p>
+
+<%= link_to('Confirm request', confirm_signup_path(@signup, :token => @token), :class => "button", :method => :post ) %>
+

--- a/BrainPortal/config/routes.rb
+++ b/BrainPortal/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
     member do
       post 'resend_confirm'
       get  'confirm'
+      post 'confirm'
     end
     collection do
       post 'multi_action'


### PR DESCRIPTION
This should be easy to review.

When testing, remember that your dev environment doesn't actually send emails, but you can find the email's content in your RAILS logs.

YOu'll be able to find the URL of the confirm page, just post it in a incognito window.

You can also reset the 'confirmed' status in the console for multiple rounds of trials with

```
s = Signup.find(23) # adjust number
s.confirmed = false
s.save
```