### PR TITLE
Update cluster submission options for both commands (sbatch,qsub)

### DIFF
--- a/BrainPortal/app/views/bourreaux/new.html.erb
+++ b/BrainPortal/app/views/bourreaux/new.html.erb
@@ -169,7 +169,7 @@
           <%= f.text_field :cms_default_queue %><br/>
           <div class="field_explanation">Optional.</div>
 
-          <p><%= f.label :cms_extra_qsub_args, "Extra 'qsub' options" %><br/>
+          <p><%= f.label :cms_extra_qsub_args, "Extra cluster submission options(srun, qsub)" %><br/>
           <%= f.text_field :cms_extra_qsub_args, :size => 60 %><br/>
           <div class="field_explanation">Optional. Careful, this is inserted as-is in the command-line for submitting jobs.</div>
 

--- a/BrainPortal/app/views/bourreaux/new.html.erb
+++ b/BrainPortal/app/views/bourreaux/new.html.erb
@@ -169,7 +169,7 @@
           <%= f.text_field :cms_default_queue %><br/>
           <div class="field_explanation">Optional.</div>
 
-          <p><%= f.label :cms_extra_qsub_args, "Extra cluster submission options(srun, qsub)" %><br/>
+          <p><%= f.label :cms_extra_qsub_args, "Extra cluster submission options(sbatch, qsub)" %><br/>
           <%= f.text_field :cms_extra_qsub_args, :size => 60 %><br/>
           <div class="field_explanation">Optional. Careful, this is inserted as-is in the command-line for submitting jobs.</div>
 

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -399,7 +399,7 @@
 
         <% t.empty_cell %>
 
-        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra 'qsub' options", :show_width => 2) do |f| %>
+        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra cluster submission options(srun, qsub)", :show_width => 2) do |f| %>
           <%= f.text_field :cms_extra_qsub_args, :size => 60 %><br/>
           <div class="field_explanation">Optional. Careful, this is inserted as-is in the command-line for submitting jobs.</div>
         <% end %>

--- a/BrainPortal/app/views/bourreaux/show.html.erb
+++ b/BrainPortal/app/views/bourreaux/show.html.erb
@@ -399,7 +399,7 @@
 
         <% t.empty_cell %>
 
-        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra cluster submission options(srun, qsub)", :show_width => 2) do |f| %>
+        <% t.edit_cell(:cms_extra_qsub_args, :header => "Extra cluster submission options(sbatch, qsub)", :show_width => 2) do |f| %>
           <%= f.text_field :cms_extra_qsub_args, :size => 60 %><br/>
           <div class="field_explanation">Optional. Careful, this is inserted as-is in the command-line for submitting jobs.</div>
         <% end %>

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -106,7 +106,7 @@
 
   <%= show_table(@tool_config, :form_helper => cf, :header => "Execution Server Control", :edit_condition => check_role(:admin_user)) do |t| %>
 
-    <% t.edit_cell(:extra_qsub_args, :header => "Extra 'qsub' options", :show_width => 2) do |f| %>
+    <% t.edit_cell(:extra_qsub_args, :header => "Extra cluster submission options(srun, qsub)", :show_width => 2) do |f| %>
       <%= f.text_field :extra_qsub_args, :size => 80 %>
       <div class="wide_field_explanation">
         <b>Note:</b>This string will be appended to the extra 'qsub' option defined at the bourreau level.

--- a/BrainPortal/app/views/tool_configs/_form_fields.html.erb
+++ b/BrainPortal/app/views/tool_configs/_form_fields.html.erb
@@ -106,7 +106,7 @@
 
   <%= show_table(@tool_config, :form_helper => cf, :header => "Execution Server Control", :edit_condition => check_role(:admin_user)) do |t| %>
 
-    <% t.edit_cell(:extra_qsub_args, :header => "Extra cluster submission options(srun, qsub)", :show_width => 2) do |f| %>
+    <% t.edit_cell(:extra_qsub_args, :header => "Extra cluster submission options(sbatch, qsub)", :show_width => 2) do |f| %>
       <%= f.text_field :extra_qsub_args, :size => 80 %>
       <div class="wide_field_explanation">
         <b>Note:</b>This string will be appended to the extra 'qsub' option defined at the bourreau level.


### PR DESCRIPTION
Updated `cluster submission` instead of the label Extra 'qsub' options on the Tool Version page.
Fixes #879 