### PR TITLE
detect possible overwriting output files by BoutiquesOutputFilenameRe…

### DIFF
--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -212,8 +212,8 @@ module BoutiquesOutputFilenameRenamer
 
 
   # checking that output patterns actually provided in the case of batch tasks
-  # because this module disables CBRAIN standards output suffixes that aim at aprevenitn
-  # from overwriting the output files
+  # because this module disables CBRAIN standards output suffixes that aim at avoiding
+  # unintended overwriting the output files
   def final_task_list
     tasklist = super
     if tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
@@ -243,11 +243,11 @@ module BoutiquesOutputFilenameRenamer
           input_userfile_id_1 = t_1.invoke_params[fileinputid]     # input file id resulting in duplicated output file name
           input_userfile_1    = Userfile.find(input_userfile_id_1)
 
-          msg = ":BoutiquesOutputFilenameRenamer module require unique output names for batch tasks," +
+          msg = ":BoutiquesOutputFilenameRenamer module require unique output names for batch tasks, " +
                 "yet input files '#{input_userfile.name}' and '#{input_userfile_1.name}' result in the same output file " +
                 " '#{outname}' for output file pattern '#{original_outname_pattern}'."
 
-          self.errors.add(outnameinputid,  ": Add a pattern that may result in different files names, such a {full} or {task} to '#{outname_pattern}' ")
+          self.errors.add(outnameinputid,  ": Add a pattern that may result in different files names, such a {full} or {task_id} to '#{outname_pattern}' ")
           t.errors.add(outnameinputid, msg)
         end
       end

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -211,47 +211,56 @@ module BoutiquesOutputFilenameRenamer
 
 
 
-  # checking that output patterns actually provided in the case of batch tasks
-  # because this module disables CBRAIN standards output suffixes that aim at avoiding
-  # unintended overwriting the output files
+  # Validates that batch tasks will not produce duplicate output file names.
+  # This is necessary because this module disables CBRAIN's standard output
+  # suffixes that normally prevent overwriting existing files.
+  # The collision between different kinds of outputs is possible but seldom occurs,
+  # so it is never validated.
   def final_task_list
     tasklist = super
-    if tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
-      descriptor = descriptor_for_final_task_list
-      config_map = descriptor.custom_module_info('BoutiquesOutputFilenameRenamer') || {}
+    return tasklist unless tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
 
-      # check that the output file names are unique at least for same output id
-      # (still there could be overwriting for different output ids)
+    descriptor = descriptor_for_final_task_list
+    config_map = descriptor.custom_module_info('BoutiquesOutputFilenameRenamer') || {}
+    current_date = Time.now.strftime("%Y-%m-%d")
+    current_time = Time.now.strftime("%H:%M:%S")
 
-      config_map.each do |_, pair|
-        fileinputid, outnameinputid = *pair
-        original_outname_pattern    = invoke_params[outnameinputid]
-        next if original_outname_pattern.include?('{task_id}') # usually enough for unique output names for input
-        outname_pattern          = original_outname_pattern.gsub('{time}', '12:23:45') # time is not very reliable
-        outnames                 = {}
-        outname = input_userfile = nil
-        t, _    = tasklist.each_with_index.detect do |t, i|
-          input_userfile_id = t.invoke_params[fileinputid]
-          input_userfile    = Userfile.find(input_userfile_id)
-          outname           = t.output_name_from_pattern(outname_pattern, input_userfile.name) # expected output file name
-          outnames[outname] ||= i  # index of the first task in the tasklist, resulting in output file name 'outname'
-          outnames[outname] < i    # the file name could be generate both by  i-th and one of previous tasks
+    config_map.each do |_, pair|
+      fileinputid, outnameinputid = *pair
+      original_outname_pattern = invoke_params[outnameinputid]
+      next if original_outname_pattern.include?('{task_id}') # task_id is unique per task, so the resulting name
+
+      # Replace {time} with a fixed value. The real time flow is unpredictable and cannot be relied upon in long loops
+      outname_pattern = original_outname_pattern.gsub('{time}', current_time).gsub('{date}', current_date)
+
+      # load all userfiles for this input in one shot
+      userfile_ids    = tasklist.map { |t| t.invoke_params[fileinputid] }
+      userfiles_by_id = Userfile.where(id: userfile_ids).index_by(&:id)  # access rights validated by the parent
+
+      # Loop and stop at the first collision
+      seen = {} # outname => [task_index, userfile]
+      tasklist.each_with_index do |t, i|
+        userfile = userfiles_by_id[t.invoke_params[fileinputid]]
+        outname  = t.output_name_from_pattern(outname_pattern, userfile.name)
+
+        if seen.key?(outname)
+          _, first_userfile = seen[outname]
+
+          msg  = "BoutiquesOutputFilenameRenamer requires unique output names for batch tasks."
+          msg += " Yet input files '#{userfile&.name}' and '#{first_userfile&.name}' both produce " \
+                "'#{outname}' for pattern '#{original_outname_pattern}'."
+          t.errors.add(:base, msg)
+          # just in case, the above message could be enough
+          add_invoke_params_error(outnameinputid, ": create a pattern that produces distinct names, " \
+                                          "such as {full} or {task_id}, to '#{original_outname_pattern}' output pattern")
+
+          break
         end
 
