### PR TITLE
[ADD] Separate group params in task show page

### DIFF
--- a/BrainPortal/app/assets/stylesheets/cbrain.css.erb
+++ b/BrainPortal/app/assets/stylesheets/cbrain.css.erb
@@ -1809,6 +1809,7 @@ th.center_align_heading {
 }
 
 .tsk-sw-hdr,
+.tsk-sw-sub-hdr,
 .tsk-sw-name,
 .tsk-sw-val {
   background: inherit;
@@ -1824,6 +1825,14 @@ th.center_align_heading {
   text-align: left;
 }
 
+.tsk-sw-sub-hdr {
+  font-family: sans-serif;
+  font-size: 0.9em;
+  font-weight: bold;
+  text-align: left;
+  text-decoration: underline;
+}
+
 .tsk-sw-name {
   padding-right: 40px;
 }
@@ -1831,6 +1840,11 @@ th.center_align_heading {
 .tsk-sw-param > tr > .tsk-sw-hdr {
   padding-top: 5px;
 }
+
+.tsk-sw-param > tr > .tsk-sw-sub-hdr {
+  padding-top: 5px;
+}
+
 
 .tsk-sw-param > tr > .tsk-sw-val {
   font-family: monospace;

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/boutiques_task/views/_show_param.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/boutiques_task/views/_show_param.html.erb
@@ -1,0 +1,34 @@
+
+<%-
+#
+# CBRAIN Project
+#
+# Copyright (C) 2008-2025
+# The Royal Institution for the Advancement of Learning
+# McGill University
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+-%>
+
+<tr>
+  <td class="tsk-sw-name"><%= param.name %></td>
+  <td class="tsk-sw-val">
+    <% if param.type == 'Flag' %>
+      <%= red_if(@task.invoke_params[param.id].to_s =~ /^1$|^true$/, "No", "Yes", { :color1 => 'red', :color2 => 'green' }) %>
+    <% else %>
+      <%= format_param.(@task.invoke_params[param.id]) %>
+    <% end %>
+  </td>
+</tr>

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/boutiques_task/views/_show_params.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/cbrain_task/boutiques_task/views/_show_params.html.erb
@@ -24,12 +24,24 @@
 
 <%-
   # Parameter groups
-  @descriptor = @task.descriptor_for_show_params
-  inputs      = @descriptor.inputs
-  file_inputs = @descriptor.file_inputs
-  params      = inputs.select { |i| i.type != 'File' }
-  outputs     = @descriptor.output_files
+  @descriptor     = @task.descriptor_for_show_params
+  inputs          = @descriptor.inputs
+  file_inputs     = @descriptor.file_inputs
+  file_inputs_ids = file_inputs.map(&:id)
+  params          = inputs.select { |i| i.type != 'File' }
+  param_ids       = params.map { |p| p.id }
+  outputs         = @descriptor.output_files
+  groups          = @descriptor.groups
+
+  # Find parameters that are part of groups
+  param_with_groups_ids    = groups.map { |m| m.members || []}.flatten - file_inputs.map(&:id)
+  params_with_groups       = params.select { |p| param_with_groups_ids.include?(p.id) }
+
+  # Keep in params, those that are not part of groups
+  param_without_groups_ids = param_ids - param_with_groups_ids
+  params                   = params.select { |p| param_without_groups_ids.include?(p.id) }
 -%>
+
 <%- unless [params, file_inputs, outputs].all?(&:empty?) -%>
 <%
   # Format a parameter (input or output) +value+ for display. Mostly for
@@ -59,18 +71,27 @@
           Parameters
         </th>
       </tr>
-    <%- params.each do |param| -%>
-      <tr>
-        <td class="tsk-sw-name"><%= param.name %></td>
-        <td class="tsk-sw-val">
-          <% if param.type == 'Flag' %>
-            <%= red_if(@task.invoke_params[param.id].to_s =~ /^1$|^true$/, "No", "Yes", { :color1 => 'red', :color2 => 'green' }) %>
-          <% else %>
-            <%= format_param.(@task.invoke_params[param.id]) %>
-          <% end %>
-        </td>
-      </tr>
-    <%- end -%>
+      <%- params.each do |param| -%>
+        <%= render :partial => task_partial(:show_param), :locals => { :param => param, :format_param => format_param } %>
+      <%- end -%>
+    </tbody>
+  <%- end -%>
+  <%- unless params_with_groups.empty? -%>
+    <tbody class="tsk-sw-param">
+      <%- groups.each do |group| -%>
+        <%- members = group.members || [] -%>
+        <%- params_members = members - file_inputs_ids -%>
+        <%- next if params_members.empty? -%>
+        <tr>
+          <th colspan="2" class="tsk-sw-sub-hdr">
+            <%= group.name %>
+          </th>
+        </tr>
+        <%- params_members.each do |param_id| -%>
+          <%- param = params_with_groups.find { |p| p.id == param_id } -%>
+          <%= render :partial => task_partial(:show_param), :locals => { :param => param, :format_param => format_param } %>
+        <%- end -%>
+      <%- end -%>
     </tbody>
   <%- end -%>
   <%- unless file_inputs.empty? -%>


### PR DESCRIPTION
Some tool implemented via Boutiques descriptor have a lot of parameters, it is possible in Boutiques descriptor to group it via `groups` structure each group can have `members` (that correspond to parameters), 

It can be used in the task show page to regroup the member parameter for a better user experience. 

Here an example of the new UI: 

![image](https://github.com/user-attachments/assets/53e3c373-dd9d-49f4-a0ff-a433af17f58f)
