### PR TITLE
relax over-zealous string input validation: by allowing empty strings

### DIFF
--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -539,7 +539,7 @@ class BoutiquesPortalTask < PortalTask
     charset_regex  = /\A[\w,\.\/\:\-\ \*\{\}\(\)\%\@\=\+]\z/  if charset_regex == ':description:'     # single line text with spaces, no bash special characters
 
     # Default check is pretty strict, but works for most applications.
-    charset_regex ||= /\A[\w,\.\/\:\-\+]+\z/ # letters, digits, underscores, commas, periods, slashes, colons, dashes, plusses "a0_,./:-+"
+    charset_regex ||= /\A[\w,\.\/\:\-\+]*\z/ # letters, digits, underscores, commas, periods, slashes, colons, dashes, plusses "a0_,./:-+"
 
     # These two lines force anchoring, in case the person maintaining the descriptor
     # forgot them in the values of custom['cbrain:override-input-string-ruby-regex']


### PR DESCRIPTION
I think the new input validation rules create unwarranted problems, I see some support request related to empty strings being rejected.

Can we fix it before more user got issues?