-        if !t.nil?
-          t_1                 = tasklist[outnames[outname]]
-          input_userfile_id_1 = t_1.invoke_params[fileinputid]     # input file id resulting in duplicated output file name
-          input_userfile_1    = Userfile.find(input_userfile_id_1)
-
-          msg = ":BoutiquesOutputFilenameRenamer module require unique output names for batch tasks, " +
-                "yet input files '#{input_userfile.name}' and '#{input_userfile_1.name}' result in the same output file " +
-                " '#{outname}' for output file pattern '#{original_outname_pattern}'."
-
-          self.errors.add(outnameinputid,  ": Add a pattern that may result in different files names, such a {full} or {task_id} to '#{outname_pattern}' ")
-          t.errors.add(outnameinputid, msg)
-        end
+        seen[outname] = [i, userfile]
       end
     end
+
     tasklist
   end
 
@@ -284,7 +293,7 @@ module BoutiquesOutputFilenameRenamer
 
   # This overrides the BoutiquesClusterTask method and replaces
   # the default behavor of adding an extension "-taskid" to output
-  # filenames. Instead, we trust the user to have generated a proper filename
+  # filenames. Instead, we expect the user to have generated a proper filename
   # with the pattern system. The "type" value returned is the same as
   # whatever "super" method returned.
   def name_and_type_for_output_file(output, pathname)

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -95,7 +95,7 @@
 #           }
 module BoutiquesOutputFilenameRenamer
 
-    # Note: to access the revision info of the module,
+  # Note: to access the revision info of the module,
   # you need to access the constant directly, the
   # object method revision_info() won't work.
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
@@ -206,10 +206,6 @@ module BoutiquesOutputFilenameRenamer
         params_errors.add(outnameinputid, "is a pattern that seems to have unreplaced components")
       end
     end
-
-    # check_for_overwriting_output_files(config_map)
-    # msg = "BoutiquesOutputFilenameRenamer module require actual pattern with {task_id}, {full} or {full_ex} is not compatible with batch tasks"
-    # raise exception msg unless self.has_pattern?
     message
   end
 

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -217,7 +217,7 @@ module BoutiquesOutputFilenameRenamer
   def final_task_list
     tasklist = super
     if tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
-      descriptor = descriptor_for_after_form
+      descriptor = descriptor_for_final_task_list
       config_map = descriptor.custom_module_info('BoutiquesOutputFilenameRenamer') || {}
 
       # check that the output file names are unique at least for same output id
@@ -225,17 +225,17 @@ module BoutiquesOutputFilenameRenamer
 
       config_map.each do |_, pair|
         fileinputid, outnameinputid = *pair
-        outname_pattern             = invoke_params[outnameinputid].gsub('{time}', 'timestamp') # timestamp is unreliable
-        next if outname_pattern.include?('{task_id}') # enough for unique output names for input
+        original_outname_pattern    = invoke_params[outnameinputid]
+        next if original_outname_pattern.include?('{task_id}') # usually enough for unique output names for input
+        outname_pattern          = original_outname_pattern.gsub('{time}', '12:23:45') # time is not very reliable
         outnames                 = {}
         outname = input_userfile = nil
