### PR TITLE
for single-input tasks, do not treat input file singleton list #1577

### DIFF
--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -136,11 +136,12 @@ class BoutiquesPortalTask < PortalTask
 
     # Required parameters
     descriptor.required_inputs.each do |input|
-      # skip if the input is the sole mandatory file and if
+      # skip if the input is the sole mandatory file,
       # the task is qualified to launch multiple tasks
-      # only if no params was provide
+      # and there is more than one file is selected in UI
       next if descriptor.qualified_to_launch_multiple_tasks? &&
               descriptor.sole_mandatory_file_input == input  &&
+              self.params[:interface_userfile_ids].length > 1
               !invoke_params[input.id].present?
 
       sanitize_param(input)


### PR DESCRIPTION
This to restore name and type validation for tools with a single input file.

This handles only single file case, not a bunch of file (some of which could be list). The former might be done  by overwriting input sanitizer rather than after form handler. Yet I am not sure for the case of long lists as regex validation is not linear with standard regular expression engine, could create issue