### PR TITLE
Remove ANSI Sequences from cluster_stdout/cluster_stderr

### DIFF
--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -1289,13 +1289,13 @@ class ClusterTask < CbrainTask
 
      if stdoutfile && File.exist?(stdoutfile)
        io = IO.popen("tail -#{stdout_lim} #{stdoutfile.to_s.bash_escape}","r")
-       self.cluster_stdout = io.read
+       self.cluster_stdout = io.read.gsub(/\e\[[0-9;]*[a-zA-Z]/, '')  
        io.close
      end
 
      if stderrfile && File.exist?(stderrfile)
        io = IO.popen("tail -#{stderr_lim} #{stderrfile.to_s.bash_escape}","r")
-       self.cluster_stderr = io.read
+       self.cluster_stderr = io.read.gsub(/\e\[[0-9;]*[a-zA-Z]/, '') 
        io.close
      end
 


### PR DESCRIPTION
Remove ANSI sequences from cluster task stdout and stderr outputs for cleaner logging

Using regex, `/\e\[[0-9;]*[a-zA-Z]/` ANSI escape sequences that control color `\e[31m`, underline `\e[4m` , bold `\e[1m`, background color `\e[41m` .


Related Issue: 
#849 

CC: @prioux 