### PR TITLE
Clean redundant Boutiques module log messages in `BrainPortal/lib`

### DIFF
--- a/BrainPortal/lib/boutiques_allowed_exit_codes.rb
+++ b/BrainPortal/lib/boutiques_allowed_exit_codes.rb
@@ -50,7 +50,7 @@ module BoutiquesAllowedExitCodes
     descriptor = self.descriptor_for_save_results
     ok_codes   = descriptor.custom_module_info('BoutiquesAllowedExitCodes') || [ 0 ]
 
-    addlog("BoutiquesAllowedExitCodes rev. #{Revision_info.short_commit}, status=#{status}, allowed=#{ok_codes}")
+    addlog("Status=#{status}, allowed=#{ok_codes}")
 
     ! Array(ok_codes).include?(status)
   end

--- a/BrainPortal/lib/boutiques_dir_maker.rb
+++ b/BrainPortal/lib/boutiques_dir_maker.rb
@@ -66,9 +66,7 @@ module BoutiquesDirMaker
     patterns   = descriptor.custom_module_info('BoutiquesDirMaker')
     return commands if patterns.blank?
 
-    # Log revision information
-    commit = Revision_info.short_commit
-    self.addlog("Creating auxiliary directories with BoutiquesDirMaker rev. #{commit}.")
+    self.addlog("Creating auxiliary directories")
 
     substitutions_by_token  = descriptor.build_substitutions_by_tokens_hash(
       JSON.parse(File.read(self.invoke_json_basename))
@@ -79,9 +77,9 @@ module BoutiquesDirMaker
       path = descriptor.apply_substitutions(pattern, substitutions_by_token)
       path = path.strip  # whitespaces in dir names are not supported
       path = Pathname.new(path.strip).cleanpath  # normalizing: removing unnecessary dots ...
-      cb_error "BoutiquesDirMaker cannot create path '#{path}' (pattern '#{pattern}')." if path.to_s.start_with?('.')
+      cb_error "Cannot create path '#{path}' (pattern '#{pattern}')." if path.to_s.start_with?('.')
       safe_mkdir(path)
-      self.addlog("BoutiquesDirMaker created '#{path}'.")
+      self.addlog("Created '#{path}'.")
     end
     commands
   end

--- a/BrainPortal/lib/boutiques_forced_output_browse_path.rb
+++ b/BrainPortal/lib/boutiques_forced_output_browse_path.rb
@@ -72,10 +72,10 @@ module BoutiquesForcedOutputBrowsePath
     attlist[:name] = pn.basename.to_s  # "hello.txt"
     if dp.has_browse_path_capabilities?
       attlist[:browse_path] = pn.dirname.to_s   # "a/b/c"
-      self.addlog "BoutiquesForcedOutputBrowsePath: result DataProvider browse_path will be '#{pn.dirname}'"
+      self.addlog "Result DataProvider browse_path will be '#{pn.dirname}'"
     else
       attlist[:browse_path] = nil # ignore the browse_path
-      self.addlog "BoutiquesForcedOutputBrowsePath: result DataProvider doesn't have multi-level capabilities, ignoring forced browse_path '#{pn.dirname}'."
+      self.addlog "Result DataProvider doesn't have multi-level capabilities, ignoring forced browse_path '#{pn.dirname}'."
     end
 
     # Invoke the standard code
@@ -90,9 +90,8 @@ module BoutiquesForcedOutputBrowsePath
   # happens in the other module BoutiquesOutputFilenameRenamer )
   def name_and_type_for_output_file(output, pathname)
     dest_supports_browse_path = self.results_data_provider.has_browse_path_capabilities?
-    if self.getlog.to_s !~ /BoutiquesForcedOutputBrowsePath rev/
-      self.addlog("BoutiquesForcedOutputBrowsePath rev. #{Revision_info.short_commit}") # only log this once
-      self.addlog("BoutiquesForcedOutputBrowsePath: result DataProvider doesn't have multi-level capabilities, ignoring all forced browse_path configured by the descriptor.") if ! dest_supports_browse_path
+    if ! dest_supports_browse_path && self.getlog.to_s !~ /ignoring all forced browse_path configured by the descriptor/
+      self.addlog("Result DataProvider doesn't have multi-level capabilities, ignoring all forced browse_path configured by the descriptor.")
     end
     name, type  = super # the standard names and types; the name will be replaced
     return [ name, type ] if ! dest_supports_browse_path # when ignoring it all

--- a/BrainPortal/lib/boutiques_input_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_input_cache_cleaner.rb
@@ -92,7 +92,7 @@ module BoutiquesInputCacheCleaner
       next if     last_cache_access_time >= setup_time  # skip, file is being accessed by another task
 
       userfile.cache_erase
-      self.addlog("BoutiquesInputCacheCleaner deleted cache of '#{userfile.name}'")
+      self.addlog("Deleted cache of '#{userfile.name}'")
 
     end
 

--- a/BrainPortal/lib/boutiques_input_copier.rb
+++ b/BrainPortal/lib/boutiques_input_copier.rb
@@ -117,24 +117,20 @@ module BoutiquesInputCopier
 
     # Get the custom module info
     module_config = descriptor.custom_module_info('BoutiquesInputCopier')
-    basename = Revision_info.basename
-    commit   = Revision_info.short_commit
-    self.addlog("#{basename} rev. #{commit}")
-
     if module_config.blank?
-      self.addlog("Configuration for BoutiquesInputCopier is blank, nothing to do.")
+      self.addlog("Configuration is blank, nothing to do.")
       return true
     end
 
     invoke_params = self.invoke_params
 
     module_config.each do |parent_inputid, config|
-      self.addlog("#{basename}: handling copy of input '#{parent_inputid}'")
+      self.addlog("Handling copy of input '#{parent_inputid}'")
 
       # Skip if no input is selected
       userfile_id = invoke_params[parent_inputid]
       if userfile_id.blank?
-        self.addlog("#{basename}: no input files provided for '#{parent_inputid}', skipping")
+        self.addlog("No input files provided for '#{parent_inputid}', skipping")
         next
       end
 
@@ -148,7 +144,7 @@ module BoutiquesInputCopier
       # We skip if (the checkbox is SHOWN) *AND* (the user DID NOT SELECT IT)
       # We COPY in all other cases.
       if checkbox_hidden.blank? && (checkbox_checked.blank? || checkbox_checked == "0")
-        self.addlog("#{basename}: no need to copy for #{parent_inputid}, skipping")
+        self.addlog("No need to copy for #{parent_inputid}, skipping")
         next
       end
 
@@ -161,14 +157,14 @@ module BoutiquesInputCopier
       userfile_cache_full_path = userfile.cache_full_path     # Path in cache
 
       if ! File.symlink?(userfile_name)
-        cb_error("#{basename}: original userfile is not a symlink: '#{userfile_name}'.")
+        cb_error("Original userfile is not a symlink: '#{userfile_name}'.")
       end
 
       if userfile_cache_full_path.to_s != userfile_path.to_s
-        cb_error("#{basename}: path of cache and workdir are inconsistent for '#{userfile_name}'.")
+        cb_error("Path of cache and workdir are inconsistent for '#{userfile_name}'.")
       end
 
-      self.addlog("#{basename}: Copy input for '#{userfile_name}' in task work directory")
+      self.addlog("Copy input for '#{userfile_name}' in task work directory")
 
       # Remove the symbolic link to the userfile's cache from the working directory
       File.delete(userfile_name)

--- a/BrainPortal/lib/boutiques_input_subdir_maker.rb
+++ b/BrainPortal/lib/boutiques_input_subdir_maker.rb
@@ -131,12 +131,8 @@ module BoutiquesInputSubdirMaker
     original_userfile_ids = {} # Needed in 'ensure' clause below
 
     return super if parent_dirname_by_inputid.blank? # no config means nothing to do
-
-    # Log revision information
-    basename = Revision_info.basename
-    commit   = Revision_info.short_commit
-    self.addlog("Creating parent directories in BoutiquesInputSubdirMaker.")
-    self.addlog("#{basename} rev. #{commit}")
+    # Log our activity  
+    self.addlog("Creating parent directories")
 
     # Remove IDs from invoke_params
     parent_dirname_by_inputid.each_key do |inputid|

--- a/BrainPortal/lib/boutiques_output_cache_cleaner.rb
+++ b/BrainPortal/lib/boutiques_output_cache_cleaner.rb
@@ -123,9 +123,6 @@ module BoutiquesOutputCacheCleaner
     # This is controlled by a new fake input checkbox in the form. See above.
     return true unless self.params[:cbrain_enable_output_cache_cleaner]
 
-    # Log version of this module
-    self.addlog("BoutiquesOutputCacheCleaner rev. #{Revision_info.short_commit}")
-
     # Get the list of outputs to clean from the descriptor
     descriptor = self.descriptor_for_save_results
     output_ids = descriptor.custom_module_info('BoutiquesOutputCacheCleaner') || []

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -227,7 +227,6 @@ module BoutiquesOutputFilenameRenamer
       outname_pattern   = invoke_params[outnameinputid]
       outname           = output_name_from_pattern(outname_pattern, input_userfile.name)
       if outname_pattern != outname
-        self.addlog("BoutiquesOutputFilenameRenamer rev. #{Revision_info.short_commit}")
         self.addlog "Generating output name: \"#{outname_pattern}\" -> \"#{outname}\""
         self.invoke_params[outnameinputid] = outname # replace pattern with value
       end

--- a/BrainPortal/lib/boutiques_output_tagger.rb
+++ b/BrainPortal/lib/boutiques_output_tagger.rb
@@ -57,20 +57,20 @@ module BoutiquesOutputTagger
       file_ids.each do |fid|
         userfile = Userfile.where(:id => fid).first
         if ! userfile
-          self.addlog("BoutiquesOutputTagger: Skipped tagging file ##{fid} for output '#{output_id}': file doesn't exist.")
+          self.addlog("Skipped tagging file ##{fid} for output '#{output_id}': file doesn't exist.")
           next
         end
         tag_ids = taglist.map do |tagname|
           tag_req = Tag.where(:name => tagname, :group_id => self.group_id) # scope is one tag name per prject
           tag = tag_req.first
           if ! tag
-             self.addlog "BoutiquesOutputTagger: Creating new tag '#{tagname}'"
+             self.addlog "Creating new tag '#{tagname}'"
              tag_req = tag_req.where(:user_id => self.user_id)  # add owner
              tag = tag_req.create!
           end
           tag.id
         end
-        self.addlog "BoutiquesOutputTagger: tagging file '#{userfile.name}' (ID #{userfile.id}) with tags: #{taglist.join(', ')}"
+        self.addlog "Tagging file '#{userfile.name}' (ID #{userfile.id}) with tags: #{taglist.join(', ')}"
         userfile.tag_ids |= tag_ids
       end
     end

--- a/BrainPortal/lib/boutiques_save_std_out_std_err.rb
+++ b/BrainPortal/lib/boutiques_save_std_out_std_err.rb
@@ -124,10 +124,10 @@ module BoutiquesSaveStdOutStdErr
     attlist[:name] = pn.basename.to_s  # "hello.txt"
     if dp.has_browse_path_capabilities?
       attlist[:browse_path] = pn.dirname.to_s   # "a/b/c"
-      self.addlog "BoutiquesSaveStdErrOut: result DataProvider browse_path for Stderr and Stdout will be '#{pn.dirname}'"
+      self.addlog "Result DataProvider browse_path for Stderr and Stdout will be '#{pn.dirname}'"
     else
       attlist[:browse_path] = nil # ignore the browse_path
-      self.addlog "BoutiquesSaveStdErrOut: result DataProvider doesn't have multi-level capabilities, ignoring forced browse_path for Stderr and Stdout '#{pn.dirname}'."
+      self.addlog "Result DataProvider doesn't have multi-level capabilities, ignoring forced browse_path for Stderr and Stdout '#{pn.dirname}'."
     end
 
     # Invoke the standard code

--- a/BrainPortal/lib/boutiques_task_logs_copier.rb
+++ b/BrainPortal/lib/boutiques_task_logs_copier.rb
@@ -148,9 +148,9 @@ module BoutiquesTaskLogsCopier
     # and patterns are normally configured by the administrator, who
     # should know better than to misconfigure the module or
     # point at paths outside the task's work directory.
-    cb_error "Misconfigured module BoutiquesTaskLogsCopier for #{typeinfo} with absolute path pattern '#{destpath}'" if destpath.absolute?
+    cb_error "Misconfigured module for #{typeinfo} with absolute path pattern '#{destpath}'" if destpath.absolute?
     if prefixglob.to_s.blank? || prefixglob.to_s == '.'
-      cb_error "Misconfigured module BoutiquesTaskLogsCopier without a prefix subdirectory for #{typeinfo} '#{destpath}'"
+      cb_error "Misconfigured module without a prefix subdirectory for #{typeinfo} '#{destpath}'"
     end
 
     # Try to find one and only one directory where to install the file.
@@ -178,7 +178,7 @@ module BoutiquesTaskLogsCopier
 
     destdir = dirglobs.first
     if ! path_is_in_workdir?(destdir)
-      self.addlog "Misconfigured module BoutiquesTaskLogsCopier: path pattern '#{destpath}' is outside of the task's workdirectory; #{typeinfo} file not saved."
+      self.addlog "Misconfigured module: path pattern '#{destpath}' is outside of the task's workdirectory; #{typeinfo} file not saved."
       return
     end
 


### PR DESCRIPTION
Updated log messages across multiple modules to remove redundant class/module names and improve readability.
Fixes #1618 