### PR TITLE
allow autolink group description

### DIFF
--- a/BrainPortal/app/controllers/groups_controller.rb
+++ b/BrainPortal/app/controllers/groups_controller.rb
@@ -185,6 +185,7 @@ class GroupsController < ApplicationController
     respond_to do |format|
       if @group.update_attributes_with_logging(new_group_attr,current_user)
         @group.reload
+        add_meta_data_from_form(@group, [:autolink_description])
         if new_group_attr[:creator_id].present?
           @group.addlog_object_list_updated("Creator", User, original_creator, @group.creator_id, current_user, :login)
         end

--- a/BrainPortal/app/helpers/rich_ui_helper.rb
+++ b/BrainPortal/app/helpers/rich_ui_helper.rb
@@ -52,6 +52,20 @@ module RichUiHelper
     "<span style=\"white-space: pre-wrap;\">".html_safe + description + "</span>".html_safe
   end
 
+  def full_description(description, autolink=false)
+
+    if autolink
+      description = ERB::Util.html_escape(description)
+      description = description.gsub(URI::DEFAULT_PARSER.make_regexp(['https'])) do |url|
+        "<a href='#{url}' target='_blank' rel='noopener'>#{url}</a>"
+      end.html_safe
+    end
+
+    return "<span style=\"white-space: pre-wrap;\">".html_safe + description + "</span>".html_safe
+
+  end
+
+
   # Create an element that opens a dropdown when it's
   # hovered over.
   def hover_dropdown(header, options = {}, &block)

--- a/BrainPortal/app/helpers/rich_ui_helper.rb
+++ b/BrainPortal/app/helpers/rich_ui_helper.rb
@@ -48,12 +48,8 @@ module RichUiHelper
 
   # Takes a +description+ with multiple lines and shows
   # the whole thing, including line breaks.
-  def full_description(description)
-    "<span style=\"white-space: pre-wrap;\">".html_safe + description + "</span>".html_safe
-  end
-
+  # +autolink+ indicates are urls clickable or not
   def full_description(description, autolink=false)
-
     if autolink
       description = ERB::Util.html_escape(description)
       description = description.gsub(URI::DEFAULT_PARSER.make_regexp(['https'])) do |url|

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -63,7 +63,7 @@
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
 
-    <% t.edit_cell(:description, :content =>  full_description(@group.description)) do |f| %>
+    <% t.edit_cell(:description, :content =>  full_description(@group.description, @group.meta['autolink_description'])) do |f| %>
         <%= f.text_area :description, :rows => 4, :cols => 40 %><br>
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
     <% end %>

--- a/BrainPortal/app/views/groups/show.html.erb
+++ b/BrainPortal/app/views/groups/show.html.erb
@@ -63,9 +63,13 @@
 
     <% t.cell("Type") { @group.pretty_category_name(current_user) } %>
 
-    <% t.edit_cell(:description, :content =>  full_description(@group.description, @group.meta['autolink_description'])) do |f| %>
+    <% t.edit_cell(:description, :content =>  full_description(@group.description, @group.meta['autolink_description'] == 'yes')) do |f| %>
         <%= f.text_area :description, :rows => 4, :cols => 40 %><br>
         <div class="field_explanation">The first line should be a short summary, and the rest are for details.</div><br>
+    <% end %>
+
+    <% if current_user.has_role?(:admin_user) && @group.is_a?(WorkGroup) %>
+      <% t.boolean_edit_cell("meta[autolink_description]", @group.meta["autolink_description"].to_s, "yes", "", :header => "Urls are clickable ") %>
     <% end %>
 
     <% t.edit_cell("Not assignable", :content => check_box_tag(nil ,nil, @group.not_assignable?, :disabled => true)) do |f| %>


### PR DESCRIPTION
This is to automatically transform all links in a group description into a clickable link. 

The use case is to refer to website(s) where files in group were taken etc.

See https://github.com/aces/cbrain-plugins-neuro/issues/296