-        t, _     = tasklist.each_with_index.detect do |t, i|
-
+        t, _    = tasklist.each_with_index.detect do |t, i|
           input_userfile_id = t.invoke_params[fileinputid]
           input_userfile    = Userfile.find(input_userfile_id)
           outname           = t.output_name_from_pattern(outname_pattern, input_userfile.name) # expected output file name
-          outnames[outname] ||= i # index of the first task in the tasklist, resulting in that output file name
-          outnames[outname] < i   # same outname in two tasks
+          outnames[outname] ||= i  # index of the first task in the tasklist, resulting in output file name 'outname'
+          outnames[outname] < i    # the file name could be generate both by  i-th and one of previous tasks
         end
 
         if !t.nil?
@@ -245,7 +245,7 @@ module BoutiquesOutputFilenameRenamer
 
           msg = ":BoutiquesOutputFilenameRenamer module require unique output names for batch tasks," +
                 "yet input files '#{input_userfile.name}' and '#{input_userfile_1.name}' result in the same output file " +
-                " '#{outname}' for output file pattern #{outname_pattern} ."
+                " '#{outname}' for output file pattern '#{original_outname_pattern}'."
 
           self.errors.add(outnameinputid,  ": Add a pattern that may result in different files names, such a {full} or {task} to '#{outname_pattern}' ")
           t.errors.add(outnameinputid, msg)

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -95,7 +95,7 @@
 #           }
 module BoutiquesOutputFilenameRenamer
 
-  # Note: to access the revision info of the module,
+    # Note: to access the revision info of the module,
   # you need to access the constant directly, the
   # object method revision_info() won't work.
   Revision_info=CbrainFileRevision[__FILE__] #:nodoc:
@@ -206,8 +206,59 @@ module BoutiquesOutputFilenameRenamer
         params_errors.add(outnameinputid, "is a pattern that seems to have unreplaced components")
       end
     end
+
+    # check_for_overwriting_output_files(config_map)
+    # msg = "BoutiquesOutputFilenameRenamer module require actual pattern with {task_id}, {full} or {full_ex} is not compatible with batch tasks"
+    # raise exception msg unless self.has_pattern?
     message
   end
+
+
+
+  # checking that output patterns actually provided in the case of batch tasks
+  # because this module disables CBRAIN standards output suffixes that aim at aprevenitn
+  # from overwriting the output files
+  def final_task_list
+    tasklist = super
+    if tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
+      descriptor = descriptor_for_after_form
+      config_map = descriptor.custom_module_info('BoutiquesOutputFilenameRenamer') || {}
+
+      # check that the output file names are unique at least for same output id
+      # (still there could be overwriting for different output ids)
+
+      config_map.each do |_, pair|
+        fileinputid, outnameinputid = *pair
+        outname_pattern             = invoke_params[outnameinputid].gsub('{time}', 'timestamp') # timestamp is unreliable
+        next if outname_pattern.include?('{task_id}') # enough for unique output names for input
+        outnames                 = {}
+        outname = input_userfile = nil
+        t, _     = tasklist.each_with_index.detect do |t, i|
+
+          input_userfile_id = t.invoke_params[fileinputid]
+          input_userfile    = Userfile.find(input_userfile_id)
+          outname           = t.output_name_from_pattern(outname_pattern, input_userfile.name) # expected output file name
+          outnames[outname] ||= i # index of the first task in the tasklist, resulting in that output file name
+          outnames[outname] < i   # same outname in two tasks
+        end
+
+        if !t.nil?
+          t_1                 = tasklist[outnames[outname]]
+          input_userfile_id_1 = t_1.invoke_params[fileinputid]     # input file id resulting in duplicated output file name
+          input_userfile_1    = Userfile.find(input_userfile_id_1)
+
+          msg = ":BoutiquesOutputFilenameRenamer module require unique output names for batch tasks," +
+                "yet input files '#{input_userfile.name}' and '#{input_userfile_1.name}' result in the same output file " +
+                " '#{outname}' for output file pattern #{outname_pattern} ."
+
+          self.errors.add(outnameinputid,  ": Add a pattern that may result in different files names, such a {full} or {task} to '#{outname_pattern}' ")
+          t.errors.add(outnameinputid, msg)
+        end
+      end
+    end
+    tasklist
+  end
+
 
   ##################################################
   # Cluster side overrides

