### PR TITLE
Taskarray validations

### DIFF
--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -342,6 +342,10 @@ class BoutiquesPortalTask < PortalTask
         end
       end
 
+      # Re-introduce the file IDs of the task list, in case the main form
+      # needs to be re-rendered.
+      self.params[:interface_userfile_ids] |= task_array_userfiles_ids
+
       return tasklist.flatten
     end # When only one file input
 
@@ -505,8 +509,8 @@ class BoutiquesPortalTask < PortalTask
   # Ensure that the +input+ parameter is not null and matches a generic tool
   # parameter type (:file, :numeric, :string or :flag) before converting the
   # parameter's value to the corresponding Ruby type (if appropriate).
-  # For example, sanitize_param(someinput) where someinput's name is 'deviation'
-  # and someinput's type is 'numeric' would validate that
+      # For example, sanitize_param(someinput) where someinput's name is 'deviation'
+      # and someinput's type is 'numeric' would validate that
   # self.params['invoke']['deviation'] is a number and then convert it to a Ruby Float or
   # Integer.
   #
@@ -548,7 +552,7 @@ class BoutiquesPortalTask < PortalTask
 
     # Taken userfile names. An error will be raised if two input files have the
     # same name.
-    @taken_files ||= Set.new
+    @taken_files ||= {}
 
     # Fetch the parameter and convert to an Enumerable if required
     values = invoke_params[name]
@@ -608,10 +612,10 @@ class BoutiquesPortalTask < PortalTask
           next nil # remove bad value
         end
 
-        if @taken_files.include?(file.id)
+        if @taken_files[file.id].present? && @taken_files[file.id] != input.id
           params_errors.add(invokename, ": file name already in use (#{file.name})")
         else
-          @taken_files.add(file.id)
+          @taken_files[file.id] = input.id
         end
 
       end

--- a/BrainPortal/app/models/portal_task.rb
+++ b/BrainPortal/app/models/portal_task.rb
@@ -743,6 +743,17 @@ class PortalTask < CbrainTask
     @params_errors_cache
   end
 
+  # Needed in case of a dup()
+  def params_errors_clear #:nodoc:
+    @params_errors_cache = nil
+  end
+
+  def dup #:nodoc:
+    obj = super
+    obj.params_errors_clear
+    obj
+  end
+
   # This method returns a 'pretty' name for a params attributes.
   # This implementation will try to look up a hash table returned
   # by the class method pretty_params_names() first, so an


### PR DESCRIPTION
This PR adds some more validation late in the path to creating task arrays.

The "after_form" method is re-invoked on each task created for a task array. This re-triggers also all the special module codes that apply to after_form.

I've had to re-organize some controller code in TaskController:

1. The method create_tasklist_from_initial_task() used to create the task array by calling "final_task_list" in the task model, and then save the tasks (while also parallelizing them etc).
2. Now final_task_list() is called in create() separately, and the task list is passed as an argument to create_tasklist_from_initial_task() only after validation has succeeded.

TO TEST THIS:

a) my favorite way was to turn online a bourreau in my test environment but never actually start it. That way I could fill the task forms and click launch over and over and nothing was actually processed on the bourreau. Find your bourreur in the console, set its "online" to true. Don't even start it.

b) You will need a BoutiquesTask that has more than one file input, but only one mandatory, and that has validation tests on that file input. I used hippunfold in cbrain-plugins-neuro.

c) have several "BidsSubject" registered, along with normal files and FileCollections. Create a CbrainFileList with 3 BidsSubject, another one with 1 BidsSubject and a normal file, etc.

d) I have tested things by selecing in the file manager these combinations

* 1 cbfilelist of 3 bids subjects
* 1 cbfilelist of 1 bids and one file
* 3 bidssubject
* 3 bids subjects and 1 file (not assigned)
* 3 bids subjects and 1 file that I assign to the "derivatives" file input

I tried things by assigning the bids subject field in the form, or not assigning anything.

In all possible combinations I found that the form reacted properly with messages about what was not correct. In the end I was only able to create tasks if my main input contained ONLY bids subjects named "sub-1".
