### PR TITLE
BTQ tasks can propagate number of cores to Scir

### DIFF
--- a/BrainPortal/app/models/boutiques_cluster_task.rb
+++ b/BrainPortal/app/models/boutiques_cluster_task.rb
@@ -416,6 +416,16 @@ class BoutiquesClusterTask < ClusterTask
     nil
   end
 
+  # Returns a number of cores needed for the job; nil means to not
+  # ask for anything particular.
+  def job_number_of_cores
+    descriptor = self.descriptor_for_cluster_commands
+    if descriptor.suggested_resources.present? && descriptor.suggested_resources['cpu-cores'].present?
+      return descriptor.suggested_resources['cpu-cores'].to_i
+    end
+    nil
+  end
+
   #########################################################
   # Local utility methods
   #########################################################

--- a/BrainPortal/app/models/cluster_task.rb
+++ b/BrainPortal/app/models/cluster_task.rb
@@ -168,6 +168,12 @@ class ClusterTask < CbrainTask
     nil
   end
 
+  # Returns a number of cores needed for the job; nil means to not
+  # ask for anything particular.
+  def job_number_of_cores
+    nil
+  end
+
 
 
   ##################################################################
@@ -1924,6 +1930,7 @@ exit $status
     job.name     = self.tname_tid  # "#{self.name}-#{self.id}" # some clusters want all names to be different!
     job.walltime = self.job_walltime_estimate
     job.memory   = self.job_memory_estimate
+    job.ncores   = self.job_number_of_cores
     job.task_id  = self.id
 
     # Note: all extra_qsub_args defined in the tool_configs (bourreau, tool and bourreau/tool)

--- a/BrainPortal/lib/scir.rb
+++ b/BrainPortal/lib/scir.rb
@@ -214,7 +214,7 @@ class Scir
     # We only support a subset of DRMAA's job template
     attr_accessor :name, :command, :arg, :wd,
         :stdin, :stdout, :stderr, :join,
-        :queue, :walltime, :memory,   # walltime is in seconds, memory in megabytes
+        :queue, :walltime, :memory, :ncores,   # walltime is in seconds, memory in megabytes
         :tc_extra_qsub_args, :task_id
 
     def revision_info #:nodoc:

--- a/BrainPortal/lib/scir_slurm.rb
+++ b/BrainPortal/lib/scir_slurm.rb
@@ -182,6 +182,7 @@ class ScirSlurm < Scir
       command += "#{Scir.cbrain_config[:extra_qsub_args]} " if Scir.cbrain_config[:extra_qsub_args].present?
       command += "--time=#{(self.walltime.to_i+60) / 60} "  if self.walltime.present?
       command += "--mem=#{self.memory}m "                   if self.memory.present?
+      command += "-c #{self.ncores} "                       if self.ncores.present?
       command += "#{self.tc_extra_qsub_args} "              if self.tc_extra_qsub_args.present?
       command += "#{shell_escape(self.arg[0])} "
       command += " 2>&1"


### PR DESCRIPTION
Support only for SLURM. Closes #1472 