### PR TITLE
Fix number validation in boutiques_portal_task.rb

### DIFF
--- a/BrainPortal/app/models/boutiques_portal_task.rb
+++ b/BrainPortal/app/models/boutiques_portal_task.rb
@@ -568,6 +568,8 @@ class BoutiquesPortalTask < PortalTask
       when :number
         if value.blank?
           params_errors.add(invokename, ": value missing")
+        elsif (value.is_a?(Integer) || value.is_a?(Float))
+          value
         elsif (number = (Integer(value) rescue Float(value) rescue nil))
           value = number
         else


### PR DESCRIPTION
This prevent a bug that happen when sanitize params is called twice. 