### PR TITLE
remove redundant HTML pass through code resolves #1490

### DIFF
--- a/BrainPortal/app/helpers/userfiles_helper.rb
+++ b/BrainPortal/app/helpers/userfiles_helper.rb
@@ -108,10 +108,6 @@ module UserfilesHelper
         ) do
           ("<span class=\"sub_viewable_link\">"+display_name+"</span>").html_safe
       end
-    elsif display_name =~ /\.html$/i # TODO: this will never happen if we ever create a HtmlFile model with at least one viewer
-      link_to "#{display_name}",
-        stream_userfile_path(@userfile, :file_path => file_name, :disposition => 'inline'),
-        :target => '_BLANK'
     else
       link_to h(display_name),
               url_for(:action  => :content, :content_loader => :collection_file, :arguments => file_name)

--- a/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/html_file/views/_html.html.erb
+++ b/BrainPortal/cbrain_plugins/cbrain-plugins-base/userfiles/html_file/views/_html.html.erb
@@ -37,7 +37,7 @@
 <% end %>
 <br>
 The HTML document previewed in the frame below is not part of CBRAIN. <em> You should <strong>not</strong> open it or
-interact with it unless you fully trust it. </em> Forms, and external links are disabled.
+interact with it unless you fully trust it. </em> Forms and external links are disabled.
 <br>
 <iframe sandbox="allow-scripts allow-same-origin"
     src="<%= stream_userfile_path(@userfile, :disposition => 'inline')%>"


### PR DESCRIPTION
user html files should be rendered via dedicated viewer, so some old code can be dropped #1490