--- a/BrainPortal/lib/boutiques_output_filename_renamer.rb
+++ b/BrainPortal/lib/boutiques_output_filename_renamer.rb
@@ -209,8 +209,6 @@ module BoutiquesOutputFilenameRenamer
     message
   end
 
-
-
   # Validates that batch tasks will not produce duplicate output file names.
   # This is necessary because this module disables CBRAIN's standard output
   # suffixes that normally prevent overwriting existing files.
@@ -218,26 +216,37 @@ module BoutiquesOutputFilenameRenamer
   # so it is never validated.
   def final_task_list
     tasklist = super
-    return tasklist unless tasklist.length > 1 && tasklist.last.is_a?(CbrainTask)
+    return tasklist if tasklist.length < 2  # single task
+
+    # addressing a corner case
+    list_plus_message = tasklist  # [t,t,t]    OR   [ [t,t,t], message ]
+    if list_plus_message.size == 2 && list_plus_message[0].is_a?(Array) # rare case when an optional message is present
+      tasklist,message = list_plus_message
+    else # standard case
+      tasklist = list_plus_message
+      message  = nil
+    end
 
     descriptor = descriptor_for_final_task_list
     config_map = descriptor.custom_module_info('BoutiquesOutputFilenameRenamer') || {}
+
     current_date = Time.now.strftime("%Y-%m-%d")
     current_time = Time.now.strftime("%H:%M:%S")
 
     config_map.each do |_, pair|
       fileinputid, outnameinputid = *pair
       original_outname_pattern = invoke_params[outnameinputid]
-      next if original_outname_pattern.include?('{task_id}') # task_id is unique per task, so the resulting name
+      next if original_outname_pattern.blank?
+      next if original_outname_pattern.include?('{task_id}') # task_id is unique per task, hence should be sufficient
 
-      # Replace {time} with a fixed value. The real time flow is unpredictable and cannot be relied upon in long loops
+      # Replace {time} with a fixed value. The real time flow cannot be relied upon in long loops
       outname_pattern = original_outname_pattern.gsub('{time}', current_time).gsub('{date}', current_date)
 
-      # load all userfiles for this input in one shot
+      # load all userfiles for this input
       userfile_ids    = tasklist.map { |t| t.invoke_params[fileinputid] }
-      userfiles_by_id = Userfile.where(id: userfile_ids).index_by(&:id)  # access rights validated by the parent
+      userfiles_by_id = Userfile.where(id: userfile_ids).index_by(&:id)  # access rights are already validated by the parent method
 
-      # Loop and stop at the first collision
+      # Loop and stop at the first found collision
       seen = {} # outname => [task_index, userfile]
       tasklist.each_with_index do |t, i|
         userfile = userfiles_by_id[t.invoke_params[fileinputid]]
@@ -246,14 +255,13 @@ module BoutiquesOutputFilenameRenamer
         if seen.key?(outname)
           _, first_userfile = seen[outname]
 
-          msg  = "BoutiquesOutputFilenameRenamer requires unique output names for batch tasks."
-          msg += " Yet input files '#{userfile&.name}' and '#{first_userfile&.name}' both produce " \
-                "'#{outname}' for pattern '#{original_outname_pattern}'."
+          msg  = "BoutiquesOutputFilenameRenamer requires unique output names for batch tasks." \
+                 " Yet input files '#{userfile.name}' and '#{first_userfile.name}' both produce " \
+                 "'#{outname}' for pattern '#{original_outname_pattern}'."
           t.errors.add(:base, msg)
-          # just in case, the above message could be enough
+          # another hint just in case, the above message could be enough
           add_invoke_params_error(outnameinputid, ": create a pattern that produces distinct names, " \
-                                          "such as {full} or {task_id}, to '#{original_outname_pattern}' output pattern")
-
+                     "such as {full} or {task_id}, to '#{original_outname_pattern}' output pattern")
           break
         end
 
@@ -261,8 +269,9 @@ module BoutiquesOutputFilenameRenamer
       end
     end
 
-    tasklist
+    return tasklist,message
   end
+
 
 
   ##################################################


### PR DESCRIPTION
See  #1632.

Note the usage of output templates, especially time and date does not guarantee output uniqueness, I think it is better just pre-check for possible duplicates when computing results.

This PR will make check for patterns presence